### PR TITLE
[phabricator] Handle project info in core:edge transactions

### DIFF
--- a/tests/data/phabricator/phabricator_transactions.json
+++ b/tests/data/phabricator/phabricator_transactions.json
@@ -341,18 +341,7 @@
                 "authorPHID": "PHID-USER-2uk52xorcqb6sjvp467y",
                 "comments": null,
                 "dateCreated": "1462379566",
-                "newValue": {
-                    "PHID-PROJ-2qnt6thbrd7qnx5bitzy": {
-                        "data": [],
-                        "dst": "PHID-PROJ-2qnt6thbrd7qnx5bitzy",
-                        "type": 41
-                    },
-                    "PHID-PROJ-zi2ndtoy3fh5pnbqzfdo": {
-                        "data": [],
-                        "dst": "PHID-PROJ-zi2ndtoy3fh5pnbqzfdo",
-                        "type": 41
-                    }
-                },
+                "newValue": ["PHID-PROJ-2qnt6thbrd7qnx5bitzy", "PHID-PROJ-zi2ndtoy3fh5pnbqzfdo"],
                 "oldValue": [],
                 "taskID": "73",
                 "transactionID": "1248",
@@ -531,7 +520,7 @@
                 "comments": null,
                 "dateCreated": "1462645103",
                 "newValue": [
-                    "PHID-USER-2uk52xorcqb6sjvp467y",
+                    null,
                     "PHID-USER-bjxhrstz5fb5gkrojmev"
                 ],
                 "oldValue": [],

--- a/tests/test_phabricator.py
+++ b/tests/test_phabricator.py
@@ -242,9 +242,8 @@ class TestPhabricatorBackend(unittest.TestCase):
         # Check that project data is included for core:edge type transactions
         trans = tasks[0]['data']['transactions'][7]
         self.assertEqual(trans['transactionType'], 'core:edge')
-        self.assertEqual(trans['newValue']['PHID-PROJ-2qnt6thbrd7qnx5bitzy']['dst_data']['phid'],
-                         trans['newValue']['PHID-PROJ-2qnt6thbrd7qnx5bitzy']['dst'])
-        self.assertEqual(trans['newValue']['PHID-PROJ-2qnt6thbrd7qnx5bitzy']['dst_data']['name'], 'Bug report')
+        self.assertEqual(trans['newValue_data'][0]['phid'],
+                         trans['newValue'][trans['newValue_data'][0]['phid']]['dst'])
 
         # Check that policy data is include for core:edit-policy type transactions
         trans = tasks[0]['data']['transactions'][8]


### PR DESCRIPTION
This patch allows to handle different JSON structures (dict and list) of how project data appears in old and new values within the transactions core:edge.