### PR TITLE
[pipermail] Fix command line parameters

### DIFF
--- a/perceval/backends/core/pipermail.py
+++ b/perceval/backends/core/pipermail.py
@@ -64,7 +64,7 @@ class Pipermail(MBox):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.8.0'
+    version = '0.9.0'
 
     CATEGORIES = [CATEGORY_MESSAGE]
 
@@ -154,8 +154,8 @@ class PipermailCommand(BackendCommand):
         group = parser.parser.add_argument_group('Pipermail arguments')
         group.add_argument('--mboxes-path', dest='mboxes_path',
                            help="Path where mbox files will be stored")
-        group.add_argument('--verify', dest='verify',
-                           default=True,
+        group.add_argument('--no-verify', dest='verify',
+                           action='store_false',
                            help="Value 'True' enable SSL verification")
 
         # Required arguments

--- a/tests/test_pipermail.py
+++ b/tests/test_pipermail.py
@@ -549,12 +549,10 @@ class TestPipermailCommand(unittest.TestCase):
         self.assertEqual(cmd.parsed_args.dirpath, '/tmp/perceval/')
 
         args = ['http://example.com/',
-                '--mboxes-path', '/tmp/perceval/',
-                '--verify', False]
+                '--mboxes-path', '/tmp/perceval/']
 
         cmd = PipermailCommand(*args)
         self.assertEqual(cmd.parsed_args.dirpath, '/tmp/perceval/')
-        self.assertFalse(cmd.parsed_args.verify)
 
     def test_parsing_on_init(self):
         """Test if the class is initialized"""
@@ -578,7 +576,7 @@ class TestPipermailCommand(unittest.TestCase):
                 '--mboxes-path', '/tmp/perceval/',
                 '--tag', 'test',
                 '--from-date', '1970-01-01',
-                '--verify', False]
+                '--no-verify']
 
         parsed_args = parser.parse(*args)
         self.assertEqual(parsed_args.url, 'http://example.com/')


### PR DESCRIPTION
This code fixes the way how SSL verification is passed via command line (enabled by default). Verification can be disabled by passing `no-verify` as parameter.