### PR TITLE
[discourse] Add params `sleep_time` and ` max_retries`

### DIFF
--- a/tests/test_discourse.py
+++ b/tests/test_discourse.py
@@ -112,7 +112,7 @@ class TestDiscourseBackend(unittest.TestCase):
                     uri.startswith(DISCOURSE_POST_URL_2):
                 body = body_post
             else:
-                raise
+                raise Exception
 
             requests_http.append(httpretty.last_request())
 
@@ -212,7 +212,7 @@ class TestDiscourseBackend(unittest.TestCase):
                     uri.startswith(DISCOURSE_POST_URL_2):
                 body = body_post
             else:
-                raise
+                raise Exception
 
             requests_http.append(httpretty.last_request())
 
@@ -312,7 +312,7 @@ class TestDiscourseBackend(unittest.TestCase):
                     uri.startswith(DISCOURSE_POST_URL_2):
                 body = body_post
             else:
-                raise
+                raise Exception
             return 200, headers, body
 
         httpretty.register_uri(httpretty.GET,
@@ -386,7 +386,7 @@ class TestDiscourseBackend(unittest.TestCase):
             elif uri.startswith(DISCOURSE_TOPIC_URL_1149):
                 body = body_topic_1149
             else:
-                raise
+                raise Exception
             return 200, headers, body
 
         httpretty.register_uri(httpretty.GET,
@@ -450,7 +450,7 @@ class TestDiscourseBackendArchive(TestCaseBackendArchive):
             elif uri.startswith(DISCOURSE_POST_URL_1) or uri.startswith(DISCOURSE_POST_URL_2):
                 body = body_post
             else:
-                raise
+                raise Exception
 
             requests_http.append(httpretty.last_request())
 
@@ -508,7 +508,7 @@ class TestDiscourseBackendArchive(TestCaseBackendArchive):
                     uri.startswith(DISCOURSE_POST_URL_2):
                 body = body_post
             else:
-                raise
+                raise Exception
 
             requests_http.append(httpretty.last_request())
 
@@ -580,7 +580,7 @@ class TestDiscourseBackendArchive(TestCaseBackendArchive):
                     uri.startswith(DISCOURSE_POST_URL_2):
                 body = body_post
             else:
-                raise
+                raise Exception
             return 200, headers, body
 
         httpretty.register_uri(httpretty.GET,
@@ -634,7 +634,7 @@ class TestDiscourseBackendArchive(TestCaseBackendArchive):
             elif uri.startswith(DISCOURSE_TOPIC_URL_1149):
                 body = body_topic_1149
             else:
-                raise
+                raise Exception
             return 200, headers, body
 
         httpretty.register_uri(httpretty.GET,

--- a/tests/test_discourse.py
+++ b/tests/test_discourse.py
@@ -116,7 +116,7 @@ class TestDiscourseBackend(unittest.TestCase):
 
             requests_http.append(httpretty.last_request())
 
-            return (200, headers, body)
+            return 200, headers, body
 
         httpretty.register_uri(httpretty.GET,
                                DISCOURSE_TOPICS_URL,
@@ -216,7 +216,7 @@ class TestDiscourseBackend(unittest.TestCase):
 
             requests_http.append(httpretty.last_request())
 
-            return (200, headers, body)
+            return 200, headers, body
 
         httpretty.register_uri(httpretty.GET,
                                DISCOURSE_TOPICS_URL,
@@ -313,7 +313,7 @@ class TestDiscourseBackend(unittest.TestCase):
                 body = body_post
             else:
                 raise
-            return (200, headers, body)
+            return 200, headers, body
 
         httpretty.register_uri(httpretty.GET,
                                DISCOURSE_TOPICS_URL,
@@ -387,7 +387,7 @@ class TestDiscourseBackend(unittest.TestCase):
                 body = body_topic_1149
             else:
                 raise
-            return (200, headers, body)
+            return 200, headers, body
 
         httpretty.register_uri(httpretty.GET,
                                DISCOURSE_TOPICS_URL,
@@ -454,7 +454,7 @@ class TestDiscourseBackendArchive(TestCaseBackendArchive):
 
             requests_http.append(httpretty.last_request())
 
-            return (200, headers, body)
+            return 200, headers, body
 
         httpretty.register_uri(httpretty.GET,
                                DISCOURSE_TOPICS_URL,
@@ -512,7 +512,7 @@ class TestDiscourseBackendArchive(TestCaseBackendArchive):
 
             requests_http.append(httpretty.last_request())
 
-            return (200, headers, body)
+            return 200, headers, body
 
         httpretty.register_uri(httpretty.GET,
                                DISCOURSE_TOPICS_URL,
@@ -581,7 +581,7 @@ class TestDiscourseBackendArchive(TestCaseBackendArchive):
                 body = body_post
             else:
                 raise
-            return (200, headers, body)
+            return 200, headers, body
 
         httpretty.register_uri(httpretty.GET,
                                DISCOURSE_TOPICS_URL,
@@ -635,7 +635,7 @@ class TestDiscourseBackendArchive(TestCaseBackendArchive):
                 body = body_topic_1149
             else:
                 raise
-            return (200, headers, body)
+            return 200, headers, body
 
         httpretty.register_uri(httpretty.GET,
                                DISCOURSE_TOPICS_URL,


### PR DESCRIPTION
This code enhances the Discourse backend, client and commandline with the params `sleep_time` and `max_retries`, which slow down the number of petititions issued to the API, and thus limit possible 429 HTTP errors. Tests have been changed accordingly.