### PR TITLE
Add snap functionality

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,22 @@
+name: perceval-snap 
+version: '0.8.0' 
+summary: Retrieve and gather data from software repositories, 
+description: |
+  Package that gathers and retrieves data from known software repositories.
+  Repository sources includes askbot, bugzilla, bugzillarest, confluence, 
+  discourse, dockerhub, gerrit, git, github, gname, hyperkitty, jenkins, jira, 
+  mbox, mediawiki, meetup, nntp, phabricator, pipermail, redmine, rss, slack, 
+  stackexchange, supybot, telegram.
+grade: stable 
+confinement: strict 
+
+parts:
+  perceval:
+    source: https://github.com/grimoirelab/perceval.git
+    source-tag: 0.8.0
+    plugin: python
+    requirements: requirements.txt
+apps:
+  perceval:
+    command: perceval
+    plugs: [network]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,7 +12,7 @@ confinement: strict
 
 parts:
   perceval:
-    source: https://github.com/grimoirelab/perceval.git
+    source: .
     plugin: python
     requirements: requirements.txt
 apps:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: perceval-snap 
+name: perceval
 version: '0.8.0' 
 summary: Retrieve and gather data from software repositories, 
 description: |
@@ -13,7 +13,6 @@ confinement: strict
 parts:
   perceval:
     source: https://github.com/grimoirelab/perceval.git
-    source-tag: 0.8.0
     plugin: python
     requirements: requirements.txt
 apps:


### PR DESCRIPTION
Added snap functionality for this package, published here: https://dashboard.snapcraft.io/dev/snaps/7712/

Snaps aim to have apps working in any Linux distribution, anywhere, from desktop devices to IoT. They are quick to install, safe to run and you can run updates immediately. Snaps are also self-contained as they are read-only images and they bundle everything it needs to run the app. There's also a possibility to run beta features with the channel and developer mode flags. These do not affect the rest of the system either.
You can find everything about snaps in https://snapcraft.io/
