### PR TITLE
[archive] Sanitize archive

### DIFF
--- a/perceval/backends/core/bugzilla.py
+++ b/perceval/backends/core/bugzilla.py
@@ -60,7 +60,7 @@ class Bugzilla(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.10.2'
+    version = '0.10.3'
 
     CATEGORIES = [CATEGORY_BUG]
 
@@ -554,6 +554,28 @@ class BugzillaClient(HttpClient):
         req = self.fetch(url, payload=params)
 
         return req.text
+
+    @staticmethod
+    def sanitize_for_archive(url, headers, payload):
+        """Sanitize payload of a HTTP request by removing the login and password information
+        before storing/retrieving archived items
+
+        :param: url: HTTP url request
+        :param: headers: HTTP headers request
+        :param: payload: HTTP payload request
+
+        :returns url, headers and the sanitized payload
+        """
+        if BugzillaClient.PBUGZILLA_LOGIN in payload:
+            payload.pop(BugzillaClient.PBUGZILLA_LOGIN)
+
+        if BugzillaClient.PBUGZILLA_PASSWORD in payload:
+            payload.pop(BugzillaClient.PBUGZILLA_PASSWORD)
+
+        if BugzillaClient.PLOGIN in payload:
+            payload.pop(BugzillaClient.PLOGIN)
+
+        return url, headers, payload
 
     def __fetch_version(self):
         response = self.metadata()

--- a/perceval/backends/core/bugzillarest.py
+++ b/perceval/backends/core/bugzillarest.py
@@ -60,7 +60,7 @@ class BugzillaREST(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.8.2'
+    version = '0.8.3'
 
     CATEGORIES = [CATEGORY_BUG]
 
@@ -424,6 +424,28 @@ class BugzillaRESTClient(HttpClient):
                                     code=result['code'])
 
         return r.text
+
+    @staticmethod
+    def sanitize_for_archive(url, headers, payload):
+        """Sanitize payload of a HTTP request by removing the login, password and token information
+        before storing/retrieving archived items
+
+        :param: url: HTTP url request
+        :param: headers: HTTP headers request
+        :param: payload: HTTP payload request
+
+        :returns url, headers and the sanitized payload
+        """
+        if BugzillaRESTClient.PBUGZILLA_LOGIN in payload:
+            payload.pop(BugzillaRESTClient.PBUGZILLA_LOGIN)
+
+        if BugzillaRESTClient.PBUGZILLA_PASSWORD in payload:
+            payload.pop(BugzillaRESTClient.PBUGZILLA_PASSWORD)
+
+        if BugzillaRESTClient.PBUGZILLA_TOKEN in payload:
+            payload.pop(BugzillaRESTClient.PBUGZILLA_TOKEN)
+
+        return url, headers, payload
 
 
 class BugzillaRESTCommand(BackendCommand):

--- a/perceval/backends/core/discourse.py
+++ b/perceval/backends/core/discourse.py
@@ -52,7 +52,7 @@ class Discourse(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.9.2'
+    version = '0.9.3'
 
     CATEGORIES = [CATEGORY_TOPIC]
 
@@ -334,6 +334,22 @@ class DiscourseClient(HttpClient):
                               params=params)
 
         return response
+
+    @staticmethod
+    def sanitize_for_archive(url, headers, payload):
+        """Sanitize payload of a HTTP request by removing the token information
+        before storing/retrieving archived items
+
+        :param: url: HTTP url request
+        :param: headers: HTTP headers request
+        :param: payload: HTTP payload request
+
+        :returns url, headers and the sanitized payload
+        """
+        if DiscourseClient.PKEY in payload:
+            payload.pop(DiscourseClient.PKEY)
+
+        return url, headers, payload
 
     def _call(self, res, res_id, params):
         """Run an API command.

--- a/perceval/backends/core/gerrit.py
+++ b/perceval/backends/core/gerrit.py
@@ -59,7 +59,7 @@ class Gerrit(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.10.2'
+    version = '0.10.3'
 
     CATEGORIES = [CATEGORY_REVIEW]
 
@@ -387,6 +387,19 @@ class GerritClient():
 
         return next_item
 
+    @staticmethod
+    def sanitize_for_archive(cmd):
+        """Sanitize the Gerrit command by removing username information
+        before storing/retrieving archived items
+
+        :param: cmd: Gerrit command
+
+        :returns the sanitized cmd
+        """
+        sanitized_cmd = re.sub(" \S*@", ' xxxxx@', cmd)
+
+        return sanitized_cmd
+
     def __execute(self, cmd):
         """Execute gerrit command"""
 
@@ -400,6 +413,7 @@ class GerritClient():
     def __execute_from_archive(self, cmd):
         """Execute gerrit command against the archive"""
 
+        cmd = self.sanitize_for_archive(cmd)
         response = self.archive.retrieve(cmd, None, None)
 
         if isinstance(response, RuntimeError):
@@ -426,6 +440,7 @@ class GerritClient():
             result = RuntimeError(cmd + " failed " + str(self.MAX_RETRIES) + " times. Giving up!")
 
         if self.archive:
+            cmd = self.sanitize_for_archive(cmd)
             self.archive.store(cmd, None, None, result)
 
         if isinstance(result, RuntimeError):

--- a/perceval/backends/core/meetup.py
+++ b/perceval/backends/core/meetup.py
@@ -410,6 +410,25 @@ class MeetupClient(HttpClient, RateLimitHandler):
         for page in self._fetch(resource, params):
             yield page
 
+    @staticmethod
+    def sanitize_for_archive(url, headers, payload):
+        """Sanitize payload of a HTTP request by removing the token information
+        before storing/retrieving archived items
+
+        :param: url: HTTP url request
+        :param: headers: HTTP headers request
+        :param: payload: HTTP payload request
+
+        :returns url, headers and the sanitized payload
+        """
+        if MeetupClient.PKEY in payload:
+            payload.pop(MeetupClient.PKEY)
+
+        if MeetupClient.PSIGN in payload:
+            payload.pop(MeetupClient.PSIGN)
+
+        return url, headers, payload
+
     def _fetch(self, resource, params):
         """Fetch a resource.
 

--- a/perceval/backends/core/phabricator.py
+++ b/perceval/backends/core/phabricator.py
@@ -50,7 +50,7 @@ class Phabricator(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.9.3'
+    version = '0.9.4'
 
     CATEGORIES = [CATEGORY_TASK]
 
@@ -455,6 +455,24 @@ class ConduitClient(HttpClient):
         response = self._call(self.PHAB_PHIDS, params)
 
         return response
+
+    @staticmethod
+    def sanitize_for_archive(url, headers, payload):
+        """Sanitize payload of a HTTP request by removing the token information
+        before storing/retrieving archived items
+
+        :param: url: HTTP url request
+        :param: headers: HTTP headers request
+        :param: payload: HTTP payload request
+
+        :returns url, headers and the sanitized payload
+        """
+        if '__conduit__' in payload['params']:
+            params = json.loads(payload['params'])
+            params.pop('__conduit__')
+            payload['params'] = json.dumps(params, sort_keys=True)
+
+        return url, headers, payload
 
     def _call(self, method, params):
         """Call a method.

--- a/perceval/backends/core/redmine.py
+++ b/perceval/backends/core/redmine.py
@@ -57,7 +57,7 @@ class Redmine(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.9.3'
+    version = '0.9.4'
 
     CATEGORIES = [CATEGORY_ISSUE]
 
@@ -405,6 +405,22 @@ class RedmineClient(HttpClient):
         response = self._call(resource, params)
 
         return response
+
+    @staticmethod
+    def sanitize_for_archive(url, headers, payload):
+        """Sanitize payload of a HTTP request by removing the token information
+        before storing/retrieving archived items
+
+        :param: url: HTTP url request
+        :param: headers: HTTP headers request
+        :param: payload: HTTP payload request
+
+        :returns url, headers and the sanitized payload
+        """
+        if RedmineClient.PKEY in payload:
+            payload.pop(RedmineClient.PKEY)
+
+        return url, headers, payload
 
     def _call(self, resource, params):
         """Call to get a resource.

--- a/perceval/backends/core/slack.py
+++ b/perceval/backends/core/slack.py
@@ -57,7 +57,7 @@ class Slack(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.6.3'
+    version = '0.6.4'
 
     CATEGORIES = [CATEGORY_MESSAGE]
 
@@ -356,6 +356,22 @@ class SlackClient(HttpClient):
         response = self._fetch(resource, params)
 
         return response
+
+    @staticmethod
+    def sanitize_for_archive(url, headers, payload):
+        """Sanitize payload of a HTTP request by removing the token information
+        before storing/retrieving archived items
+
+        :param: url: HTTP url request
+        :param: headers: HTTP headers request
+        :param: payload: HTTP payload request
+
+        :returns url, headers and the sanitized payload
+        """
+        if SlackClient.PTOKEN in payload:
+            payload.pop(SlackClient.PTOKEN)
+
+        return url, headers, payload
 
     def _fetch(self, resource, params):
         """Fetch a resource.

--- a/perceval/backends/core/telegram.py
+++ b/perceval/backends/core/telegram.py
@@ -22,6 +22,7 @@
 
 import json
 import logging
+import re
 
 from grimoirelab.toolkit.uris import urijoin
 
@@ -61,7 +62,7 @@ class Telegram(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.9.2'
+    version = '0.9.3'
 
     CATEGORIES = [CATEGORY_MESSAGE]
 
@@ -325,6 +326,21 @@ class TelegramBotClient(HttpClient):
         response = self._call(self.UPDATES_METHOD, params)
 
         return response
+
+    @staticmethod
+    def sanitize_for_archive(url, headers, payload):
+        """Sanitize URL of a HTTP request by removing the token information
+        before storing/retrieving archived items
+
+        :param: url: HTTP url request
+        :param: headers: HTTP headers request
+        :param: payload: HTTP payload request
+
+        :returns the sanitized url, plus the headers and payload
+        """
+        url = re.sub('bot.*/', 'botXXXXX/', url)
+
+        return url, headers, payload
 
     def _call(self, method, params):
         """Retrive the given resource.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -48,6 +48,8 @@ CLIENT_IRONMAN_URL = "https://gateway.marvel.com/v1/public/characters/4"
 
 class MockedClient(HttpClient, RateLimitHandler):
 
+    sanitize = False
+
     def __init__(self, base_url, sleep_time=HttpClient.DEFAULT_SLEEP_TIME,
                  max_retries=HttpClient.MAX_RETRIES,
                  extra_status_forcelist=None,
@@ -57,9 +59,10 @@ class MockedClient(HttpClient, RateLimitHandler):
                  rate_limit_header=RateLimitHandler.RATE_LIMIT_HEADER,
                  rate_limit_reset_header=RateLimitHandler.RATE_LIMIT_RESET_HEADER,
                  define_calculate_time_to_reset=True,
-                 archive=None, from_archive=False):
+                 archive=None, from_archive=False, sanitize=False):
 
         self.define_calculate_time_to_reset = define_calculate_time_to_reset
+        MockedClient.sanitize = sanitize
         super().__init__(base_url, sleep_time=sleep_time, max_retries=max_retries,
                          extra_status_forcelist=extra_status_forcelist,
                          extra_retry_after_status=extra_retry_after_status,
@@ -309,6 +312,15 @@ class TestHttpClient(unittest.TestCase):
         client = MockedClient(CLIENT_API_URL, sleep_time=0.1, max_retries=1, archive=archive, from_archive=True)
         with self.assertRaises(requests.exceptions.HTTPError):
             _ = client.fetch(CLIENT_SPIDERMAN_URL)
+
+    def test_sanitize_for_archive(self):
+        """Test whether the default sanitize method works properly"""
+
+        url, headers, payload = HttpClient.sanitize_for_archive("url", "headers", "payload")
+
+        self.assertEqual(url, "url")
+        self.assertEqual(headers, "headers")
+        self.assertEqual(payload, "payload")
 
 
 class TestRateLimitHandler(unittest.TestCase):

--- a/tests/test_discourse.py
+++ b/tests/test_discourse.py
@@ -422,7 +422,7 @@ class TestDiscourseBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend_write_archive = Discourse(DISCOURSE_SERVER_URL, archive=self.archive)
+        self.backend_write_archive = Discourse(DISCOURSE_SERVER_URL, api_token="aaaaa", archive=self.archive)
         self.backend_read_archive = Discourse(DISCOURSE_SERVER_URL, archive=self.archive)
 
     def tearDown(self):
@@ -767,6 +767,30 @@ class TestDiscourseClient(unittest.TestCase):
         self.assertEqual(req.method, 'GET')
         self.assertRegex(req.path, '/posts/21.json')
         self.assertDictEqual(req.querystring, expected)
+
+    def test_sanitize_for_archive_no_api_key(self):
+        """Test whether the sanitize method works properly when the api_key does not exist"""
+
+        url = "http://example.com"
+        headers = "headers-information"
+        payload = "payload-information"
+
+        s_url, s_headers, s_payload = DiscourseClient.sanitize_for_archive(url, headers, payload)
+
+        self.assertEqual(url, s_url)
+        self.assertEqual(headers, s_headers)
+        self.assertEqual(payload, s_payload)
+
+    def test_sanitize_for_archive(self):
+        """Test whether the sanitize method works properly"""
+
+        url = "http://example.com"
+        headers = "headers-information"
+        payload = {'api_key': 'aaaa'}
+
+        url, headers, payload = DiscourseClient.sanitize_for_archive(None, None, payload)
+        with self.assertRaises(KeyError):
+            payload.pop("api_key")
 
 
 class TestDiscourseCommand(unittest.TestCase):

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -239,7 +239,7 @@ class TestGerritBackendArchive(TestCaseBackendArchive):
         super().setUp()
         self.backend_write_archive = Gerrit(GERRIT_REPO, user=GERRIT_USER, port=29418, max_reviews=2,
                                             archive=self.archive)
-        self.backend_read_archive = Gerrit(GERRIT_REPO, user=GERRIT_USER, port=29418, max_reviews=2,
+        self.backend_read_archive = Gerrit(GERRIT_REPO, user="another-user", port=29418, max_reviews=2,
                                            archive=self.archive)
 
     def tearDown(self):
@@ -368,6 +368,14 @@ class TestGerritClient(unittest.TestCase):
         client._version[0] = 1
         result = client.next_retrieve_group_item(entry={'sortKey': 'asc'})
         self.assertEqual(result, 'asc')
+
+    def test_sanitize_for_archive(self):
+        """Test whether the sanitize method works properly"""
+
+        cmd = "ssh -p 29418 user@example.org gerrit version"
+        sanitized_cmd = GerritClient.sanitize_for_archive(cmd)
+
+        self.assertEqual("ssh -p 29418 xxxxx@example.org gerrit version", sanitized_cmd)
 
 
 class TestGerritCommand(unittest.TestCase):

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -20,6 +20,7 @@
 #     Santiago Dueñas <sduenas@bitergia.com>
 #
 
+import copy
 import datetime
 import dateutil.tz
 import httpretty
@@ -541,7 +542,7 @@ class TestMeetupBackendArchive(TestCaseBackendArchive):
     def setUp(self):
         super().setUp()
         self.backend_write_archive = Meetup('sqlpass-es', 'aaaa', max_items=2, archive=self.archive)
-        self.backend_read_archive = Meetup('sqlpass-es', 'aaaa', max_items=2, archive=self.archive)
+        self.backend_read_archive = Meetup('sqlpass-es', 'bbbb', max_items=2, archive=self.archive)
 
     @httpretty.activate
     def test_fetch_from_archive(self):
@@ -894,6 +895,25 @@ class TestMeetupClient(unittest.TestCase):
 
         end = float(time.time())
         self.assertGreater(end, expected)
+
+    def test_sanitize_for_archive(self):
+        """Test whether the sanitize method works properly"""
+
+        url = "http://example.com"
+        headers = "headers-information"
+        payload = {'page': 2,
+                   'sign': ('true',),
+                   'order': 'updated',
+                   'scroll': 'since:2016-01-01T00:00:00.000Z',
+                   'key': 'aaaa'}
+
+        s_url, s_headers, s_payload = MeetupClient.sanitize_for_archive(url, headers, copy.deepcopy(payload))
+        payload.pop('key')
+        payload.pop('sign')
+
+        self.assertEqual(url, s_url)
+        self.assertEqual(headers, s_headers)
+        self.assertEqual(payload, s_payload)
 
 
 if __name__ == "__main__":

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -20,6 +20,7 @@
 #     Santiago Dueñas <sduenas@bitergia.com>
 #
 
+import copy
 import datetime
 import httpretty
 import os
@@ -420,7 +421,7 @@ class TestRedmineBackendArchive(TestCaseBackendArchive):
     def setUp(self):
         super().setUp()
         self.backend_write_archive = Redmine(REDMINE_URL, api_token='AAAA', max_issues=3, archive=self.archive)
-        self.backend_read_archive = Redmine(REDMINE_URL, api_token='AAAA', max_issues=3, archive=self.archive)
+        self.backend_read_archive = Redmine(REDMINE_URL, api_token='BBBB', max_issues=3, archive=self.archive)
 
     @httpretty.activate
     def test_fetch_from_archive(self):
@@ -575,6 +576,20 @@ class TestRedmineClient(unittest.TestCase):
         self.assertEqual(req.method, 'GET')
         self.assertRegex(req.path, '/users/3.json')
         self.assertDictEqual(req.querystring, expected)
+
+    def test_sanitize_for_archive(self):
+        """Test whether the sanitize method works properly"""
+
+        url = "http://example.com"
+        headers = "headers-information"
+        payload = {'key': 'aaaa'}
+
+        s_url, s_headers, s_payload = RedmineClient.sanitize_for_archive(url, headers, copy.deepcopy(payload))
+        payload.pop("key")
+
+        self.assertEqual(url, s_url)
+        self.assertEqual(headers, s_headers)
+        self.assertEqual(payload, s_payload)
 
 
 if __name__ == "__main__":

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -20,6 +20,7 @@
 #     Santiago Dueñas <sduenas@bitergia.com>
 #
 
+import copy
 import datetime
 import dateutil
 import httpretty
@@ -438,7 +439,7 @@ class TestSlackBackendArchive(TestCaseBackendArchive):
     def setUp(self):
         super().setUp()
         self.backend_write_archive = Slack('C011DUKE8', 'aaaa', max_items=5, archive=self.archive)
-        self.backend_read_archive = Slack('C011DUKE8', 'aaaa', max_items=5, archive=self.archive)
+        self.backend_read_archive = Slack('C011DUKE8', 'bbbb', max_items=5, archive=self.archive)
 
     @httpretty.activate
     @unittest.mock.patch('perceval.backends.core.slack.datetime_utcnow')
@@ -577,6 +578,20 @@ class TestSlackClient(unittest.TestCase):
 
         with self.assertRaises(SlackClientError):
             _ = client.history('CH0')
+
+    def test_sanitize_for_archive(self):
+        """Test whether the sanitize method works properly"""
+
+        url = "http://example.com"
+        headers = "headers-information"
+        payload = {'token': 'aaaa', 'channel': 'C011DUKE8'}
+
+        s_url, s_headers, s_payload = SlackClient.sanitize_for_archive(url, headers, copy.deepcopy(payload))
+        payload.pop("token")
+
+        self.assertEqual(url, s_url)
+        self.assertEqual(headers, s_headers)
+        self.assertEqual(payload, s_payload)
 
 
 class TestSlackCommand(unittest.TestCase):

--- a/tests/test_stackexchange.py
+++ b/tests/test_stackexchange.py
@@ -21,6 +21,7 @@
 #     Quan Zhou <quan@bitergia.com>
 #
 
+import copy
 import datetime
 import httpretty
 import json
@@ -167,7 +168,7 @@ class TestStackExchangeBackendArchive(TestCaseBackendArchive):
                                                    api_token="aaa", max_questions=1,
                                                    archive=self.archive)
         self.backend_read_archive = StackExchange(site="stackoverflow.com", tagged="python",
-                                                  api_token="aaa", max_questions=1,
+                                                  api_token="bbb", max_questions=1,
                                                   archive=self.archive)
 
     @httpretty.activate
@@ -414,6 +415,27 @@ class TestStackExchangeClient(unittest.TestCase):
         # backoff value harcoded in the JSON
         diff = after - before
         self.assertGreaterEqual(diff, 0.2)
+
+    def test_sanitize_for_archive(self):
+        """Test whether the sanitize method works properly"""
+
+        url = "http://example.com"
+        headers = "headers-information"
+        payload = {'order': 'desc',
+                   'site': 'stackoverflow',
+                   'sort': 'activity',
+                   'pagesize': 1,
+                   'key': 'aaa',
+                   'filter': 'Bf*y*ByQD_upZqozgU6lXL_62USGOoV3)MFNgiHqHpmO_Y-jHR',
+                   'page': 1,
+                   'tagged': 'python'}
+
+        s_url, s_headers, s_payload = StackExchangeClient.sanitize_for_archive(url, headers, copy.deepcopy(payload))
+        payload.pop("key")
+
+        self.assertEqual(url, s_url)
+        self.assertEqual(headers, s_headers)
+        self.assertEqual(payload, s_payload)
 
 
 class TestStackExchangeCommand(unittest.TestCase):

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -260,7 +260,7 @@ class TestTelegramBackendArchive(TestCaseBackendArchive):
     def setUp(self):
         super().setUp()
         self.backend_write_archive = Telegram(TELEGRAM_BOT, TELEGRAM_TOKEN, archive=self.archive)
-        self.backend_read_archive = Telegram(TELEGRAM_BOT, TELEGRAM_TOKEN, archive=self.archive)
+        self.backend_read_archive = Telegram(TELEGRAM_BOT, "another-token", archive=self.archive)
 
     @httpretty.activate
     def test_fetch_from_archive(self):
@@ -375,6 +375,19 @@ class TestTelegramBotClient(unittest.TestCase):
         self.assertEqual(req.method, 'GET')
         self.assertRegex(req.path, '/bot12345678/getUpdates')
         self.assertDictEqual(req.querystring, expected)
+
+    def test_sanitize_for_archive(self):
+        """Test whether the sanitize method works properly"""
+
+        url = "https://api.telegram.org/bot12345678/getUpdates"
+        headers = "headers-information"
+        payload = "payload-information"
+
+        s_url, s_headers, s_payload = TelegramBotClient.sanitize_for_archive(url, headers, payload)
+
+        self.assertEqual(s_url, "https://api.telegram.org/botXXXXX/getUpdates")
+        self.assertEqual(s_headers, headers)
+        self.assertEqual(s_payload, payload)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This patch enables removing credentials information available in url, payload and headers when storing data to the archive. Thus, it enables sharing archives between users, avoiding credentials exposure.