### PR TITLE
[client] Avoid negative sleep time error for rate limit reset

### DIFF
--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -24,11 +24,11 @@
 
 import json
 import logging
-import time
 
 import requests
-
-from grimoirelab.toolkit.datetime import datetime_to_utc, str_to_datetime
+from grimoirelab.toolkit.datetime import (datetime_to_utc,
+                                          datetime_utcnow,
+                                          str_to_datetime)
 from grimoirelab.toolkit.uris import urijoin
 
 from ...backend import (Backend,
@@ -80,7 +80,7 @@ class GitHub(Backend):
     :param sleep_time: time to sleep in case
         of connection problems
     """
-    version = '0.16.0'
+    version = '0.16.1'
 
     CATEGORIES = [CATEGORY_ISSUE, CATEGORY_PULL_REQUEST]
 
@@ -458,7 +458,12 @@ class GitHubClient(HttpClient, RateLimitHandler):
         between the current date and the next date when the token is fully regenerated.
         """
 
-        return self.rate_limit_reset_ts - (int(time.time()) + 1)
+        time_to_reset = self.rate_limit_reset_ts - (datetime_utcnow().replace(microsecond=0).timestamp() + 1)
+
+        if time_to_reset < 0:
+            time_to_reset = 0
+
+        return time_to_reset
 
     def issue_reactions(self, issue_number):
         """Get reactions of an issue"""

--- a/perceval/backends/core/meetup.py
+++ b/perceval/backends/core/meetup.py
@@ -68,7 +68,7 @@ class Meetup(Backend):
     :param sleep_time: minimun waiting time to avoid too many request
          exception
     """
-    version = '0.11.3'
+    version = '0.11.4'
 
     CATEGORIES = [CATEGORY_EVENT]
 
@@ -341,6 +341,10 @@ class MeetupClient(HttpClient, RateLimitHandler):
 
     def calculate_time_to_reset(self):
         """Number of seconds to wait. They are contained in the rate limit reset header"""
+
+        if self.rate_limit_reset_ts < 0:
+            self.rate_limit_reset_ts = 0
+
         return self.rate_limit_reset_ts
 
     def events(self, group, from_date=DEFAULT_DATETIME):

--- a/perceval/client.py
+++ b/perceval/client.py
@@ -53,7 +53,7 @@ class HttpClient:
     :param sleep_time: time to sleep in case
         of connection problems
     """
-    version = '0.1.3'
+    version = '0.1.4'
 
     DEFAULT_SLEEP_TIME = 1
 
@@ -198,7 +198,7 @@ class RateLimitHandler:
     :param rate_limit_header: header to know the current rate limit
     :param rate_limit_reset_header: header to know the next rate limit reset
     """
-    version = '0.1'
+    version = '0.2'
 
     MIN_RATE_LIMIT = 10
     MAX_RATE_LIMIT = 500
@@ -236,6 +236,11 @@ class RateLimitHandler:
         """
         if self.rate_limit is not None and self.rate_limit <= self.min_rate_to_sleep:
             seconds_to_reset = self.calculate_time_to_reset()
+
+            if seconds_to_reset < 0:
+                logger.warning("Value of sleep for rate limit is negative, reset it to 0")
+                seconds_to_reset = 0
+
             cause = "Rate limit exhausted."
             if self.sleep_for_rate:
                 logger.info("%s Waiting %i secs for rate limit reset.", cause, seconds_to_reset)


### PR DESCRIPTION
This patch fixes issue #355. It prevents to sleep for a negative number of seconds when waiting for tokens rate limit reset. The error seems to occur when a given token is shared among several fetching processes.