### PR TITLE
[pipermail] Remove duplicated test

### DIFF
--- a/tests/test_pipermail.py
+++ b/tests/test_pipermail.py
@@ -548,12 +548,6 @@ class TestPipermailCommand(unittest.TestCase):
         cmd = PipermailCommand(*args)
         self.assertEqual(cmd.parsed_args.dirpath, '/tmp/perceval/')
 
-        args = ['http://example.com/',
-                '--mboxes-path', '/tmp/perceval/']
-
-        cmd = PipermailCommand(*args)
-        self.assertEqual(cmd.parsed_args.dirpath, '/tmp/perceval/')
-
     def test_parsing_on_init(self):
         """Test if the class is initialized"""
 


### PR DESCRIPTION
This code removes a duplicated test in the method `test_mboxes_path_init`.