### PR TITLE
[backend] Fix 'Namespace' object has no attribute 'fetch_archive'

### DIFF
--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -351,7 +351,7 @@ class BackendCommand:
         """
         backend_args = vars(self.parsed_args)
 
-        if self.parsed_args.fetch_archive:
+        if self.archive_manager and self.parsed_args.fetch_archive:
             items = fetch_from_archive(self.BACKEND, backend_args,
                                        self.archive_manager,
                                        self.parsed_args.category,


### PR DESCRIPTION
This error was raised when Perceval was run from the command line
with those backends which don't support the archive mode.

This patch fixes #327 