### PR TITLE
Changes to work with grimoirelab_toolkit.

### DIFF
--- a/perceval/archive.py
+++ b/perceval/archive.py
@@ -29,7 +29,7 @@ import pickle
 import sqlite3
 import uuid
 
-from grimoirelab.toolkit.datetime import (datetime_utcnow,
+from grimoirelab_toolkit.datetime import (datetime_utcnow,
                                           datetime_to_utc,
                                           str_to_datetime)
 

--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -29,8 +29,8 @@ import os
 import pkgutil
 import sys
 
-from grimoirelab.toolkit.introspect import find_signature_parameters
-from grimoirelab.toolkit.datetime import (datetime_utcnow,
+from grimoirelab_toolkit.introspect import find_signature_parameters
+from grimoirelab_toolkit.datetime import (datetime_utcnow,
                                           str_to_datetime)
 from .archive import Archive, ArchiveManager
 from .errors import ArchiveError, BackendError

--- a/perceval/backends/core/askbot.py
+++ b/perceval/backends/core/askbot.py
@@ -28,8 +28,8 @@ import re
 import bs4
 import requests
 
-from grimoirelab.toolkit.datetime import datetime_to_utc, str_to_datetime
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.datetime import datetime_to_utc, str_to_datetime
+from grimoirelab_toolkit.uris import urijoin
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/bugzilla.py
+++ b/perceval/backends/core/bugzilla.py
@@ -29,7 +29,7 @@ import re
 import bs4
 import dateutil.tz
 
-from grimoirelab.toolkit.datetime import str_to_datetime
+from grimoirelab_toolkit.datetime import str_to_datetime
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/bugzillarest.py
+++ b/perceval/backends/core/bugzillarest.py
@@ -26,8 +26,8 @@ import logging
 
 import requests
 
-from grimoirelab.toolkit.datetime import datetime_to_utc, str_to_datetime
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.datetime import datetime_to_utc, str_to_datetime
+from grimoirelab_toolkit.uris import urijoin
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/confluence.py
+++ b/perceval/backends/core/confluence.py
@@ -25,8 +25,8 @@ import json
 
 import requests
 
-from grimoirelab.toolkit.datetime import datetime_to_utc, str_to_datetime
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.datetime import datetime_to_utc, str_to_datetime
+from grimoirelab_toolkit.uris import urijoin
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/discourse.py
+++ b/perceval/backends/core/discourse.py
@@ -25,8 +25,8 @@
 import json
 import logging
 
-from grimoirelab.toolkit.datetime import datetime_to_utc, str_to_datetime
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.datetime import datetime_to_utc, str_to_datetime
+from grimoirelab_toolkit.uris import urijoin
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/dockerhub.py
+++ b/perceval/backends/core/dockerhub.py
@@ -23,8 +23,8 @@
 import json
 import logging
 
-from grimoirelab.toolkit.datetime import datetime_utcnow
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.datetime import datetime_utcnow
+from grimoirelab_toolkit.uris import urijoin
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/gerrit.py
+++ b/perceval/backends/core/gerrit.py
@@ -27,7 +27,7 @@ import re
 import subprocess
 import time
 
-from grimoirelab.toolkit.datetime import datetime_to_utc
+from grimoirelab_toolkit.datetime import datetime_to_utc
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/git.py
+++ b/perceval/backends/core/git.py
@@ -31,7 +31,7 @@ import threading
 import dulwich.client
 import dulwich.repo
 
-from grimoirelab.toolkit.datetime import datetime_to_utc, str_to_datetime
+from grimoirelab_toolkit.datetime import datetime_to_utc, str_to_datetime
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -26,10 +26,10 @@ import json
 import logging
 
 import requests
-from grimoirelab.toolkit.datetime import (datetime_to_utc,
+from grimoirelab_toolkit.datetime import (datetime_to_utc,
                                           datetime_utcnow,
                                           str_to_datetime)
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.uris import urijoin
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/gitlab.py
+++ b/perceval/backends/core/gitlab.py
@@ -27,10 +27,10 @@ import requests
 
 import urllib.parse
 
-from grimoirelab.toolkit.datetime import (datetime_to_utc,
+from grimoirelab_toolkit.datetime import (datetime_to_utc,
                                           datetime_utcnow,
                                           str_to_datetime)
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.uris import urijoin
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/hyperkitty.py
+++ b/perceval/backends/core/hyperkitty.py
@@ -28,8 +28,8 @@ import dateutil.parser
 import dateutil.relativedelta
 import dateutil.tz
 
-from grimoirelab.toolkit.datetime import datetime_to_utc, datetime_utcnow
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.datetime import datetime_to_utc, datetime_utcnow
+from grimoirelab_toolkit.uris import urijoin
 
 from .mbox import MBox, MailingList, CATEGORY_MESSAGE
 from ...backend import (BackendCommand,

--- a/perceval/backends/core/jenkins.py
+++ b/perceval/backends/core/jenkins.py
@@ -25,7 +25,7 @@ import logging
 
 import requests
 
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.uris import urijoin
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/jira.py
+++ b/perceval/backends/core/jira.py
@@ -28,8 +28,8 @@ import requests
 
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
-from grimoirelab.toolkit.datetime import datetime_to_utc, str_to_datetime
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.datetime import datetime_to_utc, str_to_datetime
+from grimoirelab_toolkit.uris import urijoin
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/launchpad.py
+++ b/perceval/backends/core/launchpad.py
@@ -24,9 +24,9 @@ import json
 import logging
 import requests
 
-from grimoirelab.toolkit.datetime import (datetime_to_utc,
+from grimoirelab_toolkit.datetime import (datetime_to_utc,
                                           str_to_datetime)
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.uris import urijoin
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/mattermost.py
+++ b/perceval/backends/core/mattermost.py
@@ -23,8 +23,8 @@
 import json
 import logging
 
-from grimoirelab.toolkit.datetime import datetime_to_utc, datetime_utcnow
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.datetime import datetime_to_utc, datetime_utcnow
+from grimoirelab_toolkit.uris import urijoin
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/mbox.py
+++ b/perceval/backends/core/mbox.py
@@ -31,7 +31,7 @@ import tempfile
 import gzip
 import bz2
 
-from grimoirelab.toolkit.datetime import (InvalidDateError,
+from grimoirelab_toolkit.datetime import (InvalidDateError,
                                           datetime_to_utc,
                                           str_to_datetime)
 

--- a/perceval/backends/core/mediawiki.py
+++ b/perceval/backends/core/mediawiki.py
@@ -25,10 +25,10 @@ import logging
 
 import dateutil
 
-from grimoirelab.toolkit.datetime import (datetime_to_utc,
+from grimoirelab_toolkit.datetime import (datetime_to_utc,
                                           datetime_utcnow,
                                           str_to_datetime)
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.uris import urijoin
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/meetup.py
+++ b/perceval/backends/core/meetup.py
@@ -24,8 +24,8 @@ import json
 import logging
 import requests
 
-from grimoirelab.toolkit.datetime import datetime_to_utc
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.datetime import datetime_to_utc
+from grimoirelab_toolkit.uris import urijoin
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/nntp.py
+++ b/perceval/backends/core/nntp.py
@@ -26,7 +26,7 @@ import nntplib
 
 import email.parser
 
-from grimoirelab.toolkit.datetime import str_to_datetime
+from grimoirelab_toolkit.datetime import str_to_datetime
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/phabricator.py
+++ b/perceval/backends/core/phabricator.py
@@ -23,7 +23,7 @@
 import json
 import logging
 
-from grimoirelab.toolkit.datetime import datetime_to_utc
+from grimoirelab_toolkit.datetime import datetime_to_utc
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/pipermail.py
+++ b/perceval/backends/core/pipermail.py
@@ -31,8 +31,8 @@ import bs4
 import dateutil
 import requests
 
-from grimoirelab.toolkit.datetime import datetime_to_utc
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.datetime import datetime_to_utc
+from grimoirelab_toolkit.uris import urijoin
 
 from .mbox import MBox, MailingList, CATEGORY_MESSAGE
 from ...backend import (BackendCommand,

--- a/perceval/backends/core/redmine.py
+++ b/perceval/backends/core/redmine.py
@@ -25,8 +25,8 @@ import logging
 
 import requests
 
-from grimoirelab.toolkit.datetime import datetime_to_utc, str_to_datetime
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.datetime import datetime_to_utc, str_to_datetime
+from grimoirelab_toolkit.uris import urijoin
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/rss.py
+++ b/perceval/backends/core/rss.py
@@ -24,7 +24,7 @@ import logging
 
 import feedparser
 
-from grimoirelab.toolkit.datetime import str_to_datetime
+from grimoirelab_toolkit.datetime import str_to_datetime
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/slack.py
+++ b/perceval/backends/core/slack.py
@@ -23,8 +23,8 @@
 import json
 import logging
 
-from grimoirelab.toolkit.datetime import datetime_to_utc, datetime_utcnow
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.datetime import datetime_to_utc, datetime_utcnow
+from grimoirelab_toolkit.uris import urijoin
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/stackexchange.py
+++ b/perceval/backends/core/stackexchange.py
@@ -25,8 +25,8 @@ import json
 import logging
 import time
 
-from grimoirelab.toolkit.datetime import datetime_to_utc
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.datetime import datetime_to_utc
+from grimoirelab_toolkit.uris import urijoin
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/supybot.py
+++ b/perceval/backends/core/supybot.py
@@ -27,7 +27,7 @@ import re
 
 import dateutil
 
-from grimoirelab.toolkit.datetime import datetime_to_utc, str_to_datetime
+from grimoirelab_toolkit.datetime import datetime_to_utc, str_to_datetime
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/telegram.py
+++ b/perceval/backends/core/telegram.py
@@ -24,7 +24,7 @@ import json
 import logging
 import re
 
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.uris import urijoin
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/perceval/backends/core/twitter.py
+++ b/perceval/backends/core/twitter.py
@@ -23,7 +23,7 @@
 import json
 import logging
 
-from grimoirelab.toolkit.datetime import datetime_utcnow, str_to_datetime
+from grimoirelab_toolkit.datetime import datetime_utcnow, str_to_datetime
 
 from ...backend import (Backend,
                         BackendCommand,

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -33,7 +33,7 @@ import unittest.mock
 import httpretty
 import requests
 
-from grimoirelab.toolkit.datetime import datetime_utcnow, datetime_to_utc
+from grimoirelab_toolkit.datetime import datetime_utcnow, datetime_to_utc
 
 from perceval.archive import Archive, ArchiveManager
 from perceval.errors import ArchiveError, ArchiveManagerError

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -34,7 +34,7 @@ import unittest.mock
 
 import dateutil.tz
 
-from grimoirelab.toolkit.datetime import (InvalidDateError,
+from grimoirelab_toolkit.datetime import (InvalidDateError,
                                           datetime_utcnow,
                                           str_to_datetime)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -33,7 +33,7 @@ import requests
 
 pkg_resources.declare_namespace('perceval.backends')
 
-from grimoirelab.toolkit.datetime import datetime_utcnow
+from grimoirelab_toolkit.datetime import datetime_utcnow
 
 from perceval.archive import Archive
 from perceval.client import HttpClient, RateLimitHandler

--- a/tests/test_dockerhub.py
+++ b/tests/test_dockerhub.py
@@ -30,7 +30,7 @@ import dateutil
 import httpretty
 import pkg_resources
 
-from grimoirelab.toolkit.uris import urijoin
+from grimoirelab_toolkit.uris import urijoin
 
 pkg_resources.declare_namespace('perceval.backends')
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -32,7 +32,7 @@ import requests
 
 pkg_resources.declare_namespace('perceval.backends')
 
-from grimoirelab.toolkit.datetime import datetime_utcnow
+from grimoirelab_toolkit.datetime import datetime_utcnow
 from perceval.backend import BackendCommandArgumentParser
 from perceval.client import RateLimitHandler
 from perceval.errors import RateLimitError

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -34,7 +34,7 @@ import requests
 
 pkg_resources.declare_namespace('perceval.backends')
 
-from grimoirelab.toolkit.datetime import datetime_utcnow
+from grimoirelab_toolkit.datetime import datetime_utcnow
 from perceval.backend import BackendCommandArgumentParser
 from perceval.errors import RateLimitError
 from perceval.utils import DEFAULT_DATETIME

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -29,7 +29,7 @@ import unittest
 import httpretty
 import pkg_resources
 
-from grimoirelab.toolkit.datetime import str_to_datetime
+from grimoirelab_toolkit.datetime import str_to_datetime
 
 pkg_resources.declare_namespace('perceval.backends')
 

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -31,7 +31,7 @@ import unittest
 import urllib
 import unittest.mock
 
-from grimoirelab.toolkit.datetime import (datetime_to_utc,
+from grimoirelab_toolkit.datetime import (datetime_to_utc,
                                           str_to_datetime)
 
 pkg_resources.declare_namespace('perceval.backends')

--- a/tests/test_twitter.py
+++ b/tests/test_twitter.py
@@ -33,7 +33,7 @@ import pkg_resources
 
 pkg_resources.declare_namespace('perceval.backends')
 
-from grimoirelab.toolkit.datetime import str_to_datetime
+from grimoirelab_toolkit.datetime import str_to_datetime
 from perceval.backend import BackendCommandArgumentParser
 from perceval.errors import BackendError, RateLimitError
 from perceval.backends.core.twitter import (Twitter,


### PR DESCRIPTION
Once the corresponding pull request is accepted, the grimoirelab.toolkit module becomes grimoirelab_toolkit.
Therefore, we need all of these changes for still working with the new name.

This is needed after chaoss/grimoirelab-toolkit#13 is accepted. Tests will fail until that change is merged.