### PR TITLE
Handle Github Enterprise returning list instead of dict for reviewers

### DIFF
--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -87,7 +87,7 @@ class GitHub(Backend):
     :param sleep_time: time to sleep in case
         of connection problems
     """
-    version = '0.22.0'
+    version = '0.22.1'
 
     CATEGORIES = [CATEGORY_ISSUE, CATEGORY_PULL_REQUEST, CATEGORY_REPO]
 
@@ -387,6 +387,10 @@ class GitHub(Backend):
 
         for raw_requested_reviewers in group_requested_reviewers:
             group_requested_reviewers = json.loads(raw_requested_reviewers)
+
+            # GH Enterprise returns list of users instead of dict (issue #523)
+            if isinstance(group_requested_reviewers, list):
+                group_requested_reviewers = {'users': group_requested_reviewers}
 
             for requested_reviewer in group_requested_reviewers['users']:
                 user_data = self.__get_user(requested_reviewer['login'])

--- a/tests/data/github/github_enterprise_request_requested_reviewers
+++ b/tests/data/github/github_enterprise_request_requested_reviewers
@@ -1,0 +1,21 @@
+[
+  {
+    "login": "zhquan_example",
+    "id": 1,
+    "avatar_url": "",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/zhquan_example",
+    "html_url": "https://github.com/zhquan_example",
+    "followers_url": "https://api.github.com/users/zhquan_example/followers",
+    "following_url": "https://api.github.com/users/zhquan_example/following{/other_user}",
+    "gists_url": "https://api.github.com/users/zhquan_example/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/zhquan_example/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/zhquan_example/subscriptions",
+    "organizations_url": "https://api.github.com/users/zhquan_example/orgs",
+    "repos_url": "https://api.github.com/users/zhquan_example/repos",
+    "events_url": "https://api.github.com/users/zhquan_example/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/zhquan_example/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+]

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1321,7 +1321,7 @@ class TestGitHubBackend(unittest.TestCase):
         pull_request_reviews = read_file('data/github/github_request_pull_request_1_reviews')
         pull_request_commits = read_file('data/github/github_request_pull_request_1_commits')
         pull_request_comment_2_reactions = read_file('data/github/github_request_pull_request_1_comment_2_reactions')
-        pull_requested_reviewers = read_file('data/github/github_request_requested_reviewers')
+        pull_requested_reviewers = read_file('data/github/github_enterprise_request_requested_reviewers')
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ENTREPRISE_RATE_LIMIT,


### PR DESCRIPTION
Fixes #523
This PR handles cases where Github Enterprise servers may return a list of users for `/repos/{org}/{repo}/pulls/{number}/requested_reviewers` instead of the dict referenced [here](https://developer.github.com/enterprise/2.16/v3/pulls/review_requests/).

Test run: https://travis-ci.org/cewilliams/grimoirelab-perceval/builds/530053609