### PR TITLE
Fix support for package namespaces.

### DIFF
--- a/bin/perceval
+++ b/bin/perceval
@@ -28,8 +28,8 @@ import os.path
 import sys
 
 import perceval
-import perceval.backends
-
+import perceval.backend
+import perceval.backends.core
 
 PERCEVAL_USAGE_MSG = \
 """%(prog)s [-c <file>] [-g] <backend> [<args>] | --help | --version"""
@@ -81,7 +81,7 @@ PERCEVAL_EPILOG_MSG = \
 """Run '%(prog)s <backend> --help' to get information about a specific backend."""
 
 PERCEVAL_VERSION_MSG = \
-"""%(prog)s """  + perceval.__version__
+"""%(prog)s """  + perceval.backends.core.__version__
 
 
 # Logging formats
@@ -98,7 +98,7 @@ def main():
     else:
         defaults = {}
 
-    _, PERCEVAL_CMDS = perceval.find_backends(perceval.backends)
+    _, PERCEVAL_CMDS = perceval.backend.find_backends(perceval.backends)
 
     if args.backend not in PERCEVAL_CMDS:
         raise RuntimeError("Unknown backend %s" % args.backend)

--- a/perceval/__init__.py
+++ b/perceval/__init__.py
@@ -20,11 +20,4 @@
 #     Santiago Dueñas <sduenas@bitergia.com>
 #
 
-import logging
-
-from ._version import __version__
-from .backend import fetch, fetch_from_archive, find_backends
-
-__all__ = [__version__, fetch, fetch_from_archive, find_backends]
-
-logging.getLogger(__name__).addHandler(logging.NullHandler())
+__import__('pkg_resources').declare_namespace(__name__)

--- a/perceval/backends/core/__init__.py
+++ b/perceval/backends/core/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2018 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+from ..._version import __version__
+
+__version__ = __version__

--- a/setup.py
+++ b/setup.py
@@ -92,9 +92,7 @@ setup(name="perceval",
           'perceval.backends',
           'perceval.backends.core'
       ],
-      namespaces=[
-          'perceval.backends'
-      ],
+      namespace_packages=['perceval', 'perceval.backends'],
       install_requires=[
           'python-dateutil>=2.6.0',
           'requests>=2.7.0',

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -38,7 +38,7 @@ from grimoirelab.toolkit.datetime import (InvalidDateError,
                                           datetime_utcnow,
                                           str_to_datetime)
 
-from perceval import __version__
+from perceval.backends.core import __version__
 from perceval.archive import Archive, ArchiveManager
 from perceval.backend import (Backend,
                               BackendCommandArgumentParser,


### PR DESCRIPTION
This module was not really using package namespaces. This patch should provide that support. For that, some changes had to be done to the module itself, mainly changing __init__.py in perceval and perceval/backends to contain only the line for declaring namepaces. This means that symbols that were exported by those __init__.py files now need to be imported from the corresponding modules. In particular, __version__ is now provided by perceval.backends.core for this package.

All of this has bin fixed in bin/perceval, but maybe other packages (GrimoireELK, SirArthur, Mordred) would need similar fixes.