### PR TITLE
[tests] Fix fetch_from_archive test

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -45,7 +45,7 @@ class TestCaseBackendArchive(unittest.TestCase):
         """Test whether the method fetch_from_archive works properly"""
 
         items = [items for items in self.backend_write_archive.fetch(**kwargs)]
-        items_archived = [item for item in self.backend_write_archive.fetch_from_archive()]
+        items_archived = [item for item in self.backend_read_archive.fetch_from_archive()]
 
         self.assertEqual(len(items), len(items_archived))
 


### PR DESCRIPTION
This patch fixes the method _test_fetch_from_archive. Before, archived items and items were read from the same backend, now archived items are read from backend_read_archive, while items from backend_write_archive.