### PR TITLE
[doc] Update documentation for github and gitlab backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ are:
     dockerhub        Fetch repository data from Docker Hub site
     gerrit           Fetch reviews from a Gerrit server
     git              Fetch commits from Git
-    github           Fetch issues from GitHub
-    gitlab           Fetch issues from GitLab
+    github           Fetch issues, pull requests and repository information from GitHub
+    gitlab           Fetch issues, merge requests from GitLab
     googlehits       Fetch hits from Google API
     groupsio         Fetch messages from Groups.io
     hyperkitty       Fetch messages from a HyperKitty archiver
@@ -214,6 +214,12 @@ $ perceval git '/tmp/gitlog.log'
 ### GitHub
 ```
 $ perceval github elastic logstash --from-date '2016-01-01'
+```
+
+The GitHub backend accepts the categories `issue`, `pull_request` and `repository` which allow to fetch the specific data.
+
+```
+$ perceval github --category issue elastic logstash
 ```
 
 ### GitLab

--- a/bin/perceval
+++ b/bin/perceval
@@ -47,8 +47,8 @@ are:
     dockerhub        Fetch repository data from Docker Hub site
     gerrit           Fetch reviews from a Gerrit server
     git              Fetch commits from Git
-    github           Fetch issues from GitHub
-    gitlab           Fetch issues from GitLab
+    github           Fetch issues, pull requests and repository information from GitHub
+    gitlab           Fetch issues, merge requests from GitLab
     googlehits       Fetch hits from Google API
     groupsio         Fetch messages from Groups.io
     hyperkitty       Fetch messages from a HyperKitty archiver

--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -569,8 +569,15 @@ class GitHubClient(HttpClient, RateLimitHandler):
         return self.fetch_items(path, payload)
 
     def issues(self, from_date=None):
-        """Get the issues from pagination. Note that issues contain also pull requests."""
+        """Fetch the issues from the repository.
 
+        The method retrieves, from a GitHub repository, the issues
+        updated since the given date.
+
+        :param from_date: obtain issues updated since this date
+
+        :returns: a generator of issues
+        """
         payload = {
             'state': 'all',
             'per_page': PER_PAGE,
@@ -584,8 +591,15 @@ class GitHubClient(HttpClient, RateLimitHandler):
         return self.fetch_items(path, payload)
 
     def pulls(self, from_date=None):
-        """Get the pull requests from pagination"""
+        """Fetch the pull requests from the repository.
 
+        The method retrieves, from a GitHub repository, the pull requests
+        updated since the given date.
+
+        :param from_date: obtain pull requests updated since this date
+
+        :returns: a generator of pull requests
+        """
         issues_groups = self.issues(from_date=from_date)
 
         for raw_issues in issues_groups:


### PR DESCRIPTION
This code updates the information about the categories of the github and gitlab backends in the README and bin/perceval. Furthermore, it improves the docstrings of the methods `pulls` and `issues` of the GitHubClient.

Please check and suggest me changes if you need any. I would be happy to make the changes in this same PR.
@jgbarah @valeriocos 

Sorry for the delay in PR as I was busy with some exams in the last week.
Solves #494 if this pr is merged.