### PR TITLE
[git] Add for-each-ref command to GitRepository class

### DIFF
--- a/perceval/backends/core/git.py
+++ b/perceval/backends/core/git.py
@@ -64,7 +64,7 @@ class Git(Backend):
     :raises RepositoryError: raised when there was an error cloning or
         updating the repository.
     """
-    version = '0.11.0'
+    version = '0.11.1'
 
     CATEGORIES = [CATEGORY_COMMIT]
 
@@ -938,6 +938,25 @@ class GitRepository:
                      self.uri, self.dirpath)
 
         return commits
+
+    def for_each_ref(self, commit):
+        """List the references (branches and tags) which contain the specified commit.
+
+        The methods executes the Git for-each-ref command with the option `--contains`:
+
+            git for-each-ref --contains
+
+        :param commit: hash of the target commit
+
+        :raises RepositoryError: when an error occurs executing the command
+        """
+        cmd_for_each_ref = ['git', 'for-each-ref', '--contains', commit]
+
+        for line in self._exec_nb(cmd_for_each_ref, cwd=self.dirpath, env=self.gitenv):
+            yield line.rstrip('\n')
+
+        logger.debug("Git for-each-ref executed on %s repository (%s)",
+                     self.uri, self.dirpath)
 
     def rev_list(self, branches=None):
         """Read the list commits from the repository

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1569,6 +1569,34 @@ class TestGitRepository(TestCaseGit):
 
         shutil.rmtree(new_path)
 
+    def test_for_each_ref(self):
+        """Test for-each-ref command"""
+
+        new_path = os.path.join(self.tmp_path, 'newgit')
+
+        repo = GitRepository.clone(self.git_path, new_path)
+        gitfor = [line for line in repo.for_each_ref('456a68ee1407a77f3e804a30dff245bb6c6b872f')]
+
+        self.assertTrue(len(gitfor), 1)
+        commit, ref = gitfor[0].split('\t')
+
+        self.assertEqual(commit, '456a68ee1407a77f3e804a30dff245bb6c6b872f commit')
+        self.assertEqual(ref, 'refs/heads/master')
+
+        shutil.rmtree(new_path)
+
+    def test_for_each_ref_not_existing_commit(self):
+        """Test whether an exception is thrown when the commit does not exist"""
+
+        new_path = os.path.join(self.tmp_path, 'newgit')
+
+        repo = GitRepository.clone(self.git_empty_path, new_path)
+
+        with self.assertRaises(RepositoryError):
+            _ = [line for line in repo.for_each_ref('456a68ee1407a77f3e804a30dff245bb6c6b872f')]
+
+        shutil.rmtree(new_path)
+
     def test_rev_list(self):
         """Test rev-list command"""
 


### PR DESCRIPTION
This PR adds support for the `for-each-ref` command, which iterates over all the references and output information. The command is executed with the param `--contains` that lists the references containing a given commit.
Test have been added accordingly.