### PR TITLE
Option to filter classified data

### DIFF
--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -450,16 +450,17 @@ class BackendCommand:
         """
         backend_args = vars(self.parsed_args)
         category = backend_args.pop('category', None)
+        filter_classified = backend_args.pop('filter_classified', False)
         archived_since = backend_args.pop('archived_since', None)
 
         if self.archive_manager and self.parsed_args.fetch_archive:
-
             items = fetch_from_archive(self.BACKEND, backend_args,
                                        self.archive_manager,
                                        category,
                                        archived_since)
         else:
             items = fetch(self.BACKEND, backend_args, category,
+                          filter_classified=filter_classified,
                           manager=self.archive_manager)
 
         try:

--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -533,7 +533,8 @@ def uuid(*args):
     return uuid_sha1
 
 
-def fetch(backend_class, backend_args, category, manager=None):
+def fetch(backend_class, backend_args, category, filter_classified=False,
+          manager=None):
     """Fetch items using the given backend.
 
     Generator to get items using the given backend class. When
@@ -548,6 +549,7 @@ def fetch(backend_class, backend_args, category, manager=None):
     :param backend_args: dict of arguments needed to fetch the items
     :param category: category of the items to retrieve.
        If None, it will use the default backend category
+    :param filter_classified: remove classified fields from the resulting items
     :param manager: archive manager needed to store the items
 
     :returns: a generator of items
@@ -561,6 +563,8 @@ def fetch(backend_class, backend_args, category, manager=None):
 
     if category:
         backend_args['category'] = category
+    if filter_classified:
+        backend_args['filter_classified'] = filter_classified
 
     fetch_args = find_signature_parameters(backend.fetch,
                                            backend_args)

--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -39,6 +39,7 @@ from ._version import __version__
 
 logger = logging.getLogger(__name__)
 
+
 ARCHIVES_DEFAULT_PATH = '~/.perceval/archives/'
 
 
@@ -63,6 +64,17 @@ class Backend:
     process, this class provides a `version` attribute that each backend
     may override.
 
+    Each backend should implement a class attribute named `CLASSIFIED_FIELDS`.
+    It will allow to filter from items those fields that may be considered
+    sensible or confidential. This attribute is a list of lists.
+    As items returned are dicts that may contain nested dicts, each entry
+    is a list which stores the "path" or nested dicts keys to the field to
+    remove. For example, `['my', 'classified', 'field']` will remove `field`
+    from `item['data']['my']['classified']` dict.
+
+    Classified data filtering and archiving are not compatible to prevent
+    data leaks or security issues.
+
     :param origin: identifier of the repository
     :param tag: tag items using this label
     :param archive: archive to store/retrieve data
@@ -70,9 +82,10 @@ class Backend:
     :raises ValueError: raised when `archive` is not an instance of
         `Archive` class
     """
-    version = '0.7.0'
+    version = '0.8.0'
 
     CATEGORIES = []
+    CLASSIFIED_FIELDS = []
 
     def __init__(self, origin, tag=None, archive=None):
         self._origin = origin
@@ -100,22 +113,44 @@ class Backend:
     def categories(self):
         return self.CATEGORIES
 
+    @property
+    def classified_fields(self):
+        cfs = ['.'.join(cf) for cf in self.CLASSIFIED_FIELDS]
+        return cfs
+
     def fetch_items(self, category, **kwargs):
         raise NotImplementedError
 
-    def fetch(self, category, **kwargs):
+    def fetch(self, category, filter_classified=False, **kwargs):
         """Fetch items from the repository.
 
         The method retrieves items from a repository.
 
+        To removed classified fields from the resulting items, set
+        the parameter `filter_classified`. Take into account this
+        parameter is incompatible with archiving items. Raw client
+        data are archived before any other process. Therefore,
+        classified data  are stored within the archive. To prevent
+        from possible data leaks or security issues when users do
+        not need these fields, archiving and filtering are not
+        compatible.
+
         :param category: the category of the items fetched
+        :param filter_classified: remove classified fields from the resulting items
         :param kwargs: a list of other parameters (e.g., from_date, offset, etc.
         specific for each backend)
 
         :returns: a generator of items
+
+        :raises BackendError: either when the category is not valid or
+            'filter_classified' and 'archive' are active at the same time.
         """
         if category not in self.categories:
             cause = "%s category not valid for %s" % (category, self.__class__.__name__)
+            raise BackendError(cause=cause)
+
+        if filter_classified and self.archive:
+            cause = "classified fields filtering is not compatible with archiving items"
             raise BackendError(cause=cause)
 
         if self.archive:
@@ -125,7 +160,10 @@ class Backend:
         self.client = self._init_client()
 
         for item in self.fetch_items(category, **kwargs):
-            yield self.metadata(item)
+            if filter_classified:
+                item = self.filter_classified_data(item)
+
+            yield self.metadata(item, filter_classified=filter_classified)
 
     def fetch_from_archive(self):
         """Fetch the questions from an archive.
@@ -134,6 +172,7 @@ class Backend:
         no archive was provided, the method will raise a `ArchiveError` exception.
 
         :returns: a generator of items
+
         :raises ArchiveError: raised when an error occurs accessing an archive
         """
         if not self.archive:
@@ -144,7 +183,32 @@ class Backend:
         for item in self.fetch_items(self.archive.category, **self.archive.backend_params):
             yield self.metadata(item)
 
-    def metadata(self, item):
+    def filter_classified_data(self, item):
+        """Remove classified or confidential data from an item.
+
+        It removes those fields that contain data considered as classified.
+        Classified fields are defined in `CLASSIFIED_FIELDS` class attribute.
+
+        :param item: fields will be removed from this item
+
+        :returns: the same item but with confidential data filtered
+        """
+        item_uuid = uuid(self.origin, self.metadata_id(item))
+
+        logger.debug("Filtering classified data for item %s", item_uuid)
+
+        for cf in self.CLASSIFIED_FIELDS:
+            try:
+                _remove_key_from_nested_dict(item, cf)
+            except KeyError:
+                logger.debug("Classified field '%s' not found for item %s; field ignored",
+                             '.'.join(cf), item_uuid)
+
+        logger.debug("Classified data filtered for item %s", item_uuid)
+
+        return item
+
+    def metadata(self, item, filter_classified=False):
         """Add metadata to an item.
 
         It adds metadata to a given item such as how and
@@ -152,6 +216,7 @@ class Backend:
         be stored under the 'data' keyword.
 
         :param item: an item fetched by a backend
+        :param filter_classified: sets if classified fields were filtered
         """
         item = {
             'backend_name': self.__class__.__name__,
@@ -161,6 +226,7 @@ class Backend:
             'origin': self.origin,
             'uuid': uuid(self.origin, self.metadata_id(item)),
             'updated_on': self.metadata_updated_on(item),
+            'classified_fields_filtered': self.classified_fields if filter_classified else None,
             'category': self.metadata_category(item),
             'tag': self.tag,
             'data': item,
@@ -190,6 +256,18 @@ class Backend:
 
     def _init_client(self, from_archive=False):
         raise NotImplementedError
+
+
+def _remove_key_from_nested_dict(nested_dict, path_to_field):
+    if len(path_to_field) == 0:
+        return
+
+    key = path_to_field[0]
+
+    if len(path_to_field) == 1:
+        nested_dict.pop(key)
+    else:
+        _remove_key_from_nested_dict(nested_dict[key], path_to_field[1:])
 
 
 class BackendCommandArgumentParser:

--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -304,6 +304,9 @@ class BackendCommandArgumentParser:
                            help="type of the items to fetch")
         group.add_argument('--tag', dest='tag',
                            help="tag the items generated during the fetching process")
+        group.add_argument('--filter-classified', dest='filter_classified',
+                           action='store_true',
+                           help="filter classified fields, if any, from fetched items")
 
         if (from_date or to_date) and offset:
             raise AttributeError("date and offset parameters are incompatible")

--- a/perceval/backends/core/meetup.py
+++ b/perceval/backends/core/meetup.py
@@ -68,9 +68,10 @@ class Meetup(Backend):
     :param sleep_time: time (in seconds) to sleep in case
         of connection problems
     """
-    version = '0.11.6'
+    version = '0.12.0'
 
     CATEGORIES = [CATEGORY_EVENT]
+    CLASSIFIED_FIELDS = [['group', 'topics']]
 
     def __init__(self, group, api_token, max_items=MAX_ITEMS,
                  tag=None, archive=None,
@@ -88,7 +89,8 @@ class Meetup(Backend):
 
         self.client = None
 
-    def fetch(self, category=CATEGORY_EVENT, from_date=DEFAULT_DATETIME, to_date=None):
+    def fetch(self, category=CATEGORY_EVENT, from_date=DEFAULT_DATETIME, to_date=None,
+              filter_classified=False):
         """Fetch the events from the server.
 
         This method fetches those events of a group stored on the server
@@ -98,6 +100,7 @@ class Meetup(Backend):
         :param category: the category of items to fetch
         :param from_date: obtain events updated since this date
         :param to_date: obtain events updated before this date
+        :param filter_classified: remove classified fields from the resulting items
 
         :returns: a generator of events
         """
@@ -107,7 +110,9 @@ class Meetup(Backend):
         from_date = datetime_to_utc(from_date)
 
         kwargs = {"from_date": from_date, "to_date": to_date}
-        items = super().fetch(category, **kwargs)
+        items = super().fetch(category,
+                              filter_classified=filter_classified,
+                              **kwargs)
 
         return items
 

--- a/perceval/backends/core/nntp.py
+++ b/perceval/backends/core/nntp.py
@@ -131,15 +131,16 @@ class NNTP(Backend):
             yield article
             narts += 1
 
-    def metadata(self, item):
+    def metadata(self, item, filter_classified=False):
         """NNTP metadata.
 
         This method takes items, overriding `metadata` decorator,
         to add extra information related to NNTP.
 
         :param item: an item fetched by a backend
+        :param filter_classified: sets if classified fields were filtered
         """
-        item = super().metadata(item)
+        item = super().metadata(item, filter_classified=filter_classified)
         item['offset'] = item['data']['offset']
 
         return item

--- a/perceval/backends/core/telegram.py
+++ b/perceval/backends/core/telegram.py
@@ -148,18 +148,18 @@ class Telegram(Backend):
         logger.info("Fetch process completed: %s messages fetched",
                     nmsgs)
 
-    def metadata(self, item):
+    def metadata(self, item, filter_classified=False):
         """Telegram metadata.
 
-        The metod takes an item and overrides the `metadata` information
+        The method takes an item and overrides the `metadata` information
         to add extra information related to Telegram.
 
         Currently, it adds the 'offset' keyword.
 
         :param item: an item fetched by a backend
+        :param filter_classified: sets if classified fields were filtered
         """
-
-        item = super().metadata(item)
+        item = super().metadata(item, filter_classified=filter_classified)
         item['offset'] = item['data']['update_id']
 
         return item

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -45,7 +45,8 @@ from perceval.backend import (Backend,
                               BackendCommand,
                               uuid,
                               fetch,
-                              fetch_from_archive)
+                              fetch_from_archive,
+                              logger as backend_logger)
 from perceval.errors import ArchiveError, BackendError
 from perceval.utils import DEFAULT_DATETIME
 from base import TestCaseBackendArchive
@@ -64,6 +65,9 @@ class MockedBackend(Backend):
         super().__init__(origin, tag=tag, archive=archive)
         self._fetch_from_archive = False
 
+    def fetch(self, category=DEFAULT_CATEGORY, filter_classified=False):
+        return super().fetch(category, filter_classified=filter_classified)
+
     def fetch_items(self, category, **kwargs):
         for x in range(MockedBackend.ITEMS):
             if self._fetch_from_archive:
@@ -74,9 +78,6 @@ class MockedBackend(Backend):
                 if self.archive:
                     self.archive.store(str(x), None, None, item)
                 yield item
-
-    def fetch(self, category=DEFAULT_CATEGORY):
-        return super().fetch(category)
 
     def _init_client(self, from_archive=False):
         self._fetch_from_archive = from_archive
@@ -93,6 +94,40 @@ class MockedBackend(Backend):
     @staticmethod
     def metadata_category(item):
         return item['category']
+
+
+class ClassifiedFieldsBackend(MockedBackend):
+    """Mocked backend for testing classified fields filtering"""
+
+    CLASSIFIED_FIELDS = [
+        ['my', 'classified', 'field'],
+        ['classified']
+    ]
+
+    def fetch(self, category, filter_classified=False):
+        return super().fetch(category, filter_classified=filter_classified)
+
+    def fetch_items(self, category, **kwargs):
+        i = 0
+        for item in super().fetch_items(category, **kwargs):
+            item['my'] = {
+                'classified': {'field': i},
+                'field': i
+            }
+            item['classified'] = i
+            i += 1
+            yield item
+
+
+class NotFoundClassifiedFieldBackend(MockedBackend):
+    """Mocked backend for testing classified fields not found while filtering"""
+
+    CLASSIFIED_FIELDS = [
+        ['classified_field']
+    ]
+
+    def fetch(self, category, filter_classified=False):
+        return super().fetch(category, filter_classified=filter_classified)
 
 
 class CommandBackend(MockedBackend):
@@ -184,6 +219,15 @@ class TestBackend(unittest.TestCase):
 
         b = Backend('test')
         self.assertEqual(b.origin, 'test')
+
+    def test_classified_fields(self):
+        """Test whether classified fields property returns a list with fields"""
+
+        b = Backend('test')
+        self.assertListEqual(b.classified_fields, [])
+
+        b = ClassifiedFieldsBackend('test')
+        self.assertListEqual(b.classified_fields, ['my.classified.field', 'classified'])
 
     def test_has_archiving(self):
         """Test whether an NotImplementedError exception is thrown"""
@@ -308,6 +352,146 @@ class TestBackend(unittest.TestCase):
 
         with self.assertRaises(NotImplementedError):
             b.fetch_items(MockedBackend.DEFAULT_CATEGORY)
+
+
+class TestClassifiedFieldsFiltering(unittest.TestCase):
+    """Unit tests for Backend filtering classified fields"""
+
+    def setUp(self):
+        self.test_path = tempfile.mkdtemp(prefix='perceval_')
+
+    def tearDown(self):
+        shutil.rmtree(self.test_path)
+
+    def test_fetch_filtering_classified_fields(self):
+        """Test whether classified fields are removed from the items"""
+
+        backend = ClassifiedFieldsBackend('http://example.com/', tag='test')
+
+        items = [item for item in backend.fetch(category=ClassifiedFieldsBackend.DEFAULT_CATEGORY,
+                                                filter_classified=True)]
+
+        for x in range(5):
+            item = items[x]
+
+            expected_uuid = uuid('http://example.com/', str(x))
+            self.assertEqual(item['origin'], 'http://example.com/')
+            self.assertEqual(item['uuid'], expected_uuid)
+            self.assertEqual(item['tag'], 'test')
+            self.assertEqual(item['category'], ClassifiedFieldsBackend.DEFAULT_CATEGORY)
+            self.assertEqual(item['classified_fields_filtered'],
+                             ['my.classified.field', 'classified'])
+
+            # Fields in CLASSIFIED_FIELDS are deleted
+            expected = {
+                'category': 'mock_item',
+                'item': x,
+                'my': {
+                    'classified': {},
+                    'field': x,
+                }
+            }
+            self.assertDictEqual(item['data'], expected)
+
+    def test_fetch_filtering_not_active(self):
+        """Test whether classified fields are not removed from the items"""
+
+        backend = ClassifiedFieldsBackend('http://example.com/', tag='test')
+
+        items = [item for item in backend.fetch(category=ClassifiedFieldsBackend.DEFAULT_CATEGORY,
+                                                filter_classified=False)]
+
+        for x in range(5):
+            item = items[x]
+
+            expected_uuid = uuid('http://example.com/', str(x))
+            self.assertEqual(item['origin'], 'http://example.com/')
+            self.assertEqual(item['uuid'], expected_uuid)
+            self.assertEqual(item['tag'], 'test')
+            self.assertEqual(item['category'], ClassifiedFieldsBackend.DEFAULT_CATEGORY)
+            self.assertEqual(item['classified_fields_filtered'], None)
+
+            # Fields in CLASSIFIED_FIELDS are not deleted
+            expected = {
+                'category': 'mock_item',
+                'classified': x,
+                'item': x,
+                'my': {
+                    'classified': {'field': x},
+                    'field': x,
+                },
+            }
+            self.assertDictEqual(item['data'], expected)
+
+    def test_fetch_filtering_empty_list(self):
+        """Test whether no data is removed when classified fields list is empty"""
+
+        backend = ClassifiedFieldsBackend('http://example.com/', tag='test')
+        backend.CLASSIFIED_FIELDS = []
+
+        items = [item for item in backend.fetch(category=ClassifiedFieldsBackend.DEFAULT_CATEGORY,
+                                                filter_classified=True)]
+
+        for x in range(5):
+            item = items[x]
+
+            expected_uuid = uuid('http://example.com/', str(x))
+            self.assertEqual(item['origin'], 'http://example.com/')
+            self.assertEqual(item['uuid'], expected_uuid)
+            self.assertEqual(item['tag'], 'test')
+            self.assertEqual(item['category'], ClassifiedFieldsBackend.DEFAULT_CATEGORY)
+            self.assertEqual(item['classified_fields_filtered'], [])
+
+            expected = {
+                'category': 'mock_item',
+                'classified': x,
+                'item': x,
+                'my': {
+                    'classified': {'field': x},
+                    'field': x,
+                },
+            }
+            self.assertDictEqual(item['data'], expected)
+
+    def test_error_archive_and_filter_classified(self):
+        """Check if an error is raised when archive and classified fields filtering are both active"""
+
+        archive_path = os.path.join(self.test_path, 'myarchive')
+        archive = Archive.create(archive_path)
+
+        backend = ClassifiedFieldsBackend('http://example.com/', archive=archive)
+
+        msg_error = "classified fields filtering is not compatible with archiving items"
+
+        with self.assertRaisesRegex(BackendError, msg_error):
+            _ = [item for item in backend.fetch(category=ClassifiedFieldsBackend.DEFAULT_CATEGORY,
+                                                filter_classified=True)]
+
+    def test_not_found_field(self):
+        """Check if items are fetched when a classified field does not exist"""
+
+        backend = NotFoundClassifiedFieldBackend('http://example.com/', tag='test')
+
+        with self.assertLogs(backend_logger, level='DEBUG') as cm:
+            items = [item for item in backend.fetch(category=ClassifiedFieldsBackend.DEFAULT_CATEGORY,
+                                                    filter_classified=True)]
+
+            for x in range(5):
+                item = items[x]
+
+                # Classified fields are deleted; those not found are ignored
+                expected = {
+                    'category': 'mock_item',
+                    'item': x
+                }
+                self.assertDictEqual(item['data'], expected)
+
+                # Check logger output
+                # Each filter message appears after 3 debug messages
+                # because there are other debug messages
+                expected_uuid = uuid('http://example.com/', str(x))
+                exp = "Classified field 'classified_field' not found for item " + expected_uuid
+                self.assertRegex(cm.output[x * 3 + 1], exp)
 
 
 class TestBackendArchive(TestCaseBackendArchive):
@@ -854,9 +1038,9 @@ class TestBackendCommand(unittest.TestCase):
 
 
 class TestMetadata(unittest.TestCase):
-    """Test metadata decorator"""
+    """Test metadata method"""
 
-    def test_decorator(self):
+    def test_metadata(self):
         backend = MockedBackend('test', 'mytag')
         before = datetime_utcnow().timestamp()
         items = [item for item in backend.fetch()]
@@ -875,6 +1059,33 @@ class TestMetadata(unittest.TestCase):
             self.assertEqual(item['uuid'], expected_uuid)
             self.assertEqual(item['updated_on'], '2016-01-01')
             self.assertEqual(item['category'], 'mock_item')
+            self.assertEqual(item['classified_fields_filtered'], None)
+            self.assertEqual(item['tag'], 'mytag')
+            self.assertGreater(item['timestamp'], before)
+            self.assertLess(item['timestamp'], after)
+
+            before = item['timestamp']
+
+    def test_metadata_classified_fields(self):
+        backend = MockedBackend('test', 'mytag')
+        before = datetime_utcnow().timestamp()
+        items = [item for item in backend.fetch(filter_classified=True)]
+        after = datetime_utcnow().timestamp()
+
+        for x in range(5):
+            item = items[x]
+
+            expected_uuid = uuid('test', str(x))
+
+            self.assertEqual(item['data']['item'], x)
+            self.assertEqual(item['backend_name'], 'MockedBackend')
+            self.assertEqual(item['backend_version'], '0.2.0')
+            self.assertEqual(item['perceval_version'], __version__)
+            self.assertEqual(item['origin'], 'test')
+            self.assertEqual(item['uuid'], expected_uuid)
+            self.assertEqual(item['updated_on'], '2016-01-01')
+            self.assertEqual(item['category'], 'mock_item')
+            self.assertEqual(item['classified_fields_filtered'], [])
             self.assertEqual(item['tag'], 'mytag')
             self.assertGreater(item['timestamp'], before)
             self.assertLess(item['timestamp'], after)
@@ -949,6 +1160,7 @@ class TestFetch(unittest.TestCase):
             self.assertEqual(item['origin'], 'http://example.com/')
             self.assertEqual(item['uuid'], expected_uuid)
             self.assertEqual(item['tag'], 'test')
+            self.assertEqual(item['classified_fields_filtered'], None)
 
     def test_items_storing_archive(self):
         """Test whether items are stored in an archive"""

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -539,13 +539,24 @@ class TestBackendCommandArgumentParser(unittest.TestCase):
     def test_parse_default_args(self):
         """Test if the default configured arguments are parsed"""
 
-        args = ['--tag', 'test']
+        args = ['--tag', 'test', '--filter-classified']
 
         parser = BackendCommandArgumentParser()
         parsed_args = parser.parse(*args)
 
         self.assertIsInstance(parsed_args, argparse.Namespace)
         self.assertEqual(parsed_args.tag, 'test')
+        self.assertEqual(parsed_args.filter_classified, True)
+
+    def test_parse_default_filter_classified(self):
+        """Test default value of filter-classified options"""
+
+        args = []
+
+        parser = BackendCommandArgumentParser()
+        parsed_args = parser.parse(*args)
+
+        self.assertEqual(parsed_args.filter_classified, False)
 
     def test_parse_with_aliases(self):
         """Test if a set of aliases is created after parsing"""


### PR DESCRIPTION
This PR addresses the requirements defined in #490.

Classified fields can be declared using `CLASSIFIED_FIELDS` class attribute. This attribute will contain a list of lists. Each list stores the "path" or nested dicts keys to the field to filter. For example:
`['my', 'classified', 'field']` will remove `field` from `item['data']['my']['classified']` dict.

To filter this fields from the resulting items, `fetch()` method adds a new parameter `filter_classified`.
Classified fields can also be removed from the command line with the option `filter-classified`.

To start with new feature, this PR adds the field `group.topics` to the list of classified fields in Meetup backend. This field is considered sensible for some related groups working with GrimoireLab.