### PR TITLE
[jenkins] Control detail level of Jenkins data

### DIFF
--- a/perceval/backends/core/jenkins.py
+++ b/perceval/backends/core/jenkins.py
@@ -34,6 +34,7 @@ from ...client import HttpClient
 
 CATEGORY_BUILD = "build"
 SLEEP_TIME = 10
+DETAIL_DEPTH = 1
 
 logger = logging.getLogger(__name__)
 
@@ -49,21 +50,23 @@ class Jenkins(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     :param blacklist_jobs: exclude the jobs of this list while fetching
+    :param detail_depth: control the detail level of the data returned by the API
     :param sleep_time: minimun waiting time due to a timeout connection exception
     :param archive: collect builds already retrieved from an archive
     """
-    version = '0.10.2'
+    version = '0.11.0'
 
     CATEGORIES = [CATEGORY_BUILD]
 
     def __init__(self, url, tag=None, archive=None,
-                 blacklist_jobs=None, sleep_time=SLEEP_TIME):
+                 blacklist_jobs=None, detail_depth=DETAIL_DEPTH, sleep_time=SLEEP_TIME):
         origin = url
 
         super().__init__(origin, tag=tag, archive=archive)
         self.url = url
         self.sleep_time = sleep_time
         self.blacklist_jobs = blacklist_jobs
+        self.detail_depth = detail_depth
 
         self.client = None
 
@@ -181,18 +184,23 @@ class Jenkins(Backend):
     def _init_client(self, from_archive=False):
         """Init client"""
 
-        return JenkinsClient(self.url, self.blacklist_jobs, self.sleep_time,
+        return JenkinsClient(self.url, self.blacklist_jobs, self.detail_depth,
+                             self.sleep_time,
                              archive=self.archive, from_archive=from_archive)
 
 
 class JenkinsClient(HttpClient):
     """Jenkins API client.
 
-    This class implements a simple client to retrieve builds from
-    projects in a Jenkins node.
+    This class implements a simple client to retrieve jobs/builds from
+    projects in a Jenkins node. The amount of data returned for each request
+    depends on the detail_depth value selected (minimun and default is 1).
+    Note that increasing the detail_depth may considerably slow down the
+    fetch operation and cause connection broken errors.
 
     :param url: URL of jenkins node: https://build.opnfv.org/ci
     :param blacklist_jobs: exclude the jobs of this list while fetching
+    :param detail_depth: set the detail level of the data returned by the API
     :param sleep_time: minimun waiting time due to a timeout connection exception
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive
@@ -201,11 +209,12 @@ class JenkinsClient(HttpClient):
     """
     MAX_RETRIES = 5
 
-    def __init__(self, url, blacklist_jobs=None, sleep_time=SLEEP_TIME,
+    def __init__(self, url, blacklist_jobs=None, detail_depth=DETAIL_DEPTH, sleep_time=SLEEP_TIME,
                  archive=None, from_archive=False):
         super().__init__(url, sleep_time=sleep_time, extra_status_forcelist=[410, 502, 503],
                          archive=archive, from_archive=from_archive)
         self.blacklist_jobs = blacklist_jobs
+        self.detail_depth = detail_depth
 
     def get_jobs(self):
         """ Retrieve all jobs"""
@@ -222,10 +231,10 @@ class JenkinsClient(HttpClient):
             logging.info("Not getting blacklisted job: %s", job_name)
             return
 
-        # depth=2 to get builds details
-        url_build = urijoin(self.base_url, "job", job_name, "api", "json?depth=2")
+        payload = {'depth': self.detail_depth}
+        url_build = urijoin(self.base_url, "job", job_name, "api", "json")
 
-        response = self.fetch(url_build)
+        response = self.fetch(url_build, payload=payload)
         return response.text
 
 
@@ -246,8 +255,12 @@ class JenkinsCommand(BackendCommand):
                            nargs='*',
                            help="Wrong jobs that must not be retrieved.")
 
+        group.add_argument('--detail-depth', dest='detail_depth',
+                           type=int, default=DETAIL_DEPTH,
+                           help="Detail level of the Jenkins data.")
+
         group.add_argument('--sleep-time', dest='sleep_time',
-                           type=int,
+                           type=int, default=SLEEP_TIME,
                            help="Minimun time to wait after a Timeout connection error.")
 
         # Required arguments

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -36,7 +36,8 @@ pkg_resources.declare_namespace('perceval.backends')
 from perceval.backend import BackendCommandArgumentParser
 from perceval.backends.core.jenkins import (Jenkins,
                                             JenkinsCommand,
-                                            JenkinsClient)
+                                            JenkinsClient,
+                                            SLEEP_TIME, DETAIL_DEPTH)
 from base import TestCaseBackendArchive
 
 
@@ -46,10 +47,14 @@ JENKINS_JOB_BUILDS_1 = 'apex-build-brahmaputra'
 JENKINS_JOB_BUILDS_2 = 'apex-build-master'
 JENKINS_JOB_BUILDS_500_ERROR = '500-error-job'
 JENKINS_JOB_BUILDS_JSON_ERROR = 'invalid-json-job'
-JENKINS_JOB_BUILDS_URL_1 = JENKINS_SERVER_URL + '/job/' + JENKINS_JOB_BUILDS_1 + '/api/json?depth=2'
-JENKINS_JOB_BUILDS_URL_2 = JENKINS_SERVER_URL + '/job/' + JENKINS_JOB_BUILDS_2 + '/api/json?depth=2'
-JENKINS_JOB_BUILDS_URL_500_ERROR = JENKINS_SERVER_URL + '/job/' + JENKINS_JOB_BUILDS_500_ERROR + '/api/json?depth=2'
-JENKINS_JOB_BUILDS_URL_JSON_ERROR = JENKINS_SERVER_URL + '/job/' + JENKINS_JOB_BUILDS_JSON_ERROR + '/api/json?depth=2'
+JENKINS_JOB_BUILDS_URL_1_DEPTH_1 = JENKINS_SERVER_URL + '/job/' + JENKINS_JOB_BUILDS_1 + '/api/json?depth=1'
+JENKINS_JOB_BUILDS_URL_2_DEPTH_1 = JENKINS_SERVER_URL + '/job/' + JENKINS_JOB_BUILDS_2 + '/api/json?depth=1'
+JENKINS_JOB_BUILDS_URL_500_ERROR_DEPTH_1 = JENKINS_SERVER_URL + '/job/' + JENKINS_JOB_BUILDS_500_ERROR + '/api/json?depth=1'
+JENKINS_JOB_BUILDS_URL_JSON_ERROR_DEPTH_1 = JENKINS_SERVER_URL + '/job/' + JENKINS_JOB_BUILDS_JSON_ERROR + '/api/json?depth1'
+JENKINS_JOB_BUILDS_URL_1_DEPTH_2 = JENKINS_SERVER_URL + '/job/' + JENKINS_JOB_BUILDS_1 + '/api/json?depth=2'
+JENKINS_JOB_BUILDS_URL_2_DEPTH_2 = JENKINS_SERVER_URL + '/job/' + JENKINS_JOB_BUILDS_2 + '/api/json?depth=2'
+JENKINS_JOB_BUILDS_URL_500_ERROR_DEPTH_2 = JENKINS_SERVER_URL + '/job/' + JENKINS_JOB_BUILDS_500_ERROR + '/api/json?depth=2'
+JENKINS_JOB_BUILDS_URL_JSON_ERROR_DEPTH_2 = JENKINS_SERVER_URL + '/job/' + JENKINS_JOB_BUILDS_JSON_ERROR + '/api/json?depth2'
 
 
 requests_http = []
@@ -61,23 +66,35 @@ def read_file(filename, mode='r'):
     return content
 
 
-def configure_http_server():
+def configure_http_server(depth=1):
     bodies_jobs = read_file('data/jenkins/jenkins_jobs.json', mode='rb')
     bodies_builds_job = read_file('data/jenkins/jenkins_job_builds.json')
 
     def request_callback(method, uri, headers):
         status = 200
 
-        if uri.startswith(JENKINS_JOBS_URL):
-            body = bodies_jobs
-        elif (uri.startswith(JENKINS_JOB_BUILDS_URL_1) or
-              uri.startswith(JENKINS_JOB_BUILDS_URL_2)):
-            body = bodies_builds_job
-        elif uri.startswith(JENKINS_JOB_BUILDS_URL_500_ERROR):
-            status = 500
-            body = '500 Internal Server Error'
+        if depth == 2:
+            if uri.startswith(JENKINS_JOBS_URL):
+                body = bodies_jobs
+            elif (uri.startswith(JENKINS_JOB_BUILDS_URL_1_DEPTH_2) or
+                  uri.startswith(JENKINS_JOB_BUILDS_URL_2_DEPTH_2)):
+                body = bodies_builds_job
+            elif uri.startswith(JENKINS_JOB_BUILDS_URL_500_ERROR_DEPTH_2):
+                status = 500
+                body = '500 Internal Server Error'
+            else:
+                body = '{'
         else:
-            body = '{'
+            if uri.startswith(JENKINS_JOBS_URL):
+                body = bodies_jobs
+            elif (uri.startswith(JENKINS_JOB_BUILDS_URL_1_DEPTH_1) or
+                  uri.startswith(JENKINS_JOB_BUILDS_URL_2_DEPTH_1)):
+                body = bodies_builds_job
+            elif uri.startswith(JENKINS_JOB_BUILDS_URL_500_ERROR_DEPTH_1):
+                status = 500
+                body = '500 Internal Server Error'
+            else:
+                body = '{'
 
         requests_http.append(httpretty.last_request())
 
@@ -90,24 +107,53 @@ def configure_http_server():
                                for _ in range(3)
                            ])
     httpretty.register_uri(httpretty.GET,
-                           JENKINS_JOB_BUILDS_URL_1,
+                           JENKINS_JOB_BUILDS_URL_1_DEPTH_1,
                            responses=[
                                httpretty.Response(body=request_callback)
                                for _ in range(2)
                            ])
     httpretty.register_uri(httpretty.GET,
-                           JENKINS_JOB_BUILDS_URL_2,
+                           JENKINS_JOB_BUILDS_URL_2_DEPTH_1,
                            responses=[
                                httpretty.Response(body=request_callback)
                                for _ in range(2)
                            ])
     httpretty.register_uri(httpretty.GET,
-                           JENKINS_JOB_BUILDS_URL_500_ERROR,
+                           JENKINS_JOB_BUILDS_URL_500_ERROR_DEPTH_1,
                            responses=[
                                httpretty.Response(body=request_callback)
                            ])
     httpretty.register_uri(httpretty.GET,
-                           JENKINS_JOB_BUILDS_URL_JSON_ERROR,
+                           JENKINS_JOB_BUILDS_URL_JSON_ERROR_DEPTH_1,
+                           responses=[
+                               httpretty.Response(body=request_callback)
+                           ])
+
+    httpretty.register_uri(httpretty.GET,
+                           JENKINS_JOBS_URL,
+                           responses=[
+                               httpretty.Response(body=request_callback)
+                               for _ in range(3)
+                           ])
+    httpretty.register_uri(httpretty.GET,
+                           JENKINS_JOB_BUILDS_URL_1_DEPTH_2,
+                           responses=[
+                               httpretty.Response(body=request_callback)
+                               for _ in range(2)
+                           ])
+    httpretty.register_uri(httpretty.GET,
+                           JENKINS_JOB_BUILDS_URL_2_DEPTH_2,
+                           responses=[
+                               httpretty.Response(body=request_callback)
+                               for _ in range(2)
+                           ])
+    httpretty.register_uri(httpretty.GET,
+                           JENKINS_JOB_BUILDS_URL_500_ERROR_DEPTH_2,
+                           responses=[
+                               httpretty.Response(body=request_callback)
+                           ])
+    httpretty.register_uri(httpretty.GET,
+                           JENKINS_JOB_BUILDS_URL_JSON_ERROR_DEPTH_2,
                            responses=[
                                httpretty.Response(body=request_callback)
                            ])
@@ -119,10 +165,12 @@ class TestJenkinsBackend(unittest.TestCase):
     def test_initialization(self):
         """Test whether attributes are initializated"""
 
-        jenkins = Jenkins(JENKINS_SERVER_URL, tag='test', sleep_time=60)
+        jenkins = Jenkins(JENKINS_SERVER_URL, tag='test', sleep_time=60, detail_depth=2)
 
         self.assertEqual(jenkins.url, JENKINS_SERVER_URL)
         self.assertEqual(jenkins.origin, JENKINS_SERVER_URL)
+        self.assertEqual(jenkins.sleep_time, 60)
+        self.assertEqual(jenkins.detail_depth, 2)
         self.assertEqual(jenkins.tag, 'test')
         self.assertIsNone(jenkins.client)
 
@@ -132,6 +180,8 @@ class TestJenkinsBackend(unittest.TestCase):
         self.assertEqual(jenkins.url, JENKINS_SERVER_URL)
         self.assertEqual(jenkins.origin, JENKINS_SERVER_URL)
         self.assertEqual(jenkins.tag, JENKINS_SERVER_URL)
+        self.assertEqual(jenkins.sleep_time, SLEEP_TIME)
+        self.assertEqual(jenkins.detail_depth, DETAIL_DEPTH)
 
         jenkins = Jenkins(JENKINS_SERVER_URL, tag='')
         self.assertEqual(jenkins.url, JENKINS_SERVER_URL)
@@ -149,7 +199,7 @@ class TestJenkinsBackend(unittest.TestCase):
         self.assertEqual(Jenkins.has_resuming(), False)
 
     @httpretty.activate
-    def test_fetch(self):
+    def test_fetch_depth_1(self):
         """Test whether a list of builds is returned"""
 
         configure_http_server()
@@ -182,6 +232,63 @@ class TestJenkinsBackend(unittest.TestCase):
             self.assertEqual(build['updated_on'], expected[x][1])
             self.assertEqual(build['category'], 'build')
             self.assertEqual(build['tag'], 'http://example.com/ci')
+
+        # Check request params
+        expected = {
+            'depth': ['1']
+        }
+
+        req = httpretty.last_request()
+
+        self.assertEqual(req.method, 'GET')
+        self.assertRegex(req.path, '/ci/job')
+        self.assertDictEqual(req.querystring, expected)
+
+    @httpretty.activate
+    def test_fetch_depth_2(self):
+        """Test whether a list of builds is returned"""
+
+        configure_http_server(depth=2)
+
+        # Test fetch builds from jobs list
+        jenkins = Jenkins(JENKINS_SERVER_URL, detail_depth=2)
+        builds = [build for build in jenkins.fetch()]
+        self.assertEqual(len(builds), 64)
+
+        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "data/jenkins/jenkins_build.json")) \
+                as build_json:
+            first_build = json.load(build_json)
+            self.assertDictEqual(builds[0]['data'], first_build['data'])
+
+        # Test metadata
+        expected = [('69fb6b0fe503c59d075d497e2ff37535ccac94b6', 1458874078.582),
+                    ('1145170a61c10d1bfc60c3c93c2d800587467b4a', 1458854340.139),
+                    ('2d3688b4cac6ad22d4c20223216facfcbc8abb5f', 1458842674.184),
+                    ('77a4b72563a212d0950fc48e81471bd03409ec39', 1458831639.674),
+                    ('c1110cd988722c124d60f4f234ad1d00ea168286', 1458764722.848),
+                    ('88bbd95bf4e07792531760f6ac17711f8e3ade90', 1458740779.456),
+                    ('fa6857e34c5fabd929cad0dd736971a676ed2804', 1458687074.485),
+                    ('b8d84ea6a2c67c4fccd5cf4473af45909c174731', 1458662464.685),
+                    ('c4f3c8c773e8e26eb87b7f5e014768b7977f82e3', 1458596193.695)]
+
+        for x in range(len(expected)):
+            build = builds[x]
+            self.assertEqual(build['origin'], 'http://example.com/ci')
+            self.assertEqual(build['uuid'], expected[x][0])
+            self.assertEqual(build['updated_on'], expected[x][1])
+            self.assertEqual(build['category'], 'build')
+            self.assertEqual(build['tag'], 'http://example.com/ci')
+
+        # Check request params
+        expected = {
+            'depth': ['2']
+        }
+
+        req = httpretty.last_request()
+
+        self.assertEqual(req.method, 'GET')
+        self.assertRegex(req.path, '/ci/job')
+        self.assertDictEqual(req.querystring, expected)
 
     @httpretty.activate
     def test_fetch_empty(self):
@@ -269,12 +376,14 @@ class TestJenkinsCommand(unittest.TestCase):
         self.assertIsInstance(parser, BackendCommandArgumentParser)
 
         args = ['--tag', 'test', '--no-archive', '--sleep-time', '60',
+                '--detail-depth', '2',
                 '--blacklist-jobs', '1', '2', '3', '4', '--',
                 JENKINS_SERVER_URL]
 
         parsed_args = parser.parse(*args)
         self.assertEqual(parsed_args.url, JENKINS_SERVER_URL)
         self.assertEqual(parsed_args.tag, 'test')
+        self.assertEqual(parsed_args.detail_depth, 2)
         self.assertEqual(parsed_args.sleep_time, 60)
         self.assertEqual(parsed_args.no_archive, True)
         self.assertListEqual(parsed_args.blacklist_jobs, ['1', '2', '3', '4'])
@@ -341,7 +450,7 @@ class TestJenkinsClient(unittest.TestCase):
         # Set up a mock HTTP server
         body = read_file('data/jenkins/jenkins_job_builds.json')
         httpretty.register_uri(httpretty.GET,
-                               JENKINS_JOB_BUILDS_URL_1,
+                               JENKINS_JOB_BUILDS_URL_1_DEPTH_1,
                                body=body, status=200)
 
         client = JenkinsClient(JENKINS_SERVER_URL)
@@ -356,7 +465,7 @@ class TestJenkinsClient(unittest.TestCase):
         # Set up a mock HTTP server
         body = read_file('data/jenkins/jenkins_job_builds.json')
         httpretty.register_uri(httpretty.GET,
-                               JENKINS_JOB_BUILDS_URL_1,
+                               JENKINS_JOB_BUILDS_URL_1_DEPTH_1,
                                body=body, status=408)
 
         client = JenkinsClient(JENKINS_SERVER_URL, sleep_time=0.1)


### PR DESCRIPTION
This patch allows to control the granularity of the data returned by the Jenkins API. By default this value (detail_depth) is set to 1. Note that increasing the detail_depth may considerably slow down the fetch operation and cause connection broken errors.