### PR TITLE
[mediawiki] Optimize number of calls to API

### DIFF
--- a/tests/data/mediawiki/mediawiki_page_476589_revisions.json
+++ b/tests/data/mediawiki/mediawiki_page_476589_revisions.json
@@ -1,0 +1,18 @@
+{
+    "continue": {
+        "continue": "||",
+        "rvcontinue": "20160226140047|2062172"
+    },
+    "limits": {
+        "revisions": 500
+    },
+    "query": {
+        "pages": {
+            "476589": {
+                "ns": 0,
+                "pageid": 476589,
+                "title": "OldEditor:Test"
+            }
+        }
+    }
+}

--- a/tests/data/mediawiki/mediawiki_page_476590_revisions.json
+++ b/tests/data/mediawiki/mediawiki_page_476590_revisions.json
@@ -1,0 +1,18 @@
+{
+    "continue": {
+        "continue": "||",
+        "rvcontinue": "20160226140047|2062172"
+    },
+    "limits": {
+        "revisions": 500
+    },
+    "query": {
+        "pages": {
+            "476599": {
+                "ns": 0,
+                "pageid": 476590,
+                "title": "OldEditor:Test"
+            }
+        }
+    }
+}

--- a/tests/data/mediawiki/mediawiki_pages_all.json
+++ b/tests/data/mediawiki/mediawiki_pages_all.json
@@ -13,6 +13,12 @@
                 "ns": 0,
                 "pageid": 476583,
                 "title": "VisualEditor:Test"
+            },
+            {
+                "ns": 0,
+                "pageid": 476589,
+                "title": "NewEditor:Test",
+                "revid": 0
             }
         ]
     }

--- a/tests/data/mediawiki/mediawiki_pages_allrevisions.json
+++ b/tests/data/mediawiki/mediawiki_pages_allrevisions.json
@@ -34,6 +34,35 @@
                     }
                 ],
                 "title": "VisualEditor:Test"
+            },
+            {
+                "ns": 0,
+                "pageid": 476583,
+                "revisions": [
+                    {
+                        "parentid": 2169554,
+                        "revid": 2169844
+                    },
+                    {
+                        "parentid": 2169844,
+                        "revid": 2170296
+                    }
+                ],
+                "title": "VisualEditor:Test"
+            },
+            {
+                "ns": 0,
+                "pageid": 476589,
+                "revid": 0,
+                "oldrevid": 0,
+                "title": "NewEditor:Test"
+            },
+            {
+                "ns": 0,
+                "pageid": 476590,
+                "revid": 0,
+                "oldrevid": 0,
+                "title": "NewEditor:Test"
             }
         ]
     }

--- a/tests/data/mediawiki/mediawiki_pages_recent_changes.json
+++ b/tests/data/mediawiki/mediawiki_pages_recent_changes.json
@@ -9,20 +9,49 @@
                 "pageid": 592384,
                 "timestamp": "2016-06-23T15:42:38Z",
                 "title": "Technical Collaboration Guideline/Translation",
-                "type": "edit"
+                "type": "edit",
+                "revid": 291919,
+                "oldrevid": 210234
+            },
+            {
+                "ns": 0,
+                "pageid": 476583,
+                "timestamp": "2016-06-23T15:38:23Z",
+                "title": "VisualEditor:Test",
+                "type": "edit",
+                "revid": 291920,
+                "oldrevid": 210235
+            },
+            {
+                "ns": 0,
+                "pageid": 476589,
+                "timestamp": "2016-06-23T15:37:23Z",
+                "title": "OldEditor:Test",
+                "type": "edit",
+                "revid": 0,
+                "oldrevid": 0
+            },
+            {
+                "ns": 0,
+                "pageid": 476583,
+                "timestamp": "2016-06-23T15:36:23Z",
+                "title": "VisualEditor:Test",
+                "type": "edit",
+                "revid": 291923,
+                "oldrevid": 210237
             },
             {
                 "ns": 0,
                 "pageid": 476583,
                 "timestamp": "2016-06-23T15:27:23Z",
                 "title": "VisualEditor:Test",
-                "type": "edit"
+                "type": "edit",
+                "revid": 291923,
+                "oldrevid": 210237
             }
         ]
     },
-    "query-continue": {
-        "recentchanges": {
-            "rccontinue": "20160614151314|2402770"
-        }
+    "continue": {
+        "rccontinue": "20160614151314|2402770"
     }
 }


### PR DESCRIPTION
This code targets #436, thus it optmizes the number of calls to fetch revision info, in particular if a page doesn't have any revision, the call is not performed. Furthermore, this code avoids errors when creating the archive (which doesn't allow to store duplicated API calls).