### PR TITLE
[gitlab] Fix `has_resuming` method

### DIFF
--- a/perceval/backends/core/gitlab.py
+++ b/perceval/backends/core/gitlab.py
@@ -81,7 +81,7 @@ class GitLab(Backend):
     :param sleep_time: time to sleep in case
     :param blacklist_ids: ids of items that must not be retrieved
     """
-    version = '0.6.0'
+    version = '0.6.1'
 
     CATEGORIES = [CATEGORY_ISSUE, CATEGORY_MERGE_REQUEST]
 
@@ -158,7 +158,7 @@ class GitLab(Backend):
 
         :returns: this backend does not support items resuming
         """
-        return False
+        return True
 
     @staticmethod
     def metadata_id(item):

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -407,7 +407,7 @@ class TestGitLabBackend(unittest.TestCase):
     def test_has_resuming(self):
         """Test if it returns False when has_resuming is called"""
 
-        self.assertEqual(GitLab.has_resuming(), False)
+        self.assertEqual(GitLab.has_resuming(), True)
 
     @httpretty.activate
     def test_fetch_issues(self):


### PR DESCRIPTION
This code fixes the return value of the `has_resuming` method, which now is set to true.