### PR TITLE
windows 10 changed #!/usr/bin/env python3 to #!/usr/bin/env python

### DIFF
--- a/bin/perceval
+++ b/bin/perceval
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Perceval documentation build configuration file, created by

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_bugzillarest.py
+++ b/tests/test_bugzillarest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_discourse.py
+++ b/tests/test_discourse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_launchpad.py
+++ b/tests/test_launchpad.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_mbox.py
+++ b/tests/test_mbox.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_nntp.py
+++ b/tests/test_nntp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_stackexchange.py
+++ b/tests/test_stackexchange.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_twitter.py
+++ b/tests/test_twitter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia


### PR DESCRIPTION
-changed #!/usr/bin/env python3 to #!/usr/bin/env python so that windows will not error "/usr/bin/env: ‘python3’: No such file or directory"
-may cause issues if a user has more than one version of python installed
-could make a windows specific copy "pip3 install perceval_windows"
