### PR TITLE
[doc] Update docstring for `sleep_time` param

### DIFF
--- a/perceval/backends/core/gitlab.py
+++ b/perceval/backends/core/gitlab.py
@@ -78,7 +78,8 @@ class GitLab(Backend):
          it will be reset
     :param max_retries: number of max retries to a data source
         before raising a RetryError exception
-    :param sleep_time: time to sleep in case
+    :param sleep_time: time (in seconds) to sleep in case
+        of connection problems
     :param blacklist_ids: ids of items that must not be retrieved
     """
     version = '0.6.2'
@@ -366,8 +367,8 @@ class GitLabClient(HttpClient, RateLimitHandler):
      :param sleep_for_rate: sleep until rate limit is reset
      :param min_rate_to_sleep: minimun rate needed to sleep until
           it will be reset
-     :param sleep_time: time to sleep in case
-         of connection problems
+     :param sleep_time: time (in seconds) to sleep in case
+        of connection problems
     :param max_retries: number of max retries to a data source
          before raising a RetryError exception
     :param archive: an archive to store/read fetched data

--- a/perceval/backends/core/googlehits.py
+++ b/perceval/backends/core/googlehits.py
@@ -56,7 +56,7 @@ class GoogleHits(Backend):
     :param archive: archive to store/retrieve items
     :param max_retries: number of max retries to a data source
         before raising a RetryError exception
-    :param sleep_time: time to sleep in case
+    :param sleep_time: time (in seconds) to sleep in case
         of connection problems
     """
     version = '0.2.2'
@@ -201,7 +201,7 @@ class GoogleHitsClient(HttpClient):
 
     Client for fetching hits data from Google API.
 
-    :param sleep_time: time to sleep in case
+    :param sleep_time: time (in seconds) to sleep in case
         of connection problems
     :param max_retries: number of max retries to a data source
         before raising a RetryError exception

--- a/perceval/backends/core/jenkins.py
+++ b/perceval/backends/core/jenkins.py
@@ -51,7 +51,8 @@ class Jenkins(Backend):
     :param archive: archive to store/retrieve items
     :param blacklist_jobs: exclude the jobs of this list while fetching
     :param detail_depth: control the detail level of the data returned by the API
-    :param sleep_time: minimun waiting time due to a timeout connection exception
+    :param sleep_time: time (in seconds) to sleep in case
+        of connection problems
     :param archive: collect builds already retrieved from an archive
     """
     version = '0.11.2'
@@ -201,7 +202,8 @@ class JenkinsClient(HttpClient):
     :param url: URL of jenkins node: https://build.opnfv.org/ci
     :param blacklist_jobs: exclude the jobs of this list while fetching
     :param detail_depth: set the detail level of the data returned by the API
-    :param sleep_time: minimun waiting time due to a timeout connection exception
+    :param sleep_time: time (in seconds) to sleep in case
+        of connection problems
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive
 

--- a/perceval/backends/core/launchpad.py
+++ b/perceval/backends/core/launchpad.py
@@ -54,7 +54,8 @@ class Launchpad(Backend):
     :param distribution: Launchpad distribution
     :param package: Distribution package
     :param items_per_page: number of items in a retrieved page
-    :param sleep_time: time to sleep in case of connection problems
+    :param sleep_time: time (in seconds) to sleep in case
+        of connection problems
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
@@ -276,7 +277,8 @@ class LaunchpadClient(HttpClient):
     :param distribution: Launchpad distribution
     :param package: Distribution package
     :param items_per_page: number of items in a retrieved page
-    :param sleep_time: time to sleep in case of connection problems
+    :param sleep_time: time (in seconds) to sleep in case
+        of connection problems
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive
     """

--- a/perceval/backends/core/mattermost.py
+++ b/perceval/backends/core/mattermost.py
@@ -67,8 +67,8 @@ class Mattermost(Backend):
     :param sleep_for_rate: sleep until rate limit is reset
     :param min_rate_to_sleep: minimun rate needed to sleep until
          it will be reset
-    :param sleep_time: minimun waiting time to avoid too many request
-         exception
+    :param sleep_time: time (in seconds) to sleep in case
+        of connection problems
     """
     version = '0.1.0'
 
@@ -266,7 +266,7 @@ class MattermostClient(HttpClient, RateLimitHandler):
     :param sleep_for_rate: sleep until rate limit is reset
     :param min_rate_to_sleep: minimun rate needed to sleep until
          it will be reset
-    :param sleep_time: time to sleep in case
+    :param sleep_time: time (in seconds) to sleep in case
         of connection problems
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive

--- a/perceval/backends/core/meetup.py
+++ b/perceval/backends/core/meetup.py
@@ -65,8 +65,8 @@ class Meetup(Backend):
     :param sleep_for_rate: sleep until rate limit is reset
     :param min_rate_to_sleep: minimun rate needed to sleep until
          it will be reset
-    :param sleep_time: minimun waiting time to avoid too many request
-         exception
+    :param sleep_time: time (in seconds) to sleep in case
+        of connection problems
     """
     version = '0.11.6'
 
@@ -302,7 +302,7 @@ class MeetupClient(HttpClient, RateLimitHandler):
     :param sleep_for_rate: sleep until rate limit is reset
     :param min_rate_to_sleep: minimun rate needed to sleep until
          it will be reset
-    :param sleep_time: time to sleep in case
+    :param sleep_time: time (in seconds) to sleep in case
         of connection problems
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive

--- a/perceval/backends/core/phabricator.py
+++ b/perceval/backends/core/phabricator.py
@@ -54,7 +54,7 @@ class Phabricator(Backend):
     :param archive: archive to store/retrieve items
     :param max_retries: number of max retries to a data source
         before raising a RetryError exception
-    :param sleep_time: time to sleep in case
+    :param sleep_time: time (in seconds) to sleep in case
         of connection problems
     """
     version = '0.11.1'
@@ -449,7 +449,7 @@ class ConduitClient(HttpClient):
         of the API
     :param max_retries: number of max retries to a data source
         before raising a RetryError exception
-    :param sleep_time: time to sleep in case
+    :param sleep_time: time (in seconds) to sleep in case
         of connection problems
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive

--- a/perceval/backends/core/twitter.py
+++ b/perceval/backends/core/twitter.py
@@ -67,8 +67,8 @@ class Twitter(Backend):
     :param sleep_for_rate: sleep until rate limit is reset
     :param min_rate_to_sleep: minimun rate needed to sleep until
          it will be reset
-    :param sleep_time: minimun waiting time to avoid too many request
-         exception
+    :param sleep_time: time (in seconds) to sleep in case
+        of connection problems
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
@@ -230,7 +230,7 @@ class TwitterClient(HttpClient, RateLimitHandler):
     :param sleep_for_rate: sleep until rate limit is reset
     :param min_rate_to_sleep: minimun rate needed to sleep until
          it will be reset
-    :param sleep_time: time to sleep in case
+    :param sleep_time: time (in seconds) to sleep in case
         of connection problems
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive

--- a/perceval/client.py
+++ b/perceval/client.py
@@ -50,7 +50,7 @@ class HttpClient:
     :param base_url: base URL of the data source
     :param max_retries: number of max retries to a data source
         before raising a RetryError exception
-    :param sleep_time: time to sleep in case
+    :param sleep_time: time (in seconds) to sleep in case
         of connection problems
     """
     version = '0.1.5'

--- a/tests/test_discourse.py
+++ b/tests/test_discourse.py
@@ -36,7 +36,9 @@ from perceval.backend import BackendCommandArgumentParser
 from perceval.utils import DEFAULT_DATETIME
 from perceval.backends.core.discourse import (Discourse,
                                               DiscourseCommand,
-                                              DiscourseClient)
+                                              DiscourseClient,
+                                              MAX_RETRIES,
+                                              DEFAULT_SLEEP_TIME)
 from base import TestCaseBackendArchive
 
 DISCOURSE_SERVER_URL = 'http://example.com'
@@ -66,6 +68,8 @@ class TestDiscourseBackend(unittest.TestCase):
         self.assertEqual(discourse.origin, DISCOURSE_SERVER_URL)
         self.assertEqual(discourse.tag, 'test')
         self.assertIsNone(discourse.client)
+        self.assertEqual(discourse.sleep_time, DEFAULT_SLEEP_TIME)
+        self.assertEqual(discourse.max_retries, MAX_RETRIES)
 
         # When origin is empty or None it will be set to
         # the value in url
@@ -78,6 +82,13 @@ class TestDiscourseBackend(unittest.TestCase):
         self.assertEqual(discourse.url, DISCOURSE_SERVER_URL)
         self.assertEqual(discourse.origin, DISCOURSE_SERVER_URL)
         self.assertEqual(discourse.tag, DISCOURSE_SERVER_URL)
+
+        discourse = Discourse(DISCOURSE_SERVER_URL, sleep_time=60, max_retries=30)
+        self.assertEqual(discourse.url, DISCOURSE_SERVER_URL)
+        self.assertEqual(discourse.origin, DISCOURSE_SERVER_URL)
+        self.assertEqual(discourse.tag, DISCOURSE_SERVER_URL)
+        self.assertEqual(discourse.sleep_time, 60)
+        self.assertEqual(discourse.max_retries, 30)
 
     def test_has_archiving(self):
         """Test if it returns True when has_archiving is called"""
@@ -112,11 +123,11 @@ class TestDiscourseBackend(unittest.TestCase):
                     uri.startswith(DISCOURSE_POST_URL_2):
                 body = body_post
             else:
-                raise
+                raise Exception
 
             requests_http.append(httpretty.last_request())
 
-            return (200, headers, body)
+            return 200, headers, body
 
         httpretty.register_uri(httpretty.GET,
                                DISCOURSE_TOPICS_URL,
@@ -146,7 +157,7 @@ class TestDiscourseBackend(unittest.TestCase):
                                ])
 
         # Test fetch topics
-        discourse = Discourse(DISCOURSE_SERVER_URL)
+        discourse = Discourse(DISCOURSE_SERVER_URL, sleep_time=0)
         topics = [topic for topic in discourse.fetch()]
 
         self.assertEqual(len(topics), 2)
@@ -212,11 +223,11 @@ class TestDiscourseBackend(unittest.TestCase):
                     uri.startswith(DISCOURSE_POST_URL_2):
                 body = body_post
             else:
-                raise
+                raise Exception
 
             requests_http.append(httpretty.last_request())
 
-            return (200, headers, body)
+            return 200, headers, body
 
         httpretty.register_uri(httpretty.GET,
                                DISCOURSE_TOPICS_URL,
@@ -248,7 +259,7 @@ class TestDiscourseBackend(unittest.TestCase):
         # On this tests only one topic will be retrieved
         from_date = datetime.datetime(2016, 5, 25, 2, 0, 0)
 
-        discourse = Discourse(DISCOURSE_SERVER_URL)
+        discourse = Discourse(DISCOURSE_SERVER_URL, sleep_time=0)
         topics = [topic for topic in discourse.fetch(from_date=from_date)]
 
         self.assertEqual(len(topics), 1)
@@ -283,7 +294,7 @@ class TestDiscourseBackend(unittest.TestCase):
                                DISCOURSE_TOPICS_URL,
                                body=body, status=200)
 
-        discourse = Discourse(DISCOURSE_SERVER_URL)
+        discourse = Discourse(DISCOURSE_SERVER_URL, sleep_time=0)
         topics = [topic for topic in discourse.fetch()]
 
         self.assertEqual(len(topics), 0)
@@ -312,8 +323,8 @@ class TestDiscourseBackend(unittest.TestCase):
                     uri.startswith(DISCOURSE_POST_URL_2):
                 body = body_post
             else:
-                raise
-            return (200, headers, body)
+                raise Exception
+            return 200, headers, body
 
         httpretty.register_uri(httpretty.GET,
                                DISCOURSE_TOPICS_URL,
@@ -351,7 +362,7 @@ class TestDiscourseBackend(unittest.TestCase):
         # One of them was pinned but the date is in range.
         from_date = datetime.datetime(2016, 5, 25, 2, 0, 0)
 
-        discourse = Discourse(DISCOURSE_SERVER_URL)
+        discourse = Discourse(DISCOURSE_SERVER_URL, sleep_time=0)
         topics = [topic for topic in discourse.fetch(from_date=from_date)]
 
         self.assertEqual(len(topics), 2)
@@ -386,8 +397,8 @@ class TestDiscourseBackend(unittest.TestCase):
             elif uri.startswith(DISCOURSE_TOPIC_URL_1149):
                 body = body_topic_1149
             else:
-                raise
-            return (200, headers, body)
+                raise Exception
+            return 200, headers, body
 
         httpretty.register_uri(httpretty.GET,
                                DISCOURSE_TOPICS_URL,
@@ -403,7 +414,7 @@ class TestDiscourseBackend(unittest.TestCase):
 
         # On this tests two topics will be retrieved.
         # One of them has last_posted_at with null
-        discourse = Discourse(DISCOURSE_SERVER_URL)
+        discourse = Discourse(DISCOURSE_SERVER_URL, sleep_time=0)
         topics = [topic for topic in discourse.fetch(from_date=None)]
 
         self.assertEqual(len(topics), 1)
@@ -422,8 +433,10 @@ class TestDiscourseBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend_write_archive = Discourse(DISCOURSE_SERVER_URL, api_token="aaaaa", archive=self.archive)
-        self.backend_read_archive = Discourse(DISCOURSE_SERVER_URL, archive=self.archive)
+        self.backend_write_archive = Discourse(DISCOURSE_SERVER_URL,
+                                               sleep_time=0, api_token="aaaaa", archive=self.archive)
+        self.backend_read_archive = Discourse(DISCOURSE_SERVER_URL,
+                                              sleep_time=0, archive=self.archive)
 
     def tearDown(self):
         shutil.rmtree(self.test_path)
@@ -450,11 +463,11 @@ class TestDiscourseBackendArchive(TestCaseBackendArchive):
             elif uri.startswith(DISCOURSE_POST_URL_1) or uri.startswith(DISCOURSE_POST_URL_2):
                 body = body_post
             else:
-                raise
+                raise Exception
 
             requests_http.append(httpretty.last_request())
 
-            return (200, headers, body)
+            return 200, headers, body
 
         httpretty.register_uri(httpretty.GET,
                                DISCOURSE_TOPICS_URL,
@@ -508,11 +521,11 @@ class TestDiscourseBackendArchive(TestCaseBackendArchive):
                     uri.startswith(DISCOURSE_POST_URL_2):
                 body = body_post
             else:
-                raise
+                raise Exception
 
             requests_http.append(httpretty.last_request())
 
-            return (200, headers, body)
+            return 200, headers, body
 
         httpretty.register_uri(httpretty.GET,
                                DISCOURSE_TOPICS_URL,
@@ -580,8 +593,8 @@ class TestDiscourseBackendArchive(TestCaseBackendArchive):
                     uri.startswith(DISCOURSE_POST_URL_2):
                 body = body_post
             else:
-                raise
-            return (200, headers, body)
+                raise Exception
+            return 200, headers, body
 
         httpretty.register_uri(httpretty.GET,
                                DISCOURSE_TOPICS_URL,
@@ -634,8 +647,8 @@ class TestDiscourseBackendArchive(TestCaseBackendArchive):
             elif uri.startswith(DISCOURSE_TOPIC_URL_1149):
                 body = body_topic_1149
             else:
-                raise
-            return (200, headers, body)
+                raise Exception
+            return 200, headers, body
 
         httpretty.register_uri(httpretty.GET,
                                DISCOURSE_TOPICS_URL,
@@ -671,6 +684,15 @@ class TestDiscourseClient(unittest.TestCase):
 
         self.assertEqual(client.base_url, DISCOURSE_SERVER_URL)
         self.assertEqual(client.api_key, 'aaaa')
+        self.assertEqual(client.sleep_time, DEFAULT_SLEEP_TIME)
+        self.assertEqual(client.max_retries, MAX_RETRIES)
+
+        client = DiscourseClient(DISCOURSE_SERVER_URL,
+                                 api_key='aaaa', sleep_time=60, max_retries=30)
+        self.assertEqual(client.base_url, DISCOURSE_SERVER_URL)
+        self.assertEqual(client.api_key, 'aaaa')
+        self.assertEqual(client.sleep_time, 60)
+        self.assertEqual(client.max_retries, 30)
 
     @httpretty.activate
     def test_topics_page(self):
@@ -683,7 +705,7 @@ class TestDiscourseClient(unittest.TestCase):
                                body=body, status=200)
 
         # Call API without args
-        client = DiscourseClient(DISCOURSE_SERVER_URL, api_key='aaaa')
+        client = DiscourseClient(DISCOURSE_SERVER_URL, api_key='aaaa', sleep_time=0)
         response = client.topics_page()
 
         self.assertEqual(response, body)
@@ -725,7 +747,7 @@ class TestDiscourseClient(unittest.TestCase):
                                body=body, status=200)
 
         # Call API
-        client = DiscourseClient(DISCOURSE_SERVER_URL, api_key='aaaa')
+        client = DiscourseClient(DISCOURSE_SERVER_URL, api_key='aaaa', sleep_time=0)
         response = client.topic(1148)
 
         self.assertEqual(response, body)
@@ -752,7 +774,7 @@ class TestDiscourseClient(unittest.TestCase):
                                body=body, status=200)
 
         # Call API
-        client = DiscourseClient(DISCOURSE_SERVER_URL, api_key='aaaa')
+        client = DiscourseClient(DISCOURSE_SERVER_URL, api_key='aaaa', sleep_time=0)
         response = client.post(21)
 
         self.assertEqual(response, body)
@@ -816,6 +838,22 @@ class TestDiscourseCommand(unittest.TestCase):
         self.assertEqual(parsed_args.tag, 'test')
         self.assertEqual(parsed_args.no_archive, True)
         self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
+        self.assertEqual(parsed_args.sleep_time, DEFAULT_SLEEP_TIME)
+        self.assertEqual(parsed_args.max_retries, MAX_RETRIES)
+
+        args = ['--tag', 'test', '--no-archive',
+                '--from-date', '1970-01-01',
+                '--max-retries', '60',
+                '--sleep-time', '30',
+                DISCOURSE_SERVER_URL]
+
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.url, DISCOURSE_SERVER_URL)
+        self.assertEqual(parsed_args.tag, 'test')
+        self.assertEqual(parsed_args.no_archive, True)
+        self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
+        self.assertEqual(parsed_args.sleep_time, 30)
+        self.assertEqual(parsed_args.max_retries, 60)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This code updates the description of the `sleep_time` param for the client and the following backends:
- gitlab
- googlehits
- jenkins
- launchpad
- mattermost
- meetup
- phabricator
- twitter