### PR TITLE
Fix error for ghost user data

### DIFF
--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -85,7 +85,7 @@ class GitHub(Backend):
     :param sleep_time: time to sleep in case
         of connection problems
     """
-    version = '0.20.0'
+    version = '0.20.1'
 
     CATEGORIES = [CATEGORY_ISSUE, CATEGORY_PULL_REQUEST, CATEGORY_REPO]
 
@@ -412,7 +412,14 @@ class GitHub(Backend):
 
             for comment in json.loads(raw_comments):
                 comment_id = comment.get('id')
-                comment['user_data'] = self.__get_user(comment['user']['login'])
+
+                user = comment.get('user', None)
+                if not user:
+                    logger.warning("Missing user info for %s", comment['url'])
+                    comment['user_data'] = None
+                else:
+                    comment['user_data'] = self.__get_user(user['login'])
+
                 comment['reactions_data'] = \
                     self.__get_pull_review_comment_reactions(comment_id, comment['reactions']['total_count'])
                 comments.append(comment)

--- a/tests/data/github/github_request_pull_request_2_comments
+++ b/tests/data/github/github_request_pull_request_2_comments
@@ -112,5 +112,82 @@
             "type": "User",
             "url": "https://api.github.com/users/zhquan_example"
         }
+    }, 
+    {
+        "_links": {
+            "html": {
+                "href": "https://github.com/zhquan_example/repo/pull/1#discussion_r46719268"
+            },
+            "pull_request": {
+                "href": "https://api.github.com/repos/zhquan_example/repo/pulls/2"
+            },
+            "self": {
+                "href": "https://api.github.com/repos/zhquan_example/repo/pulls/comments/2"
+            }
+        },
+        "author_association": "OWNER",
+        "body": "It shouldn't be there any spaces around keywords and assignments.\nFor instance : `url=None`. The same mistake can be found in other parts of this code.\n",
+        "commit_id": "cc134f32fa8c518abe5f0501836af69741b25a64",
+        "created_at": "2015-12-04T19:09:29Z",
+        "diff_hunk": "...",
+        "html_url": "https://github.com/zhquan_example/repo/pull/1#discussion_r46719268",
+        "id": 5,
+        "original_commit_id": "b030dbf53d3ecaae2f080018073c9bdafb6b4166",
+        "original_position": 46,
+        "path": "perceval/backends/gerrit.py",
+        "position": null,
+        "pull_request_review_id": null,
+        "pull_request_url": "https://api.github.com/repos/zhquan_example/repo/pulls/2",
+        "reactions": {
+            "+1": 0,
+            "-1": 0,
+            "confused": 0,
+            "heart": 0,
+            "hooray": 0,
+            "laugh": 0,
+            "total_count": 0,
+            "url": "https://api.github.com/repos/zhquan_example/repo/pulls/comments/2/reactions"
+        },
+        "updated_at": "2015-12-22T12:03:01Z",
+        "url": "https://api.github.com/repos/zhquan_example/repo/pulls/comments/2",
+        "user": {}
+    },
+    {
+        "_links": {
+            "html": {
+                "href": "https://github.com/zhquan_example/repo/pull/1#discussion_r46719268"
+            },
+            "pull_request": {
+                "href": "https://api.github.com/repos/zhquan_example/repo/pulls/2"
+            },
+            "self": {
+                "href": "https://api.github.com/repos/zhquan_example/repo/pulls/comments/2"
+            }
+        },
+        "author_association": "OWNER",
+        "body": "It shouldn't be there any spaces around keywords and assignments.\nFor instance : `url=None`. The same mistake can be found in other parts of this code.\n",
+        "commit_id": "cc134f32fa8c518abe5f0501836af69741b25a64",
+        "created_at": "2015-12-04T19:09:29Z",
+        "diff_hunk": "...",
+        "html_url": "https://github.com/zhquan_example/repo/pull/1#discussion_r46719268",
+        "id": 6,
+        "original_commit_id": "b030dbf53d3ecaae2f080018073c9bdafb6b4166",
+        "original_position": 46,
+        "path": "perceval/backends/gerrit.py",
+        "position": null,
+        "pull_request_review_id": null,
+        "pull_request_url": "https://api.github.com/repos/zhquan_example/repo/pulls/2",
+        "reactions": {
+            "+1": 0,
+            "-1": 0,
+            "confused": 0,
+            "heart": 0,
+            "hooray": 0,
+            "laugh": 0,
+            "total_count": 0,
+            "url": "https://api.github.com/repos/zhquan_example/repo/pulls/comments/2/reactions"
+        },
+        "updated_at": "2015-12-22T12:03:01Z",
+        "url": "https://api.github.com/repos/zhquan_example/repo/pulls/comments/2"
     }
 ]


### PR DESCRIPTION
Fixes #507, #459.
This PR tries to fix the error for ghost user data by making the required changes in github.py, add modifies  github_request_pull_request_2_comments and test_github.py to  add the required tests.

It keeps the comments data while setting the user to `None` for ghost user.