### PR TITLE
[git] Add rev-list command to GitRepository class

### DIFF
--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1569,6 +1569,45 @@ class TestGitRepository(TestCaseGit):
 
         shutil.rmtree(new_path)
 
+    def test_rev_list(self):
+        """Test rev-list command"""
+
+        new_path = os.path.join(self.tmp_path, 'newgit')
+
+        repo = GitRepository.clone(self.git_path, new_path)
+        gitrev = repo.rev_list()
+        gitrev = [line for line in gitrev]
+
+        expected = ['456a68ee1407a77f3e804a30dff245bb6c6b872f',
+                    '51a3b654f252210572297f47597b31527c475fb8',
+                    'ce8e0b86a1e9877f42fe9453ede418519115f367',
+                    '589bb080f059834829a2a5955bebfd7c2baa110a',
+                    'c6ba8f7a1058db3e6b4bc6f1090e932b107605fb',
+                    'c0d66f92a95e31c77be08dc9d0f11a16715d1885',
+                    '7debcf8a2f57f86663809c58b5c07a398be7674c',
+                    '87783129c3f00d2c81a3a8e585eb86a47e39891a',
+                    'bc57a9209f096a130dcc5ba7089a8663f758a703',
+                    '49345fe87bd1dfad7e682f6554f7472c5576a8c7']
+
+        self.assertTrue(len(gitrev), len(expected))
+        for i in range(len(gitrev)):
+            self.assertEqual(gitrev[i], expected[i])
+
+        shutil.rmtree(new_path)
+
+    def test_rev_list_from_empty_repository(self):
+        """Test if an exception is raised when the repository is empty"""
+
+        new_path = os.path.join(self.tmp_path, 'newgit')
+
+        repo = GitRepository.clone(self.git_empty_path, new_path)
+        gitrev = repo.rev_list()
+
+        with self.assertRaises(EmptyRepositoryError):
+            _ = [line for line in gitrev]
+
+        shutil.rmtree(new_path)
+
     def test_log(self):
         """Test log command"""
 


### PR DESCRIPTION
This code adds support for the `rev-list` command, thus the list of commit hashes is retrieved from the repo without triggering any update. The rev-list is executed with the following params by default:
`git rev-list --topo-order --branches --tags --remotes=origin`.
However, using the param `branches`, it is possible to analysis a set of branches.
Tests have been added accordingly.