### PR TITLE
[confluence] Skip contents if 'when' attribute is missing

### DIFF
--- a/perceval/backends/core/confluence.py
+++ b/perceval/backends/core/confluence.py
@@ -53,7 +53,7 @@ class Confluence(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.10.0'
+    version = '0.10.1'
 
     CATEGORIES = [CATEGORY_HISTORICAL_CONTENT]
 
@@ -255,9 +255,17 @@ class Confluence(Backend):
 
             hc = self.parse_historical_content(raw_hc)
 
+            # if 'when' attribute is not present, the historical content is skipped
+            if 'when' not in hc['version']:
+                logger.debug("Content %s v%s skipped due to missing 'when' attribute",
+                             hc['id'], str(hc['version']['number']))
+
+                fetching = not hc['history']['latest']
+                version += 1
+                continue
+
             # Return those versions that were created after 'from_date'
             when = str_to_datetime(hc['version']['when'])
-
             if when >= from_date:
                 yield hc
             else:

--- a/perceval/backends/core/confluence.py
+++ b/perceval/backends/core/confluence.py
@@ -244,7 +244,7 @@ class Confluence(Backend):
             except requests.exceptions.HTTPError as e:
                 code = e.response.status_code
 
-                # Common problems found: removed and privated contents
+                # Common problems found: removed and private contents
                 if code not in (404, 500):
                     raise e
 

--- a/tests/data/confluence/confluence_content_1_v2.json
+++ b/tests/data/confluence/confluence_content_1_v2.json
@@ -57,7 +57,7 @@
             "username": "jdoe"
         },
         "createdDate": "2016-06-10T20:05:21.000Z",
-        "latest": true
+        "latest": false
     },
     "id": "1",
     "status": "current",

--- a/tests/data/confluence/confluence_content_1_v3.json
+++ b/tests/data/confluence/confluence_content_1_v3.json
@@ -8,14 +8,6 @@
         "operations": "",
         "space": "/rest/api/space/DEV"
     },
-    "_links": {
-        "base": "http://example.com",
-        "collection": "/rest/api/content",
-        "context": "",
-        "self": "http://example.com/rest/api/content/1",
-        "tinyui": "/x/zB5o",
-        "webui": "/display/DEV/Steady+State+Project+-+2016-06-17+Goals"
-    },
     "body": {
         "_expandable": {
             "anonymous_export_view": "",

--- a/tests/data/confluence/confluence_content_1_v3.json
+++ b/tests/data/confluence/confluence_content_1_v3.json
@@ -1,0 +1,83 @@
+{
+    "_expandable": {
+        "ancestors": "",
+        "children": "/rest/api/content/1/child",
+        "container": "/rest/api/space/DEV",
+        "descendants": "/rest/api/content/1/descendant",
+        "metadata": "",
+        "operations": "",
+        "space": "/rest/api/space/DEV"
+    },
+    "_links": {
+        "base": "http://example.com",
+        "collection": "/rest/api/content",
+        "context": "",
+        "self": "http://example.com/rest/api/content/1",
+        "tinyui": "/x/zB5o",
+        "webui": "/display/DEV/Steady+State+Project+-+2016-06-17+Goals"
+    },
+    "body": {
+        "_expandable": {
+            "anonymous_export_view": "",
+            "editor": "",
+            "export_view": "",
+            "styled_view": "",
+            "view": ""
+        },
+        "storage": {
+            "_expandable": {
+                "content": "/rest/api/content/1"
+            },
+            "representation": "storage",
+            "value": "<p>CENGN currently follows a 3 week iteration cycle ..."
+        }
+    },
+    "extensions": {
+        "position": "none"
+    },
+    "history": {
+        "_expandable": {
+            "lastUpdated": "",
+            "nextVersion": "",
+            "previousVersion": ""
+        },
+        "_links": {
+            "self": "http://example.com/rest/api/content/6823628/history"
+        },
+        "createdBy": {
+            "displayName": "John Doe",
+            "profilePicture": {
+                "height": 48,
+                "isDefault": false,
+                "path": "/s/en_GB/6210/1/_/download/attachments/1/user-avatar?version=1&modificationDate=1452188900000&api=v2",
+                "width": 48
+            },
+            "type": "known",
+            "userKey": "2c9e48d5521d22bb01521d2fd9110002",
+            "username": "jdoe"
+        },
+        "createdDate": "2016-06-10T20:05:21.000Z",
+        "latest": true
+    },
+    "id": "1",
+    "status": "current",
+    "title": "Steady State Project - 2016-06-17 Goals",
+    "type": "page",
+    "version": {
+        "by": {
+            "displayName": "John Smith",
+            "profilePicture": {
+                "height": 48,
+                "isDefault": false,
+                "path": "/s/en_GB/6210/1/_/download/attachments/1/user-avatar?version=1&modificationDate=1464975020000&api=v2",
+                "width": 48
+            },
+            "type": "known",
+            "userKey": "2c9e48d553c3b7db015516fa640b00bd",
+            "username": "jsmith"
+        },
+        "message": "Task marked complete",
+        "minorEdit": false,
+        "number": 3
+    }
+}

--- a/tests/test_confluence.py
+++ b/tests/test_confluence.py
@@ -63,6 +63,7 @@ def setup_http_server():
     body_contents_empty = read_file('data/confluence/confluence_contents_empty.json', 'rb')
     body_content_1_v1 = read_file('data/confluence/confluence_content_1_v1.json', 'rb')
     body_content_1_v2 = read_file('data/confluence/confluence_content_1_v2.json', 'rb')
+    body_content_1_v3 = read_file('data/confluence/confluence_content_1_v3.json', 'rb')
     body_content_2 = read_file('data/confluence/confluence_content_2_v1.json', 'rb')
     body_content_att = read_file('data/confluence/confluence_content_att_v1.json', 'rb')
 
@@ -72,6 +73,8 @@ def setup_http_server():
 
             if 'start' in params and params['start'] == ['2']:
                 body = body_contents_next
+            elif 'start' in params and params['start'] == ['3']:
+                body = body_contents_empty
             elif params['cql'][0].startswith("lastModified>='2016-07-08 00:00'"):
                 body = body_contents_empty
             else:
@@ -81,8 +84,10 @@ def setup_http_server():
 
             if params['version'] == ['1']:
                 body = body_content_1_v1
-            else:
+            elif params['version'] == ['2']:
                 body = body_content_1_v2
+            else:
+                body = body_content_1_v3
         elif uri.startswith(CONFLUENCE_HISTORICAL_CONTENT_2):
             body = body_content_2
         elif uri.startswith(CONFLUENCE_HISTORICAL_CONTENT_ATT):
@@ -92,7 +97,7 @@ def setup_http_server():
 
         http_requests.append(httpretty.last_request())
 
-        return (200, headers, body)
+        return 200, headers, body
 
     httpretty.register_uri(httpretty.GET,
                            CONFLUENCE_CONTENTS_URL,
@@ -160,6 +165,7 @@ class TestConfluenceBackend(unittest.TestCase):
         http_requests = setup_http_server()
 
         confluence = Confluence(CONFLUENCE_URL)
+
         hcs = [hc for hc in confluence.fetch()]
 
         expected = [
@@ -207,6 +213,11 @@ class TestConfluenceBackend(unittest.TestCase):
                 'expand': ['body.storage,history,version'],
                 'status': ['historical'],
                 'version': ['2']
+            },
+            {
+                'expand': ['body.storage,history,version'],
+                'status': ['historical'],
+                'version': ['3']
             },
             {
                 'expand': ['body.storage,history,version'],
@@ -283,6 +294,11 @@ class TestConfluenceBackend(unittest.TestCase):
                 'expand': ['body.storage,history,version'],
                 'status': ['historical'],
                 'version': ['2']
+            },
+            {
+                'expand': ['body.storage,history,version'],
+                'status': ['historical'],
+                'version': ['3']
             },
             {
                 'expand': ['body.storage,history,version'],


### PR DESCRIPTION
This PR allows to skip the historical contents not having the 'when' attribute, which is used to calculated the `updated_on` value of the JSON output produced by Perceval.