### PR TITLE
[mediawiki] Skip page without `pageid` attribute

### DIFF
--- a/perceval/backends/core/mediawiki.py
+++ b/perceval/backends/core/mediawiki.py
@@ -71,7 +71,7 @@ class MediaWiki(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.9.5'
+    version = '0.9.6'
 
     CATEGORIES = [CATEGORY_PAGE]
 
@@ -119,7 +119,7 @@ class MediaWiki(Backend):
         logger.info("MediaWiki version: %s", mediawiki_version)
 
         if reviews_api:
-            if ((mediawiki_version[0] == 1 and mediawiki_version[1] >= 27) or mediawiki_version[0] > 1):
+            if (mediawiki_version[0] == 1 and mediawiki_version[1] >= 27) or mediawiki_version[0] > 1:
                 fetcher = self.__fetch_1_27(from_date)
             else:
                 logger.warning("Reviews API only available in MediaWiki >= 1.27")
@@ -287,6 +287,10 @@ class MediaWiki(Backend):
                         rccontinue = None
                         hole_created = False
                         break
+
+                    if 'pageid' not in page:
+                        logger.warning("Missing pageid in page %s; skipped", page)
+                        continue
 
                     if page['pageid'] in pages_done:
                         logger.debug("Page %s already processed; skipped", page['pageid'])

--- a/tests/data/mediawiki/mediawiki_pages_recent_changes.json
+++ b/tests/data/mediawiki/mediawiki_pages_recent_changes.json
@@ -33,6 +33,13 @@
             },
             {
                 "ns": 0,
+                "timestamp": "2016-06-23T15:37:13Z",
+                "type": "log",
+                "revid": 0,
+                "oldrevid": 0
+            },
+            {
+                "ns": 0,
                 "pageid": 476583,
                 "timestamp": "2016-06-23T15:36:23Z",
                 "title": "VisualEditor:Test",

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -258,6 +258,7 @@ class TestMediaWikiBackend_1_23(TestMediaWikiBackend):
             self.assertEqual(cm.output[0],
                              'WARNING:perceval.backends.core.mediawiki:Revisions not found in OldEditor:Test '
                              '[page id: 476589], page skipped')
+            self.assertIn('WARNING:perceval.backends.core.mediawiki:Missing pageid in page', cm.output[1])
 
     @httpretty.activate
     def test_fetch_empty(self):
@@ -296,6 +297,7 @@ class TestMediaWikiBackend_1_28(TestMediaWikiBackend):
             self.assertEqual(cm.output[0],
                              'WARNING:perceval.backends.core.mediawiki:Revisions not found in OldEditor:Test '
                              '[page id: 476589], page skipped')
+            self.assertIn('WARNING:perceval.backends.core.mediawiki:Missing pageid in page', cm.output[1])
 
         with self.assertLogs(logger, level='WARNING') as cm:
             self._test_fetch_version("1.28", from_date=from_date, reviews_api=True)
@@ -349,6 +351,7 @@ class TestMediaWikiBackendArchive1_23(TestMediaWikiBackendArchive):
             self.assertEqual(cm.output[0],
                              'WARNING:perceval.backends.core.mediawiki:Revisions not found in OldEditor:Test '
                              '[page id: 476589], page skipped')
+            self.assertIn('WARNING:perceval.backends.core.mediawiki:Missing pageid in page', cm.output[1])
 
 
 class TestMediaWikiBackendArchive1_28(TestMediaWikiBackendArchive):
@@ -363,6 +366,7 @@ class TestMediaWikiBackendArchive1_28(TestMediaWikiBackendArchive):
             self.assertEqual(cm.output[0],
                              'WARNING:perceval.backends.core.mediawiki:Revisions not found in OldEditor:Test '
                              '[page id: 476589], page skipped')
+            self.assertIn('WARNING:perceval.backends.core.mediawiki:Missing pageid in page', cm.output[1])
 
     @httpretty.activate
     def test_fetch_from_archive_reviews(self):


### PR DESCRIPTION
This PR skips pages not having the `pageid` attribute. This may be the case for pages of type `log` with `actionhidden` attribute. Tests have been added accordingly.

Backend version is now 0.9.6