### PR TITLE
[mediawiki] Fix error in client `get_version` method

### DIFF
--- a/perceval/backends/core/mediawiki.py
+++ b/perceval/backends/core/mediawiki.py
@@ -71,7 +71,7 @@ class MediaWiki(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.9.4'
+    version = '0.9.5'
 
     CATEGORIES = [CATEGORY_PAGE]
 
@@ -390,8 +390,8 @@ class MediaWikiClient(HttpClient):
             res = self.call(params)
             siteinfo = json.loads(res)
             siteinfo = siteinfo["query"]["general"]
-        except Exception:
-            logger.error(res)
+        except Exception as ex:
+            logger.error(ex)
             cause = "Wrong MediaWiki API: " + self.base_url
             raise BackendError(cause=cause)
 


### PR DESCRIPTION
This code fixes the logged error of the method `get_version` within the MediawikiClient. Before, the `res` variable was used to fill the log info, however such a variable wasn't initialized outside the try..except block. Now the exception itself is stored in the log message.