### PR TITLE
[backend] Add search terms

### DIFF
--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -74,6 +74,19 @@ class Backend:
     Classified data filtering and archiving are not compatible to prevent
     data leaks or security issues.
 
+    Each backend can also provides a set of search terms to simplify query
+    operations (avoiding the manual inspection of the items). The search
+    terms are included in a dict with the following shape:
+        {
+            'term-1': 'value-1',
+            'term-2': 'value-2',
+            'term-3': 'value-3',
+        }
+
+    The search terms are added to the metadata information of each
+    Perceval item in `search_terms` attributes. If `search_terms` is not set,
+    it will be set to `None` .
+
     :param origin: identifier of the repository
     :param tag: tag items using this label
     :param archive: archive to store/retrieve data
@@ -81,7 +94,7 @@ class Backend:
     :raises ValueError: raised when `archive` is not an instance of
         `Archive` class
     """
-    version = '0.8.0'
+    version = '0.9.0'
 
     CATEGORIES = []
     CLASSIFIED_FIELDS = []
@@ -227,6 +240,7 @@ class Backend:
             'updated_on': self.metadata_updated_on(item),
             'classified_fields_filtered': self.classified_fields if filter_classified else None,
             'category': self.metadata_category(item),
+            'search_terms': self.search_terms(item),
             'tag': self.tag,
             'data': item,
         }
@@ -252,6 +266,10 @@ class Backend:
     @staticmethod
     def metadata_category(item):
         raise NotImplementedError
+
+    @staticmethod
+    def search_terms(item):
+        return None
 
     def _init_client(self, from_archive=False):
         raise NotImplementedError

--- a/perceval/backends/core/jira.py
+++ b/perceval/backends/core/jira.py
@@ -96,7 +96,7 @@ class Jira(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.12.0'
+    version = '0.13.0'
 
     CATEGORIES = [CATEGORY_ISSUE]
 
@@ -215,6 +215,22 @@ class Jira(Backend):
         'issue'.
         """
         return CATEGORY_ISSUE
+
+    @staticmethod
+    def search_terms(item):
+        """Set the search terms of a Jira items."""
+
+        project_id = item['fields']['project']['id']
+        project_key = item['fields']['project']['key']
+        project_name = item['fields']['project']['name']
+
+        terms = {
+            'project_id': project_id,
+            'project_key': project_key,
+            'project_name': project_name
+        }
+
+        return terms
 
     @staticmethod
     def parse_issues(raw_page):

--- a/tests/data/jira/jira_issues_page_2.json
+++ b/tests/data/jira/jira_issues_page_2.json
@@ -71,7 +71,7 @@
                         "32x32": "https://jira.fiware.org/secure/projectavatar?size=medium&avatarId=10011",
                         "48x48": "https://jira.fiware.org/secure/projectavatar?avatarId=10011"
                     },
-                    "id": "10841",
+                    "id": "10843",
                     "key": "HELP",
                     "name": "Help-Desk",
                     "projectCategory": {

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -95,6 +95,18 @@ class MockedBackend(Backend):
         return item['category']
 
 
+class SearchTermsBackend(MockedBackend):
+    """Mocked backend for testing search terms"""
+
+    @staticmethod
+    def search_terms(item):
+        terms = {
+            'pos': item['item']
+        }
+
+        return terms
+
+
 class ClassifiedFieldsBackend(MockedBackend):
     """Mocked backend for testing classified fields filtering"""
 
@@ -275,6 +287,22 @@ class TestBackend(unittest.TestCase):
 
         with self.assertRaises(NotImplementedError):
             b.metadata_category(None)
+
+    def test_search_terms_none(self):
+        """Test whether the search_terms is None when it is not defined"""
+
+        b = MockedBackend('test')
+
+        for item in b.fetch():
+            self.assertIsNone(item['search_terms'])
+
+    def test_search_terms(self):
+        """Test whether the search_terms is properly set"""
+
+        b = SearchTermsBackend('test')
+
+        for item in b.fetch():
+            self.assertEqual(item['data']['item'], item['search_terms']['pos'])
 
     def test_tag(self):
         """Test whether tag value is initializated"""

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -329,6 +329,86 @@ class TestJiraBackend(unittest.TestCase):
         self.assertEqual(issue['data']['comments_data'], [])
 
     @httpretty.activate
+    def test_serch_terms(self):
+        """Test whether the search_terms is properly set"""
+
+        bodies_json = [read_file('data/jira/jira_issues_page_1.json'),
+                       read_file('data/jira/jira_issues_page_2.json')]
+        comment_json = read_file('data/jira/jira_comments_issue_page_2.json')
+        empty_comment = read_file('data/jira/jira_comments_issue_empty.json')
+
+        body = read_file('data/jira/jira_fields.json')
+
+        def request_callback(method, uri, headers):
+            body = bodies_json.pop(0)
+            return 200, headers, body
+
+        httpretty.register_uri(httpretty.GET,
+                               JIRA_SEARCH_URL,
+                               responses=[httpretty.Response(body=request_callback)
+                                          for _ in range(2)])
+
+        httpretty.register_uri(httpretty.GET,
+                               JIRA_ISSUE_1_COMMENTS_URL,
+                               body=empty_comment,
+                               status=200)
+
+        httpretty.register_uri(httpretty.GET,
+                               JIRA_ISSUE_2_COMMENTS_URL,
+                               body=comment_json,
+                               status=200)
+
+        httpretty.register_uri(httpretty.GET,
+                               JIRA_ISSUE_3_COMMENTS_URL,
+                               body=empty_comment,
+                               status=200)
+
+        httpretty.register_uri(httpretty.GET,
+                               JIRA_FIELDS_URL,
+                               body=body, status=200)
+
+        jira = Jira(JIRA_SERVER_URL)
+        issues = [issue for issue in jira.fetch()]
+
+        issue = issues[0]
+        self.assertEqual(issue['uuid'], '6a7ba2a01aee56603b9d8a5f6b40c843fc089b2f')
+        self.assertEqual(issue['updated_on'], 1457015567)
+        self.assertEqual(issue['category'], 'issue')
+        self.assertEqual(issue['tag'], 'http://example.com')
+        self.assertEqual(issue['data']['fields']['project']['id'], '10841')
+        self.assertEqual(issue['data']['fields']['project']['id'], issue['search_terms']['project_id'])
+        self.assertEqual(issue['data']['fields']['project']['key'], 'HELP')
+        self.assertEqual(issue['data']['fields']['project']['key'], issue['search_terms']['project_key'])
+        self.assertEqual(issue['data']['fields']['project']['name'], 'Help-Desk')
+        self.assertEqual(issue['data']['fields']['project']['name'], issue['search_terms']['project_name'])
+
+        issue = issues[1]
+        self.assertEqual(issue['origin'], 'http://example.com')
+        self.assertEqual(issue['uuid'], '3c3d67925b108a37f88cc6663f7f7dd493fa818c')
+        self.assertEqual(issue['updated_on'], 1457015417)
+        self.assertEqual(issue['category'], 'issue')
+        self.assertEqual(issue['tag'], 'http://example.com')
+        self.assertEqual(issue['data']['fields']['project']['id'], '10841')
+        self.assertEqual(issue['data']['fields']['project']['id'], issue['search_terms']['project_id'])
+        self.assertEqual(issue['data']['fields']['project']['key'], 'HELP')
+        self.assertEqual(issue['data']['fields']['project']['key'], issue['search_terms']['project_key'])
+        self.assertEqual(issue['data']['fields']['project']['name'], 'Help-Desk')
+        self.assertEqual(issue['data']['fields']['project']['name'], issue['search_terms']['project_name'])
+
+        issue = issues[2]
+        self.assertEqual(issue['origin'], 'http://example.com')
+        self.assertEqual(issue['uuid'], '1c7765e2a5d27495cf389f5f951c544693c4655f')
+        self.assertEqual(issue['updated_on'], 1457006245)
+        self.assertEqual(issue['category'], 'issue')
+        self.assertEqual(issue['tag'], 'http://example.com')
+        self.assertEqual(issue['data']['fields']['project']['id'], '10843')
+        self.assertEqual(issue['data']['fields']['project']['id'], issue['search_terms']['project_id'])
+        self.assertEqual(issue['data']['fields']['project']['key'], 'HELP')
+        self.assertEqual(issue['data']['fields']['project']['key'], issue['search_terms']['project_key'])
+        self.assertEqual(issue['data']['fields']['project']['name'], 'Help-Desk')
+        self.assertEqual(issue['data']['fields']['project']['name'], issue['search_terms']['project_name'])
+
+    @httpretty.activate
     def test_fetch_from_date(self):
         """Test whether a list of issues is returned from a given date"""
 


### PR DESCRIPTION
This PR proposes to extend the metadata attributes by adding a new field (`search_terms`) with the purpose of simplifying query operations and avoding inspecting the data attribute. 

The search terms are included in a dict with the following shape:
```
        {
            'term-1': 'value-1',
            'term-2': 'value-2',
            'term-3': 'value-3',
        }
```
The search terms are added to the metadata information of each item in `search_terms` attribute. If search terms are not defined, `search_terms` will be set to `None`.

This new feature is showcased with the Jira backend.