### PR TITLE
[gitlab] Sanitize requests before archiving

### DIFF
--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -22,6 +22,7 @@
 #     Valerio Cosentino <valcos@bitergia.com>
 #
 
+import copy
 import datetime
 import json
 import os
@@ -635,6 +636,20 @@ class TestGitLabClient(unittest.TestCase):
 
         with self.assertRaises(RateLimitError):
             _ = [issues for issues in client.issues()]
+
+    def test_sanitize_for_archive(self):
+        """Test whether the sanitize method works properly"""
+
+        url = "http://example.com"
+        headers = {'PRIVATE-TOKEN': 'ABCDEF'}
+        payload = {}
+
+        s_url, s_headers, s_payload = GitLabClient.sanitize_for_archive(url, copy.deepcopy(headers), payload)
+        headers.pop('PRIVATE-TOKEN')
+
+        self.assertEqual(url, s_url)
+        self.assertEqual(headers, s_headers)
+        self.assertEqual(payload, s_payload)
 
 
 class TestGitLabCommand(unittest.TestCase):


### PR DESCRIPTION
This code removes token information before archiving the GitLab data, thus it enables to read the archive afterwards without the need of passing the token.