### PR TITLE
[setup] Fix to let setup.py test run

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,6 @@
 description-file = README.md
 
 [flake8]
-exclude = .git, __pycache__, build, dist, docs, docker
+exclude = .git, .eggs, __pycache__, build, dist, docs, docker
 ignore = E129, E402, F841, C901
 max-line-length = 130

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ import re
 import sys
 import unittest
 
-from setuptools import setup, Command
+from setuptools import setup
+from setuptools.command.test import test as TestClass
 
 here = os.path.abspath(os.path.dirname(__file__))
 readme_md = os.path.join(here, 'README.md')
@@ -52,18 +53,15 @@ with codecs.open(version_py, 'r', encoding='utf-8') as fd:
                         fd.read(), re.MULTILINE).group(1)
 
 
-class TestCommand(Command):
-
+class TestCommand(TestClass):
     user_options = []
     __dir__ = os.path.dirname(os.path.realpath(__file__))
 
     def initialize_options(self):
-        os.chdir(os.path.join(self.__dir__, 'tests'))
+        super().initialize_options()
+        sys.path.insert(0, os.path.join(self.__dir__, 'tests'))
 
-    def finalize_options(self):
-        pass
-
-    def run(self):
+    def run_tests(self):
         test_suite = unittest.TestLoader().discover('.', pattern='test_*.py')
         result = unittest.TextTestRunner(buffer=True).run(test_suite)
         sys.exit(not result.wasSuccessful())
@@ -93,6 +91,8 @@ setup(name="perceval",
           'perceval.backends.core'
       ],
       namespace_packages=['perceval', 'perceval.backends'],
+      setup_requires=['wheel', 'pandoc'],
+      tests_require=['httpretty==0.8.6'],
       install_requires=[
           'python-dateutil>=2.6.0',
           'requests>=2.7.0',


### PR DESCRIPTION
The command

```
python setup.py test
```

was not working.

This patch makes it work.