### PR TITLE
[tests] Use output method in assertLogs for mbox test

### DIFF
--- a/tests/test_mbox.py
+++ b/tests/test_mbox.py
@@ -175,8 +175,8 @@ class TestMBoxArchive(TestBaseMBox):
         with self.assertLogs(logger, level='ERROR') as cm:
             container = mbox.container
             container.close()
-            self.assertEqual(cm[-1][0], 'ERROR:perceval.backends.core.mbox:Zip %s contains more than one file, '
-                                        'only the first uncompressed' % mbox.filepath)
+            self.assertEqual(cm.output[0], 'ERROR:perceval.backends.core.mbox:Zip %s contains more than one file, '
+                                           'only the first uncompressed' % mbox.filepath)
 
 
 class TestMailingList(TestBaseMBox):


### PR DESCRIPTION
This code uses the method output to explore the logs produced while fetching Mbox data, instead of accessing the lists available in the assertLogs object.