### PR TITLE
[gitlab] Force UTF-8 encoding on response contents

### DIFF
--- a/perceval/backends/core/gitlab.py
+++ b/perceval/backends/core/gitlab.py
@@ -84,7 +84,7 @@ class GitLab(Backend):
         of connection problems
     :param blacklist_ids: ids of items that must not be retrieved
     """
-    version = '0.7.0'
+    version = '0.7.1'
 
     CATEGORIES = [CATEGORY_ISSUE, CATEGORY_MERGE_REQUEST]
 
@@ -570,6 +570,7 @@ class GitLabClient(HttpClient, RateLimitHandler):
         logger.debug("Get GitLab paginated items from " + url_next)
 
         response = self.fetch(url_next, payload=payload)
+        response.encoding = 'utf-8'
 
         items = response.text
         page += 1


### PR DESCRIPTION
The module `requests` sometimes tries to guess the encoding of the responses received. It uses the module `chardet` to determine the encoding. In the case of GitLab it is unable to determine the encoding and usually produces bad guesses as Big5 encoding when all it is encoded as UTF-8.

As we know GitLab encodes in UTF-8, this commit forces to parse the response using that encoding.