### PR TITLE
[dependencies] Pin urllib3 and requests dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 python-dateutil>=2.6.0
-requests>=2.7.0
+requests==2.18.2
 beautifulsoup4>=4.3.2
 feedparser>=5.1.3
 dulwich>=0.18.5, <0.19
-urllib3>=1.22
+urllib3==1.22
 -e git+https://github.com/chaoss/grimoirelab-toolkit/#egg=grimoirelab-toolkit

--- a/setup.py
+++ b/setup.py
@@ -103,11 +103,11 @@ setup(name="perceval",
       ],
       install_requires=[
           'python-dateutil>=2.6.0',
-          'requests>=2.7.0',
+          'requests==2.18.2',
           'beautifulsoup4>=4.3.2',
           'feedparser>=5.1.3',
           'dulwich>=0.18.5, <0.19',
-          'urllib3>=1.22',
+          'urllib3==1.22',
           'grimoirelab-toolkit>=0.1.4'
       ],
       scripts=[


### PR DESCRIPTION
This code fixes the urllib3 version used by perceval to 1.22, since in the later versions urllib3.exceptions.SSLError exceptions may be thrown due to CERTIFICATE_VERIFY_FAILED. Furthermore, it also sets the version of requests to 2.18.2, which is compatible with urllib3 1.22.