### PR TITLE
[twitter] Change metadata_id attribute

### DIFF
--- a/perceval/backends/core/twitter.py
+++ b/perceval/backends/core/twitter.py
@@ -72,7 +72,7 @@ class Twitter(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.1.0'
+    version = '0.2.0'
 
     CATEGORIES = [CATEGORY_TWEET]
 
@@ -184,7 +184,7 @@ class Twitter(Backend):
     def metadata_id(item):
         """Extracts the identifier from a Twitter item."""
 
-        return str(item['id'])
+        return str(item['id_str'])
 
     @staticmethod
     def metadata_updated_on(item):


### PR DESCRIPTION
This code sets the metadata_id attribute to `id_str`. As [reported](https://twittercommunity.com/t/twitter-id-and-id-str-are-different/79942/9) by the Twitter API, `id_str` should be used in preference of `id`, because some programming languages may otherwise scramble the ID.