### PR TITLE
[github] Fix position GitHub client args

### DIFF
--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -80,7 +80,7 @@ class GitHub(Backend):
     :param sleep_time: time to sleep in case
         of connection problems
     """
-    version = '0.17.1'
+    version = '0.17.2'
 
     CATEGORIES = [CATEGORY_ISSUE, CATEGORY_PULL_REQUEST]
 
@@ -204,7 +204,7 @@ class GitHub(Backend):
 
         return GitHubClient(self.owner, self.repository, self.api_token, self.base_url,
                             self.sleep_for_rate, self.min_rate_to_sleep,
-                            self.max_retries, self.sleep_time,
+                            self.sleep_time, self.max_retries,
                             self.archive, from_archive)
 
     def __fetch_issues(self, from_date):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1530,6 +1530,18 @@ class TestGitHubClient(unittest.TestCase):
         self.assertEqual(client.max_retries, GitHubClient.MAX_RETRIES)
         self.assertEqual(client.base_url, 'https://api.github.com')
 
+        client = GitHubClient('zhquan_example', 'repo', 'aaa', None, False, 3, 20, 2, None, False)
+        self.assertEqual(client.owner, 'zhquan_example')
+        self.assertEqual(client.repository, 'repo')
+        self.assertEqual(client.token, 'aaa')
+        self.assertEqual(client.base_url, GITHUB_API_URL)
+        self.assertFalse(client.sleep_for_rate)
+        self.assertEqual(client.min_rate_to_sleep, 3)
+        self.assertEqual(client.sleep_time, 20)
+        self.assertEqual(client.max_retries, 2)
+        self.assertIsNone(client.archive)
+        self.assertFalse(client.from_archive)
+
         client = GitHubClient('zhquan_example', 'repo', 'aaa', min_rate_to_sleep=RateLimitHandler.MAX_RATE_LIMIT + 1)
         self.assertEqual(client.min_rate_to_sleep, RateLimitHandler.MAX_RATE_LIMIT)
 


### PR DESCRIPTION
This code fixes the position of client arguments: `max_retries` and `sleep_time` which were inverted in the `init_client` method within the Backend class. A test is provided to ensure the correct position of those args.