### PR TITLE
[groupsio] Fix invalid value for 'limit' in subscriptions query

### DIFF
--- a/perceval/backends/core/groupsio.py
+++ b/perceval/backends/core/groupsio.py
@@ -60,7 +60,7 @@ class Groupsio(MBox):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.1.2'
+    version = '0.1.3'
 
     CATEGORIES = [CATEGORY_MESSAGE]
 
@@ -229,7 +229,7 @@ class GroupsioClient(MailingList):
     def __find_group_id(self):
         """Find the id of a group given its name by iterating on the list of subscriptions"""
 
-        group_subscriptions = self.subscriptions(self.auth)
+        group_subscriptions = self.subscriptions()
 
         for subscriptions in group_subscriptions:
             for sub in subscriptions:

--- a/tests/test_groupsio.py
+++ b/tests/test_groupsio.py
@@ -256,6 +256,27 @@ class TestGroupsioClient(unittest.TestCase):
         client = GroupsioClient('beta+api', self.tmp_path, 'aaaaa', verify=False)
         success = client.fetch()
 
+        # Check requests
+        expected = [
+            {
+                'limit': ['100'],
+            },
+            {
+                'limit': ['100'],
+                'page_token': ['1']
+            },
+            {
+                'group_id': ['7769']
+            }
+        ]
+
+        http_requests = httpretty.httpretty.latest_requests
+
+        self.assertEqual(len(http_requests), len(expected))
+
+        for i in range(len(expected)):
+            self.assertDictEqual(http_requests[i].querystring, expected[i])
+
         self.assertEqual(client.mboxes[0].filepath, os.path.join(self.tmp_path, MBOX_FILE))
         self.assertTrue(success)
 


### PR DESCRIPTION
The request to retrieve the list of groups a user is subscribed to was wrong. The parameter 'limit' was set wrongly to the user authentication data. This commit fixes that bug.

Backend version updated to 0.1.3.