### PR TITLE
Fix Perceval version

### DIFF
--- a/bin/perceval
+++ b/bin/perceval
@@ -29,7 +29,7 @@ import sys
 
 import perceval
 import perceval.backends
-
+from perceval import _version
 
 PERCEVAL_USAGE_MSG = \
 """%(prog)s [-c <file>] [-g] <backend> [<args>] | --help | --version"""
@@ -80,7 +80,7 @@ PERCEVAL_EPILOG_MSG = \
 """Run '%(prog)s <backend> --help' to get information about a specific backend."""
 
 PERCEVAL_VERSION_MSG = \
-"""%(prog)s """  + perceval.__version__
+"""%(prog)s """  + _version.__version__
 
 
 # Logging formats


### PR DESCRIPTION
I install Perceval from pip. Then : 

```
$ perceval --version
Traceback (most recent call last):
  File "/home/nlamirault/Apps/grimoirelab/bin/perceval", line 83, in <module>
    """%(prog)s """  + perceval.__version__
AttributeError: module 'perceval' has no attribute '__version__'
```

With this patch :

```
$ perceval --version
perceval 0.9.2
```