### PR TITLE
Fix the error "Not a gzipped file (b'00')"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ python-dateutil>=2.6.0
 requests>=2.7.0
 beautifulsoup4>=4.3.2
 feedparser>=5.1.3
-dulwich>=0.18.5
+dulwich>=0.18.5, <0.19
 urllib3>=1.22
 -e git+https://github.com/chaoss/grimoirelab-toolkit/#egg=grimoirelab-toolkit

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(name="perceval",
           'requests>=2.7.0',
           'beautifulsoup4>=4.3.2',
           'feedparser>=5.1.3',
-          'dulwich>=0.18.5',
+          'dulwich>=0.18.5, <0.19',
           'urllib3>=1.22',
           'grimoirelab-toolkit>=0.1.4'
       ],


### PR DESCRIPTION
It freezes the version of the dulwich package installed as dependency
of perceval.
From now, a version >=0.18.5 and <0.19 will be installed instead of
the latest one.
https://github.com/chaoss/grimoirelab-perceval/issues/369