### PR TITLE
[jira] Add default parameters

### DIFF
--- a/perceval/backends/core/jira.py
+++ b/perceval/backends/core/jira.py
@@ -97,14 +97,14 @@ class Jira(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.11.1'
+    version = '0.11.2'
 
     CATEGORIES = [CATEGORY_ISSUE]
 
     def __init__(self, url, project=None,
                  user=None, password=None,
-                 verify=None, cert=None,
-                 max_issues=None, tag=None,
+                 verify=True, cert=None,
+                 max_issues=MAX_ISSUES, tag=None,
                  archive=None):
         origin = url
 
@@ -255,7 +255,7 @@ class JiraClient(HttpClient):
     VERSION_API = '2'
     RESOURCE = 'rest/api'
 
-    def __init__(self, url, project, user, password, verify, cert, max_issues,
+    def __init__(self, url, project, user, password, verify, cert, max_issues=MAX_ISSUES,
                  archive=None, from_archive=False):
         super().__init__(url, archive=archive, from_archive=from_archive)
         self.project = project

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -202,12 +202,14 @@ class TestJiraBackend(unittest.TestCase):
             {
                 'expand': ['renderedFields,transitions,operations,changelog'],
                 'jql': ['updated > 0 order by updated asc'],
-                'startAt': ['0']
+                'startAt': ['0'],
+                'maxResults': ['100']
             },
             {
                 'expand': ['renderedFields,transitions,operations,changelog'],
                 'jql': ['updated > 0 order by updated asc'],
-                'startAt': ['2']
+                'startAt': ['2'],
+                'maxResults': ['100']
             }
         ]
 
@@ -324,7 +326,8 @@ class TestJiraBackend(unittest.TestCase):
         expected_req = {
             'expand': ['renderedFields,transitions,operations,changelog'],
             'jql': ['updated > 1420070400000 order by updated asc'],
-            'startAt': ['0']
+            'startAt': ['0'],
+            'maxResults': ['100']
         }
 
         self.assertEqual(len(issues), 1)
@@ -363,7 +366,8 @@ class TestJiraBackend(unittest.TestCase):
         expected_req = {
             'expand': ['renderedFields,transitions,operations,changelog'],
             'jql': ['updated > 0 order by updated asc'],
-            'startAt': ['0']
+            'startAt': ['0'],
+            'maxResults': ['100']
         }
 
         self.assertEqual(len(issues), 0)


### PR DESCRIPTION
This patch sets default parameters when init the Client. Thus, allowing to keep the parameters used to fetch data from remote and archive aligned