### PR TITLE
[mediawiki] Sort request payload parameters for versions >= 1.27

### DIFF
--- a/perceval/backends/core/mediawiki.py
+++ b/perceval/backends/core/mediawiki.py
@@ -71,7 +71,7 @@ class MediaWiki(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.9.2'
+    version = '0.9.3'
 
     CATEGORIES = [CATEGORY_PAGE]
 
@@ -456,6 +456,7 @@ class MediaWikiClient(HttpClient):
 
             from_date_str = from_date.strftime("%Y-%m-%dT%H:%M:%SZ")
 
+        namespaces.sort()
         params = {
             "action": "query",
             "list": "allrevisions",


### PR DESCRIPTION
This patch sorts payload parameters used to query mediawiki server versions >= 1.27, thus allowing the correct retrieval of archived data.