### PR TITLE
Add proxy support to git clone command

### DIFF
--- a/perceval/backends/core/git.py
+++ b/perceval/backends/core/git.py
@@ -797,6 +797,9 @@ class GitRepository:
         self.gitenv = {
             'LANG': 'C',
             'PAGER': '',
+            'HTTP_PROXY': os.getenv('HTTP_PROXY', ''),
+            'HTTPS_PROXY': os.getenv('HTTPS_PROXY', ''),
+            'NO_PROXY': os.getenv('NO_PROXY', ''),
             'HOME': os.getenv('HOME', '')
         }
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1276,6 +1276,9 @@ class TestGitRepository(TestCaseGit):
         expected = {
             'LANG': 'C',
             'PAGER': '',
+            'HTTP_PROXY': '',
+            'HTTPS_PROXY': '',
+            'NO_PROXY': '',
             'HOME': ''
         }
         self.assertDictEqual(repo.gitenv, expected)


### PR DESCRIPTION
This change provides support for running `git clone` perceval task behind a corporate proxy. It takes the environment variables if they are defined.