### PR TITLE
Handle archive errors

### DIFF
--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -24,6 +24,7 @@ import argparse
 import hashlib
 import importlib
 import json
+import logging
 import os
 import pkgutil
 import sys
@@ -37,6 +38,8 @@ from .archive import Archive, ArchiveManager
 from .errors import ArchiveError
 from ._version import __version__
 
+
+logger = logging.getLogger(__name__)
 
 ARCHIVES_DEFAULT_PATH = '~/.perceval/archives/'
 
@@ -500,8 +503,11 @@ def fetch_from_archive(backend_class, backend_args, manager,
         backend.archive = Archive(filepath)
         items = backend.fetch_from_archive()
 
-        for item in items:
-            yield item
+        try:
+            for item in items:
+                yield item
+        except ArchiveError as e:
+            logger.warning("Ignoring %s archive due to: %s", filepath, str(e))
 
 
 def find_backends(top_package):


### PR DESCRIPTION
This patch handles the errors produced by `fetch()` and `fetch_from_cache()`. In the first case, when there's an error in fetch(), if an archive was created to store data it will be removed. For the second case, errors produced reading an archive file will be ignored. The archive will be skipped and the process will continue reading the next archive of the set.