### PR TITLE
[tests] Update httpretty dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,16 +354,7 @@ $ perceval twitter grimoirelab -t 12345678abcdefgh
 
 Perceval comes with a comprehensive list of unit tests.
 To run them, in addition to the dependencies installed with Perceval,
-you need version 0.8.6 of  `httpretty`.
-Currently, latest version in pypi is 0.8.14,
-which seems to have a bug exposed by some Perceval tests.
-So, ensure you install 0.8.6, which is known to work with them:
-
-```
-$ pip install httpretty==0.8.6
-$ cd tests
-$ python3 run_tests.py
-```
+you need `httpretty`.
 
 ## License
 

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,1 +1,1 @@
-httpretty==0.8.6
+httpretty>=0.9.6

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(name="perceval",
           'pandoc'
       ],
       tests_require=[
-          'httpretty==0.8.6'
+          'httpretty>=0.9.6'
       ],
       install_requires=[
           'python-dateutil>=2.6.0',


### PR DESCRIPTION
This PR tackles https://github.com/chaoss/grimoirelab-perceval/issues/557. It unpins the httpretty dependency, since the bug in version 0.8.14, which was preventing to execute some tests in Perceval, is solved in version 0.9.6. Furthermore, the README has been updated accordingly.