### PR TITLE
[slack] Handle `num_members` for archived channels

### DIFF
--- a/perceval/backends/core/slack.py
+++ b/perceval/backends/core/slack.py
@@ -58,7 +58,7 @@ class Slack(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.7.2'
+    version = '0.7.3'
 
     CATEGORIES = [CATEGORY_MESSAGE]
 
@@ -113,7 +113,12 @@ class Slack(Backend):
         raw_info = self.client.channel_info(self.channel)
 
         channel_info = self.parse_channel_info(raw_info)
-        channel_info['num_members'] = self.client.conversation_members(self.channel)
+
+        if channel_info['is_archived']:
+            channel_info['num_members'] = None
+            logger.warning("channel_info.num_members is None for archived channels %s", self.channel)
+        else:
+            channel_info['num_members'] = self.client.conversation_members(self.channel)
 
         oldest = datetime_to_utc(from_date).timestamp()
 

--- a/tests/data/slack/slack_info_archived.json
+++ b/tests/data/slack/slack_info_archived.json
@@ -1,0 +1,41 @@
+{
+    "channel": {
+        "created": 1480595743,
+        "creator": "U0001",
+        "id": "C011DUKE8",
+        "is_archived": true,
+        "is_channel": true,
+        "is_general": true,
+        "is_member": true,
+        "is_read_only": false,
+        "last_read": "1489127926.000217",
+        "latest": {
+            "bot_id": "B0001",
+            "subtype": "bot_message",
+            "text": "There are no events this week.",
+            "ts": "1486969200.000136",
+            "type": "message"
+        },
+        "members": [
+            "U0001",
+            "U0002",
+            "U0003"
+        ],
+        "name": "test channel",
+        "name_normalized": "test channel",
+        "previous_names": [],
+        "purpose": {
+            "creator": "",
+            "last_set": 0,
+            "value": "Test channel."
+        },
+        "topic": {
+            "creator": "",
+            "last_set": 0,
+            "value": "A test channel for testing Perceval"
+        },
+        "unread_count": 1,
+        "unread_count_display": 1
+    },
+    "ok": true
+}


### PR DESCRIPTION
Due to an API change, the number of members for archived channels cannot be retrieved anymore. This code set the `num_members` value of archived channels to None, and logs a warning message.

Tests have been added accordingly. The backend version is set to 0.7.3.

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>