### PR TITLE
[jira] Add comments in issues

### DIFF
--- a/tests/data/jira/jira_comments_issue_empty.json
+++ b/tests/data/jira/jira_comments_issue_empty.json
@@ -1,0 +1,6 @@
+{
+    "comments": [],
+    "maxResults": 2,
+    "startAt": 0,
+    "total": 0
+}

--- a/tests/data/jira/jira_comments_issue_page_1.json
+++ b/tests/data/jira/jira_comments_issue_page_1.json
@@ -1,0 +1,87 @@
+{
+    "comments": [
+        {
+            "author": {
+                "accountId": "557058:887ce97e-9fbd-4873-8b09-669ce3b1e696",
+                "accountType": "atlassian",
+                "active": true,
+                "avatarUrls": {
+                    "16x16": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+                    "24x24": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+                    "32x32": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue",
+                    "48x48": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue"
+                },
+                "displayName": "Peter Monks",
+                "key": "peter",
+                "name": "peter",
+                "self": "https://finosfoundation.atlassian.net/rest/api/2/user?accountId=557058%3A887ce97e-9fbd-4873-8b09-669ce3b1e696",
+                "timeZone": "America/Los_Angeles"
+            },
+            "body": "G'day [~leo.papadopoulos]!\r\n\r\nCongratulations on receiving the first contribution proposal to the Voice Program!  Next steps are [documented on the wiki|https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/92963520/Approving+new+Projects+and+Working+Groups#ApprovingnewProjectsandWorkingGroups-ApprovalProcess], and basically involve you coordinating the Voice PMC to make a [decision|https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/75530351/Decision+Making] to approve (or not), this contribution.\r\n\r\nIf you have any questions whatsoever, please don't hesitate to reach out to me, either here in this issue, via email, or on Symphony chat.\r\n\r\nCheers,\r\nPeter",
+            "created": "2018-05-24T23:35:30.742+0200",
+            "id": "10022",
+            "jsdPublic": true,
+            "self": "https://finosfoundation.atlassian.net/rest/api/2/issue/10016/comment/10022",
+            "updateAuthor": {
+                "accountId": "557058:887ce97e-9fbd-4873-8b09-669ce3b1e696",
+                "accountType": "atlassian",
+                "active": true,
+                "avatarUrls": {
+                    "16x16": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+                    "24x24": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+                    "32x32": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue",
+                    "48x48": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue"
+                },
+                "displayName": "Peter Monks",
+                "key": "peter",
+                "name": "peter",
+                "self": "https://finosfoundation.atlassian.net/rest/api/2/user?accountId=557058%3A887ce97e-9fbd-4873-8b09-669ce3b1e696",
+                "timeZone": "America/Los_Angeles"
+            },
+            "updated": "2018-05-24T23:35:30.742+0200"
+        },
+        {
+            "author": {
+                "accountId": "557058:887ce97e-9fbd-4873-8b09-669ce3b1e696",
+                "accountType": "atlassian",
+                "active": true,
+                "avatarUrls": {
+                    "16x16": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+                    "24x24": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+                    "32x32": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue",
+                    "48x48": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue"
+                },
+                "displayName": "Jack Monks",
+                "key": "jack",
+                "name": "jack",
+                "self": "https://finosfoundation.atlassian.net/rest/api/2/user?accountId=557058%3A887ce97e-9fbd-4873-8b09-669ce3b1e696",
+                "timeZone": "America/Los_Angeles"
+            },
+            "body": "Approved - see [the approval email|https://groups.google.com/a/finos.org/d/msg/voice-pmc/Qw-h8KnCndI/d5Zr23p5AAAJ].",
+            "created": "2018-05-25T18:21:23.212+0200",
+            "id": "10024",
+            "jsdPublic": true,
+            "self": "https://finosfoundation.atlassian.net/rest/api/2/issue/10016/comment/10024",
+            "updateAuthor": {
+                "accountId": "557058:887ce97e-9fbd-4873-8b09-669ce3b1e696",
+                "accountType": "atlassian",
+                "active": true,
+                "avatarUrls": {
+                    "16x16": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+                    "24x24": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+                    "32x32": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue",
+                    "48x48": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue"
+                },
+                "displayName": "Jack Monks",
+                "key": "jack",
+                "name": "jack",
+                "self": "https://finosfoundation.atlassian.net/rest/api/2/user?accountId=557058%3A887ce97e-9fbd-4873-8b09-669ce3b1e696",
+                "timeZone": "America/Los_Angeles"
+            },
+            "updated": "2018-05-25T18:21:23.212+0200"
+        }
+    ],
+    "maxResults": 2,
+    "startAt": 0,
+    "total": 3
+}

--- a/tests/data/jira/jira_comments_issue_page_2.json
+++ b/tests/data/jira/jira_comments_issue_page_2.json
@@ -1,0 +1,87 @@
+{
+    "comments": [
+        {
+            "author": {
+                "accountId": "557058:887ce97e-9fbd-4873-8b09-669ce3b1e696",
+                "accountType": "atlassian",
+                "active": true,
+                "avatarUrls": {
+                    "16x16": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+                    "24x24": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+                    "32x32": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue",
+                    "48x48": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue"
+                },
+                "displayName": "Tim Monks",
+                "key": "peter",
+                "name": "peter",
+                "self": "https://finosfoundation.atlassian.net/rest/api/2/user?accountId=557058%3A887ce97e-9fbd-4873-8b09-669ce3b1e696",
+                "timeZone": "America/Los_Angeles"
+            },
+            "body": "G'day [~leo.papadopoulos]!\r\n\r\nCongratulations on receiving the first contribution proposal to the Voice Program!  Next steps are [documented on the wiki|https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/92963520/Approving+new+Projects+and+Working+Groups#ApprovingnewProjectsandWorkingGroups-ApprovalProcess], and basically involve you coordinating the Voice PMC to make a [decision|https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/75530351/Decision+Making] to approve (or not), this contribution.\r\n\r\nIf you have any questions whatsoever, please don't hesitate to reach out to me, either here in this issue, via email, or on Symphony chat.\r\n\r\nCheers,\r\nPeter",
+            "created": "2018-05-24T23:35:30.742+0200",
+            "id": "10022",
+            "jsdPublic": true,
+            "self": "https://finosfoundation.atlassian.net/rest/api/2/issue/10016/comment/10022",
+            "updateAuthor": {
+                "accountId": "557058:887ce97e-9fbd-4873-8b09-669ce3b1e696",
+                "accountType": "atlassian",
+                "active": true,
+                "avatarUrls": {
+                    "16x16": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+                    "24x24": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+                    "32x32": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue",
+                    "48x48": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue"
+                },
+                "displayName": "Tim Monks",
+                "key": "tim",
+                "name": "tim",
+                "self": "https://finosfoundation.atlassian.net/rest/api/2/user?accountId=557058%3A887ce97e-9fbd-4873-8b09-669ce3b1e696",
+                "timeZone": "America/Los_Angeles"
+            },
+            "updated": "2018-05-24T23:35:30.742+0200"
+        },
+        {
+            "author": {
+                "accountId": "557058:887ce97e-9fbd-4873-8b09-669ce3b1e696",
+                "accountType": "atlassian",
+                "active": true,
+                "avatarUrls": {
+                    "16x16": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+                    "24x24": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+                    "32x32": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue",
+                    "48x48": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue"
+                },
+                "displayName": "Scott Monks",
+                "key": "scott",
+                "name": "scott",
+                "self": "https://finosfoundation.atlassian.net/rest/api/2/user?accountId=557058%3A887ce97e-9fbd-4873-8b09-669ce3b1e696",
+                "timeZone": "America/Los_Angeles"
+            },
+            "body": "Approved - see [the approval email|https://groups.google.com/a/finos.org/d/msg/voice-pmc/Qw-h8KnCndI/d5Zr23p5AAAJ].",
+            "created": "2018-05-25T18:21:23.212+0200",
+            "id": "10024",
+            "jsdPublic": true,
+            "self": "https://finosfoundation.atlassian.net/rest/api/2/issue/10016/comment/10024",
+            "updateAuthor": {
+                "accountId": "557058:887ce97e-9fbd-4873-8b09-669ce3b1e696",
+                "accountType": "atlassian",
+                "active": true,
+                "avatarUrls": {
+                    "16x16": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+                    "24x24": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+                    "32x32": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue",
+                    "48x48": "https://avatar-cdn.atlassian.com/891a2dced9e970d0c4eca30ac0d281b7?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F891a2dced9e970d0c4eca30ac0d281b7%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue"
+                },
+                "displayName": "Scott Monks",
+                "key": "scott",
+                "name": "scott",
+                "self": "https://finosfoundation.atlassian.net/rest/api/2/user?accountId=557058%3A887ce97e-9fbd-4873-8b09-669ce3b1e696",
+                "timeZone": "America/Los_Angeles"
+            },
+            "updated": "2018-05-25T18:21:23.212+0200"
+        }
+    ],
+    "maxResults": 2,
+    "startAt": 2,
+    "total": 3
+}

--- a/tests/data/jira/jira_issues_page_1.json
+++ b/tests/data/jira/jira_issues_page_1.json
@@ -127,7 +127,7 @@
                 },
                 "workratio": -1
             },
-            "id": "35851",
+            "id": "1",
             "key": "HELP-6043",
             "self": "https://jira.fiware.org/rest/api/2/issue/35851"
         },
@@ -262,7 +262,7 @@
                 },
                 "workratio": -1
             },
-            "id": "35850",
+            "id": "2",
             "key": "HELP-6042",
             "self": "https://jira.fiware.org/rest/api/2/issue/35850"
         }

--- a/tests/data/jira/jira_issues_page_2.json
+++ b/tests/data/jira/jira_issues_page_2.json
@@ -127,7 +127,7 @@
                 },
                 "workratio": -1
             },
-            "id": "35844",
+            "id": "3",
             "key": "HELP-6041",
             "self": "https://jira.fiware.org/rest/api/2/issue/35844"
         }

--- a/tests/data/jira/jira_issues_parse_expected.json
+++ b/tests/data/jira/jira_issues_parse_expected.json
@@ -126,7 +126,7 @@
         },
         "expand": "operations,editmeta,changelog,transitions,renderedFields",
         "self": "https://jira.fiware.org/rest/api/2/issue/35851",
-        "id": "35851",
+        "id": "1",
         "key": "HELP-6043"
     },
     {


### PR DESCRIPTION
This PR allows to include comments of Jira issues. Comments are retrieved using the API endpoint `/rest/api/2/issue/<issue-id>/comment`. Previous tests have been modified and new ones have been added accordingly. Furthermore, this PR includes also a commit which increases the test coverage of the Jira backend, which now is 100%.