### PR TITLE
Added PATH environment in git backend

### DIFF
--- a/perceval/backends/core/git.py
+++ b/perceval/backends/core/git.py
@@ -783,7 +783,8 @@ class GitRepository:
         self.gitenv = {
             'LANG': 'C',
             'PAGER': '',
-            'HOME': os.getenv('HOME', '')
+            'HOME': os.getenv('HOME', ''),
+            'PATH': os.getenv('PATH', '')
         }
 
     @classmethod
@@ -804,7 +805,8 @@ class GitRepository:
         cmd = ['git', 'clone', '--bare', uri, dirpath]
         env = {
             'LANG': 'C',
-            'HOME': os.getenv('HOME', '')
+            'HOME': os.getenv('HOME', ''),
+            'PATH': os.getenv('PATH', '')
         }
 
         cls._exec(cmd, env=env)


### PR DESCRIPTION
Update the git backend to allow the sub process which executes the git command to use the same PATH environment variable as the parent process. Without this update it will use /usr/bin/git by default, which could be different from the actual git that is used and defined by PATH.