### PR TITLE
[askbot] Handle upstream internal server

### DIFF
--- a/perceval/backends/core/askbot.py
+++ b/perceval/backends/core/askbot.py
@@ -53,7 +53,7 @@ class Askbot(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.6.3'
+    version = '0.6.4'
 
     CATEGORIES = [CATEGORY_QUESTION]
 
@@ -334,16 +334,21 @@ class AskbotClient(HttpClient):
 
         try:
             response = self.fetch(path, payload=params, headers=headers)
+            raw = response.text
         except requests.exceptions.HTTPError as ex:
             if ex.response.status_code == 404:
                 logger.debug("Comments URL did not work. Using old URL schema.")
                 self._use_new_urls = False
                 path = urijoin(self.base_url, self.COMMENTS_OLD)
                 response = self.fetch(path, payload=params, headers=headers)
+                raw = response.text
+            elif ex.response.status_code == 500:
+                logger.warning("Comments not retrieved due to %s", ex)
+                raw = '[]'
             else:
                 raise ex
 
-        return response.text
+        return raw
 
 
 class AskbotParser:

--- a/tests/test_askbot.py
+++ b/tests/test_askbot.py
@@ -38,6 +38,7 @@ from perceval.backends.core.askbot import (Askbot,
                                            AskbotClient,
                                            AskbotParser,
                                            AskbotCommand)
+
 from perceval.utils import DEFAULT_DATETIME
 from base import TestCaseBackendArchive
 
@@ -296,8 +297,8 @@ class TestAskbotClient(unittest.TestCase):
         self.assertRegex(req.path, '/question/0')
 
     @httpretty.activate
-    def test_wrong_status_get_comments(self):
-        """Test whether, when fetching comments, an exception is thrown if HTTPError is not 404"""
+    def test_403_status_get_comments(self):
+        """Test whether, when fetching comments, an exception is thrown if HTTPError is not 403"""
 
         httpretty.register_uri(httpretty.GET,
                                ASKBOT_COMMENTS_API_URL,
@@ -307,6 +308,17 @@ class TestAskbotClient(unittest.TestCase):
 
         with self.assertRaises(requests.exceptions.HTTPError):
             _ = client.get_comments(5)
+
+    @httpretty.activate
+    def test_500_status_get_comments(self):
+        """Test whether, when fetching comments, an exception is thrown if HTTPError is not 503"""
+
+        httpretty.register_uri(httpretty.GET,
+                               ASKBOT_COMMENTS_API_URL,
+                               body="", status=500)
+
+        client = AskbotClient(ASKBOT_URL)
+        self.assertEqual(client.get_comments(5), '[]')
 
     @httpretty.activate
     def test_get_comments(self):


### PR DESCRIPTION
This code allows to handle 500 http errors returned by the upstream server when fetching comments of answers, which caused perceval to fail. Now those comments are skipped and a warning message is logged.