### PR TITLE
[travis] Change how perceval is installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - pip install coveralls
 
 install:
-  - ./setup.py install
+  - pip install .
 
 script:
   - flake8 .


### PR DESCRIPTION
This code modifies how perceval is installed, thus now the installation is achieved via `pip install .`