### PR TITLE
[meetup] Add 'rsvp', 'venue', and 'event_hosts' as classified fields

### DIFF
--- a/perceval/backends/core/meetup.py
+++ b/perceval/backends/core/meetup.py
@@ -68,10 +68,15 @@ class Meetup(Backend):
     :param sleep_time: time (in seconds) to sleep in case
         of connection problems
     """
-    version = '0.12.0'
+    version = '0.13.0'
 
     CATEGORIES = [CATEGORY_EVENT]
-    CLASSIFIED_FIELDS = [['group', 'topics']]
+    CLASSIFIED_FIELDS = [
+        ['group', 'topics'],
+        ['event_hosts'],
+        ['rsvps'],
+        ['venue']
+    ]
 
     def __init__(self, group, api_token, max_items=MAX_ITEMS,
                  tag=None, archive=None,

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -517,10 +517,15 @@ class TestMeetupBackend(unittest.TestCase):
             self.assertEqual(event['updated_on'], expc[2])
             self.assertEqual(event['category'], 'event')
             self.assertEqual(event['tag'], 'https://meetup.com/')
-            self.assertEqual(event['classified_fields_filtered'], ['group.topics'])
-            self.assertNotIn('topics', event['data']['group'])
             self.assertEqual(len(event['data']['comments']), expc[3])
-            self.assertEqual(len(event['data']['rsvps']), expc[4])
+
+            # Check classified items filtering
+            self.assertEqual(event['classified_fields_filtered'],
+                             ['group.topics', 'event_hosts', 'rsvps', 'venue'])
+            self.assertNotIn('topics', event['data']['group'])
+            self.assertNotIn('event_hosts', event['data'])
+            self.assertNotIn('rsvps', event['data'])
+            self.assertNotIn('venue', event['data'])
 
         # Check requests
         expected = [


### PR DESCRIPTION
All of these fields contains data that might be considered private (street addresses, user profiles, etc) or that can lead to know people preferences.

This commit implements #504 request.