### PR TITLE
[gitlab] Handle missing attr `last` in pagination response

### DIFF
--- a/perceval/backends/core/gitlab.py
+++ b/perceval/backends/core/gitlab.py
@@ -82,7 +82,7 @@ class GitLab(Backend):
         of connection problems
     :param blacklist_ids: ids of items that must not be retrieved
     """
-    version = '0.6.2'
+    version = '0.6.3'
 
     CATEGORIES = [CATEGORY_ISSUE, CATEGORY_MERGE_REQUEST]
 
@@ -582,7 +582,11 @@ class GitLabClient(HttpClient, RateLimitHandler):
                 page += 1
 
                 items = response.text
-                logger.debug("Page: %i/%i" % (page, last_page))
+
+                if not last_page:
+                    logger.debug("Page: %i" % page)
+                else:
+                    logger.debug("Page: %i/%i" % (page, last_page))
 
     @staticmethod
     def sanitize_for_archive(url, headers, payload):


### PR DESCRIPTION
For efficiency reasons the GitLab API doesn't include the attribute `last` in the pagination responses for
calls with more than 10,000 items. Thus, this code allows to handle this case, tests have been added
accordingly.