### PR TITLE
[tests] Modify tests when fetching from archive

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -44,8 +44,8 @@ class TestCaseBackendArchive(unittest.TestCase):
     def _test_fetch_from_archive(self, **kwargs):
         """Test whether the method fetch_from_archive works properly"""
 
-        items = [items for items in self.backend.fetch(**kwargs)]
-        items_archived = [item for item in self.backend.fetch_from_archive()]
+        items = [items for items in self.backend_write_archive.fetch(**kwargs)]
+        items_archived = [item for item in self.backend_write_archive.fetch_from_archive()]
 
         self.assertEqual(len(items), len(items_archived))
 

--- a/tests/test_askbot.py
+++ b/tests/test_askbot.py
@@ -551,7 +551,8 @@ class TestAskbotBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = Askbot(ASKBOT_URL, archive=self.archive)
+        self.backend_write_archive = Askbot(ASKBOT_URL, archive=self.archive)
+        self.backend_read_archive = Askbot(ASKBOT_URL, archive=self.archive)
 
     def tearDown(self):
         shutil.rmtree(self.test_path)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -314,7 +314,8 @@ class TestBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = MockedBackend('test', archive=self.archive)
+        self.backend_write_archive = MockedBackend('test', archive=self.archive)
+        self.backend_read_archive = MockedBackend('test', archive=self.archive)
 
     def tearDown(self):
         shutil.rmtree(self.test_path)

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -474,8 +474,10 @@ class TestBugzillaBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = Bugzilla(BUGZILLA_SERVER_URL, max_bugs=5, max_bugs_csv=500,
-                                archive=self.archive)
+        self.backend_write_archive = Bugzilla(BUGZILLA_SERVER_URL, max_bugs=5, max_bugs_csv=500,
+                                              archive=self.archive)
+        self.backend_read_archive = Bugzilla(BUGZILLA_SERVER_URL, max_bugs=5, max_bugs_csv=500,
+                                             archive=self.archive)
 
     def tearDown(self):
         shutil.rmtree(self.test_path)

--- a/tests/test_bugzillarest.py
+++ b/tests/test_bugzillarest.py
@@ -264,7 +264,8 @@ class TestBugzillaRESTBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = BugzillaREST(BUGZILLA_SERVER_URL, max_bugs=2, archive=self.archive)
+        self.backend_write_archive = BugzillaREST(BUGZILLA_SERVER_URL, max_bugs=2, archive=self.archive)
+        self.backend_read_archive = BugzillaREST(BUGZILLA_SERVER_URL, max_bugs=2, archive=self.archive)
 
     def tearDown(self):
         shutil.rmtree(self.test_path)

--- a/tests/test_confluence.py
+++ b/tests/test_confluence.py
@@ -420,7 +420,8 @@ class TestConfluenceBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = Confluence(CONFLUENCE_URL, archive=self.archive)
+        self.backend_write_archive = Confluence(CONFLUENCE_URL, archive=self.archive)
+        self.backend_read_archive = Confluence(CONFLUENCE_URL, archive=self.archive)
 
     def tearDown(self):
         shutil.rmtree(self.test_path)

--- a/tests/test_discourse.py
+++ b/tests/test_discourse.py
@@ -422,7 +422,8 @@ class TestDiscourseBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = Discourse(DISCOURSE_SERVER_URL, archive=self.archive)
+        self.backend_write_archive = Discourse(DISCOURSE_SERVER_URL, archive=self.archive)
+        self.backend_read_archive = Discourse(DISCOURSE_SERVER_URL, archive=self.archive)
 
     def tearDown(self):
         shutil.rmtree(self.test_path)

--- a/tests/test_dockerhub.py
+++ b/tests/test_dockerhub.py
@@ -148,7 +148,8 @@ class TestDockerHubBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = DockerHub('grimoirelab', 'perceval', archive=self.archive)
+        self.backend_write_archive = DockerHub('grimoirelab', 'perceval', archive=self.archive)
+        self.backend_read_archive = DockerHub('grimoirelab', 'perceval', archive=self.archive)
 
     def tearDown(self):
         shutil.rmtree(self.test_path)

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -23,6 +23,7 @@
 
 import datetime
 import os
+import shutil
 import unittest.mock
 
 import pkg_resources
@@ -233,6 +234,16 @@ class TestGerritBackend(unittest.TestCase):
 
 class TestGerritBackendArchive(TestCaseBackendArchive):
     """Gerrit backend tests using an archive"""
+
+    def setUp(self):
+        super().setUp()
+        self.backend_write_archive = Gerrit(GERRIT_REPO, user=GERRIT_USER, port=29418, max_reviews=2,
+                                            archive=self.archive)
+        self.backend_read_archive = Gerrit(GERRIT_REPO, user=GERRIT_USER, port=29418, max_reviews=2,
+                                           archive=self.archive)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_path)
 
     @unittest.mock.patch('subprocess.check_output', mock_check_ouput)
     def test_fetch_from_archive(self):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -670,7 +670,8 @@ class TestGitHubBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = GitHub("zhquan_example", "repo", "aaa", archive=self.archive)
+        self.backend_write_archive = GitHub("zhquan_example", "repo", "aaa", archive=self.archive)
+        self.backend_read_archive = GitHub("zhquan_example", "repo", "aaa", archive=self.archive)
 
     @httpretty.activate
     def test_fetch_from_archive(self):

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -317,7 +317,8 @@ class TestGitHUbBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = GitLab("fdroid", "fdroiddata", api_token="your-token", archive=self.archive)
+        self.backend_write_archive = GitLab("fdroid", "fdroiddata", api_token="your-token", archive=self.archive)
+        self.backend_read_archive = GitLab("fdroid", "fdroiddata", api_token="your-token", archive=self.archive)
 
     @httpretty.activate
     def test_fetch_from_archive(self):
@@ -341,7 +342,8 @@ class TestGitHUbBackendArchive(TestCaseBackendArchive):
 
         setup_http_server(GITLAB_ENTERPRISE_URL_PROJECT, GITLAB_ENTERPRISE_ISSUES_URL)
 
-        self.backend = GitLab('am', 'test', base_url=GITLAB_ENTERPRISE_URL, archive=self.archive)
+        self.backend_write_archive = GitLab('am', 'test', base_url=GITLAB_ENTERPRISE_URL, archive=self.archive)
+        self.backend_read_archive = GitLab('am', 'test', base_url=GITLAB_ENTERPRISE_URL, archive=self.archive)
         self._test_fetch_from_archive()
 
     @httpretty.activate

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -223,7 +223,8 @@ class TestJenkinsBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = Jenkins(JENKINS_SERVER_URL, archive=self.archive)
+        self.backend_write_archive = Jenkins(JENKINS_SERVER_URL, archive=self.archive)
+        self.backend_read_archive = Jenkins(JENKINS_SERVER_URL, archive=self.archive)
 
     @httpretty.activate
     def test_fetch_from_archive(self):

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -383,7 +383,8 @@ class TestJiraBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = Jira(JIRA_SERVER_URL, archive=self.archive)
+        self.backend_write_archive = Jira(JIRA_SERVER_URL, archive=self.archive)
+        self.backend_read_archive = Jira(JIRA_SERVER_URL, archive=self.archive)
 
     @httpretty.activate
     def test_fetch_from_archive(self):

--- a/tests/test_launchpad.py
+++ b/tests/test_launchpad.py
@@ -407,8 +407,10 @@ class TestLaunchpadBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = Launchpad('mydistribution', package="mypackage",
-                                 items_per_page=2, archive=self.archive)
+        self.backend_write_archive = Launchpad('mydistribution', package="mypackage",
+                                               items_per_page=2, archive=self.archive)
+        self.backend_read_archive = Launchpad('mydistribution', package="mypackage",
+                                              items_per_page=2, archive=self.archive)
 
     @httpretty.activate
     def test_fetch_from_archive(self):
@@ -619,7 +621,9 @@ class TestLaunchpadBackendArchive(TestCaseBackendArchive):
                                body=empty_issues,
                                status=200)
 
-        self.backend = Launchpad('mydistribution', items_per_page=2, archive=self.archive)
+        self.backend_write_archive = Launchpad('mydistribution', items_per_page=2, archive=self.archive)
+        self.backend_read_archive = Launchpad('mydistribution', items_per_page=2, archive=self.archive)
+
         self._test_fetch_from_archive()
 
     @httpretty.activate

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -262,7 +262,8 @@ class TestMediaWikiBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = MediaWiki(MEDIAWIKI_SERVER_URL, archive=self.archive)
+        self.backend_write_archive = MediaWiki(MEDIAWIKI_SERVER_URL, archive=self.archive)
+        self.backend_read_archive = MediaWiki(MEDIAWIKI_SERVER_URL, archive=self.archive)
 
     @httpretty.activate
     @unittest.mock.patch('perceval.backends.core.mediawiki.datetime_utcnow')

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -529,7 +529,8 @@ class TestMeetupBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = Meetup('sqlpass-es', 'aaaa', max_items=2, archive=self.archive)
+        self.backend_write_archive = Meetup('sqlpass-es', 'aaaa', max_items=2, archive=self.archive)
+        self.backend_read_archive = Meetup('sqlpass-es', 'aaaa', max_items=2, archive=self.archive)
 
     @httpretty.activate
     def test_fetch_from_archive(self):

--- a/tests/test_nntp.py
+++ b/tests/test_nntp.py
@@ -250,7 +250,8 @@ class TestNNTPBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = NNTP(NNTP_SERVER, NNTP_GROUP, archive=self.archive)
+        self.backend_write_archive = NNTP(NNTP_SERVER, NNTP_GROUP, archive=self.archive)
+        self.backend_read_archive = NNTP(NNTP_SERVER, NNTP_GROUP, archive=self.archive)
 
     @unittest.mock.patch('nntplib.NNTP')
     def test_fetch_from_archive(self, mock_nntp):

--- a/tests/test_phabricator.py
+++ b/tests/test_phabricator.py
@@ -552,7 +552,8 @@ class TestPhabricatorBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = Phabricator(PHABRICATOR_URL, 'AAAA', archive=self.archive)
+        self.backend_write_archive = Phabricator(PHABRICATOR_URL, 'AAAA', archive=self.archive)
+        self.backend_read_archive = Phabricator(PHABRICATOR_URL, 'AAAA', archive=self.archive)
 
     @httpretty.activate
     def test_fetch_from_archive(self):

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -419,7 +419,8 @@ class TestRedmineBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = Redmine(REDMINE_URL, api_token='AAAA', max_issues=3, archive=self.archive)
+        self.backend_write_archive = Redmine(REDMINE_URL, api_token='AAAA', max_issues=3, archive=self.archive)
+        self.backend_read_archive = Redmine(REDMINE_URL, api_token='AAAA', max_issues=3, archive=self.archive)
 
     @httpretty.activate
     def test_fetch_from_archive(self):

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -188,7 +188,8 @@ class TestRSSBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = RSS(RSS_FEED_URL, archive=self.archive)
+        self.backend_write_archive = RSS(RSS_FEED_URL, archive=self.archive)
+        self.backend_read_archive = RSS(RSS_FEED_URL, archive=self.archive)
 
     @httpretty.activate
     def test_fetch_from_archive(self):

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -437,7 +437,8 @@ class TestSlackBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = Slack('C011DUKE8', 'aaaa', max_items=5, archive=self.archive)
+        self.backend_write_archive = Slack('C011DUKE8', 'aaaa', max_items=5, archive=self.archive)
+        self.backend_read_archive = Slack('C011DUKE8', 'aaaa', max_items=5, archive=self.archive)
 
     @httpretty.activate
     @unittest.mock.patch('perceval.backends.core.slack.datetime_utcnow')

--- a/tests/test_stackexchange.py
+++ b/tests/test_stackexchange.py
@@ -163,9 +163,12 @@ class TestStackExchangeBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = StackExchange(site="stackoverflow.com", tagged="python",
-                                     api_token="aaa", max_questions=1,
-                                     archive=self.archive)
+        self.backend_write_archive = StackExchange(site="stackoverflow.com", tagged="python",
+                                                   api_token="aaa", max_questions=1,
+                                                   archive=self.archive)
+        self.backend_read_archive = StackExchange(site="stackoverflow.com", tagged="python",
+                                                  api_token="aaa", max_questions=1,
+                                                  archive=self.archive)
 
     @httpretty.activate
     def test_fetch_from_archive(self):

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -259,7 +259,8 @@ class TestTelegramBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = Telegram(TELEGRAM_BOT, TELEGRAM_TOKEN, archive=self.archive)
+        self.backend_write_archive = Telegram(TELEGRAM_BOT, TELEGRAM_TOKEN, archive=self.archive)
+        self.backend_read_archive = Telegram(TELEGRAM_BOT, TELEGRAM_TOKEN, archive=self.archive)
 
     @httpretty.activate
     def test_fetch_from_archive(self):


### PR DESCRIPTION
This patch modifies the generic test used to check the **fetch_from_archive** method. Now two different backend objects are used, thus it ensures that backend and method params are initialized in the same way independently from which method is called (**fetch** or **fetch_from_archive**)