### PR TITLE
[jira] Avoid init http session when fetching data from archive

### DIFF
--- a/perceval/backends/core/jira.py
+++ b/perceval/backends/core/jira.py
@@ -97,7 +97,7 @@ class Jira(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.11.3'
+    version = '0.11.4'
 
     CATEGORIES = [CATEGORY_ISSUE]
 
@@ -270,7 +270,8 @@ class JiraClient(HttpClient):
         self.cert = cert
         self.max_issues = max_issues
 
-        self.__init_session()
+        if not from_archive:
+            self.__init_session()
 
     def get_issues(self, from_date):
         """Retrieve all the issues from a given date.

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -383,7 +383,7 @@ class TestJiraBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend_write_archive = Jira(JIRA_SERVER_URL, archive=self.archive)
+        self.backend_write_archive = Jira(JIRA_SERVER_URL, user="test", password="test", archive=self.archive)
         self.backend_read_archive = Jira(JIRA_SERVER_URL, archive=self.archive)
 
     @httpretty.activate
@@ -412,6 +412,9 @@ class TestJiraBackendArchive(TestCaseBackendArchive):
                                body=body, status=200)
 
         self._test_fetch_from_archive(from_date=None)
+
+        self.assertEqual(("test", "test"), self.backend_write_archive.client.session.auth)
+        self.assertIsNone(self.backend_read_archive.client.session.auth)
 
     @httpretty.activate
     def test_fetch_from_date_from_archive(self):


### PR DESCRIPTION
This patch avoids to create an http session when fetching data from an archive.