### PR TITLE
[tests] Replace datetime function with equivalent toolkit one

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -830,9 +830,9 @@ class TestMetadata(unittest.TestCase):
 
     def test_decorator(self):
         backend = MockedBackend('test', 'mytag')
-        before = datetime.datetime.utcnow().timestamp()
+        before = datetime_utcnow().timestamp()
         items = [item for item in backend.fetch()]
-        after = datetime.datetime.utcnow().timestamp()
+        after = datetime_utcnow().timestamp()
 
         for x in range(5):
             item = items[x]


### PR DESCRIPTION
This PR addresses #394. It replaces the datetime function used in the method `test_decorator` with its equivalent available in grimoirelab-toolkit. Thus, improving in this way the coherence in the code.