### PR TITLE
Removes unused imports

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,6 @@
 
 import sys
 import os
-import shlex
 
 os.system("sphinx-apidoc -f -o . ../perceval")
 

--- a/perceval/backends/core/nntp.py
+++ b/perceval/backends/core/nntp.py
@@ -23,8 +23,7 @@
 import io
 import logging
 import nntplib
-
-import email.parser
+import email
 
 from grimoirelab_toolkit.datetime import str_to_datetime
 
@@ -55,7 +54,7 @@ class NNTP(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.5.2'
+    version = '0.5.3'
 
     CATEGORIES = [CATEGORY_ARTICLE]
 

--- a/perceval/utils.py
+++ b/perceval/utils.py
@@ -30,7 +30,6 @@ import sys
 
 import xml.etree.ElementTree
 
-import dateutil.parser
 import dateutil.rrule
 import dateutil.tz
 


### PR DESCRIPTION
This code removes unused imports from the files docs/conf.py and perceval/utils.py. Furthermore it changes the import `email.parser` (which was not needed) to `email` in the NNTP backend and it updates its version to 0.5.3.