### PR TITLE
[archive-manager] Add default date value when searching for archives

### DIFF
--- a/perceval/archive.py
+++ b/perceval/archive.py
@@ -34,6 +34,7 @@ from grimoirelab.toolkit.datetime import (datetime_utcnow,
                                           str_to_datetime)
 
 from .errors import ArchiveError, ArchiveManagerError
+from .utils import DEFAULT_DATETIME
 
 
 logger = logging.getLogger(__name__)
@@ -411,7 +412,7 @@ class ArchiveManager:
 
         os.remove(archive_path)
 
-    def search(self, origin, backend_name, category, archived_after):
+    def search(self, origin, backend_name, category, archived_after=DEFAULT_DATETIME):
         """Search archives.
 
         Get the archives which store data based on the given parameters.
@@ -430,6 +431,9 @@ class ArchiveManager:
 
         :returns: a list with archive names which match the search criteria
         """
+        if not archived_after:
+            archived_after = DEFAULT_DATETIME
+
         archives = self._search_archives(origin, backend_name,
                                          category, archived_after)
         archives = [(fp, date) for fp, date in archives]

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -368,7 +368,6 @@ class TestArchiveManager(unittest.TestCase):
         archive_mng_path = os.path.join(self.test_path, ARCHIVE_TEST_DIR)
         manager = ArchiveManager(archive_mng_path)
 
-        dt = datetime_utcnow()
         metadata = [
             {
                 'origin': 'https://example.com',
@@ -400,14 +399,66 @@ class TestArchiveManager(unittest.TestCase):
             }
         ]
 
+        for i in range(len(metadata)):
+            # initialize the archived_after parameter after
+            # the creation of the first archive
+            if i == 1:
+                dt = datetime_utcnow()
+
+            archive = manager.create_archive()
+            archive.init_metadata(**metadata[i])
+            metadata[i]['filepath'] = archive.archive_path
+
+        archives = manager.search('https://example.com', 'git', 'commit', dt)
+
+        expected = [metadata[3]['filepath']]
+        self.assertListEqual(archives, expected)
+
+    def test_search_no_archived_after(self):
+        """Check if all archives are retrieved when the archived_after is not defined"""
+
+        archive_mng_path = os.path.join(self.test_path, ARCHIVE_TEST_DIR)
+        manager = ArchiveManager(archive_mng_path)
+
+        metadata = [
+            {
+                'origin': 'https://example.com',
+                'backend_name': 'git',
+                'backend_version': '0.8',
+                'category': 'commit',
+                'backend_params': {},
+            },
+            {
+                'origin': 'https://example.com',
+                'backend_name': 'gerrit',
+                'backend_version': '0.1',
+                'category': 'changes',
+                'backend_params': {}
+            },
+            {
+                'origin': 'https://example.com',
+                'backend_name': 'git',
+                'backend_version': '0.1',
+                'category': 'commit',
+                'backend_params': {}
+            },
+            {
+                'origin': 'https://example.com',
+                'backend_name': 'git',
+                'backend_version': '0.1',
+                'category': 'commit',
+                'backend_params': {}
+            }
+        ]
+
         for meta in metadata:
             archive = manager.create_archive()
             archive.init_metadata(**meta)
             meta['filepath'] = archive.archive_path
 
-        archives = manager.search('https://example.com', 'git', 'commit', dt)
+        archives = manager.search('https://example.com', 'git', 'commit')
 
-        expected = [metadata[0]['filepath'], metadata[3]['filepath']]
+        expected = [metadata[0]['filepath'], metadata[2]['filepath'], metadata[3]['filepath']]
         self.assertListEqual(archives, expected)
 
     def test_search_archived_after(self):


### PR DESCRIPTION
This code enables to not explicitly define a date (archived_after) to look for archives when using the search functionalities. By default, the archived_after is set to 1970-01-01