### PR TITLE
[backend] Add generic blacklist param

### DIFF
--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -81,7 +81,7 @@ class Backend:
     :raises ValueError: raised when `archive` is not an instance of
         `Archive` class
     """
-    version = '0.8.0'
+    version = '0.9.0'
 
     CATEGORIES = []
     CLASSIFIED_FIELDS = []
@@ -285,6 +285,7 @@ class BackendCommandArgumentParser:
     :param token_auth: set token/key authentication arguments
     :param archive: set archiving arguments
     :param aliases: define aliases for parsed arguments
+    :param blacklist: set a list of items IDs to be filtered out
 
     :raises AttributeArror: when both `from_date` and `offset` are set
         to `True`
@@ -292,7 +293,7 @@ class BackendCommandArgumentParser:
 
     def __init__(self, categories, from_date=False, to_date=False, offset=False,
                  basic_auth=False, token_auth=False, archive=False,
-                 aliases=None):
+                 aliases=None, blacklist=False):
         self._from_date = from_date
         self._to_date = to_date
         self._archive = archive
@@ -326,6 +327,11 @@ class BackendCommandArgumentParser:
             group.add_argument('--offset', dest='offset',
                                type=int, default=0,
                                help="offset to start fetching items")
+
+        if blacklist:
+            group.add_argument('--blacklist-ids', dest='blacklist_ids',
+                               nargs='*', type=str,
+                               help="Ids of items that must not be retrieved.")
 
         if basic_auth or token_auth:
             self._set_auth_arguments(basic_auth=basic_auth,

--- a/perceval/backends/core/gitlab.py
+++ b/perceval/backends/core/gitlab.py
@@ -84,7 +84,7 @@ class GitLab(Backend):
         of connection problems
     :param blacklist_ids: ids of items that must not be retrieved
     """
-    version = '0.8.0'
+    version = '0.8.1'
 
     CATEGORIES = [CATEGORY_ISSUE, CATEGORY_MERGE_REQUEST]
 
@@ -221,7 +221,7 @@ class GitLab(Backend):
         for raw_issues in issues_groups:
             issues = json.loads(raw_issues)
             for issue in issues:
-                issue_id = issue['iid']
+                issue_id = str(issue['iid'])
 
                 if self.blacklist_ids and issue_id in self.blacklist_ids:
                     logger.warning("Skipping blacklisted issue %s", issue_id)
@@ -278,7 +278,7 @@ class GitLab(Backend):
         for raw_merges in merges_groups:
             merges = json.loads(raw_merges)
             for merge in merges:
-                merge_id = merge['iid']
+                merge_id = str(merge['iid'])
 
                 if self.blacklist_ids and merge_id in self.blacklist_ids:
                     logger.warning("Skipping blacklisted merge request %s", merge_id)
@@ -693,7 +693,8 @@ class GitLabCommand(BackendCommand):
         parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
                                               from_date=True,
                                               token_auth=True,
-                                              archive=True)
+                                              archive=True,
+                                              blacklist=True)
 
         # GitLab options
         group = parser.parser.add_argument_group('GitLab arguments')
@@ -706,9 +707,6 @@ class GitLabCommand(BackendCommand):
                            default=MIN_RATE_LIMIT, type=int,
                            help="sleep until reset when the rate limit \
                                reaches this value")
-        group.add_argument('--blacklist-ids', dest='blacklist_ids',
-                           nargs='*', type=int,
-                           help="Ids of items that must not be retrieved.")
         group.add_argument('--is-oauth-token', dest='is_oauth_token',
                            action='store_true',
                            help="Set when using OAuth2")

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -703,6 +703,19 @@ class TestBackendCommandArgumentParser(unittest.TestCase):
         self.assertEqual(parsed_args.password, '1234')
         self.assertEqual(parsed_args.api_token, 'abcd')
 
+    def test_parse_blacklist_ids(self):
+        """Test if the blacklist argument is parsed"""
+
+        args = ['--blacklist-ids', '1'
+                '--category', 'mocked']
+
+        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND.CATEGORIES,
+                                              blacklist=True)
+        parsed_args = parser.parse(*args)
+
+        self.assertIsInstance(parsed_args, argparse.Namespace)
+        self.assertTrue(parsed_args.blacklist_ids)
+
     def test_parse_archive_args(self):
         """Test if achiving arguments are parsed"""
 

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -449,7 +449,7 @@ class TestGitLabBackend(unittest.TestCase):
         # When tag is empty or None it will be set to
         # the value in originTestGitLabBackend
         gitlab = GitLab('fdroid', 'fdroiddata', api_token='aaa', max_retries=10,
-                        sleep_time=100, blacklist_ids=[1, 2, 3])
+                        sleep_time=100, blacklist_ids=['1', '2', '3'])
 
         self.assertEqual(gitlab.owner, 'fdroid')
         self.assertEqual(gitlab.repository, 'fdroiddata')
@@ -458,7 +458,7 @@ class TestGitLabBackend(unittest.TestCase):
         self.assertIsNone(gitlab.client)
         self.assertEqual(gitlab.max_retries, 10)
         self.assertEqual(gitlab.sleep_time, 100)
-        self.assertEqual(gitlab.blacklist_ids, [1, 2, 3])
+        self.assertEqual(gitlab.blacklist_ids, ['1', '2', '3'])
         self.assertEqual(gitlab.is_oauth_token, False)
 
     @httpretty.activate
@@ -595,7 +595,7 @@ class TestGitLabBackend(unittest.TestCase):
 
         setup_http_server(GITLAB_URL_PROJECT, GITLAB_ISSUES_URL, GITLAB_MERGES_URL)
 
-        gitlab = GitLab("fdroid", "fdroiddata", "your-token", blacklist_ids=[1, 2, 3])
+        gitlab = GitLab("fdroid", "fdroiddata", "your-token", blacklist_ids=['1', '2', '3'])
 
         with self.assertLogs(level='WARNING') as cm:
             issues = [issues for issues in gitlab.fetch()]
@@ -698,7 +698,7 @@ class TestGitLabBackend(unittest.TestCase):
 
         setup_http_server(GITLAB_URL_PROJECT, GITLAB_ISSUES_URL, GITLAB_MERGES_URL)
 
-        gitlab = GitLab("fdroid", "fdroiddata", "your-token", blacklist_ids=[1, 2])
+        gitlab = GitLab("fdroid", "fdroiddata", "your-token", blacklist_ids=['1', '2'])
 
         with self.assertLogs(level='WARNING') as cm:
             merges = [merges for merges in gitlab.fetch(category=CATEGORY_MERGE_REQUEST)]
@@ -1690,7 +1690,7 @@ class TestGitLabCommand(unittest.TestCase):
         self.assertEqual(parsed_args.no_archive, True)
         self.assertEqual(parsed_args.api_token, 'abcdefgh')
         self.assertEqual(parsed_args.category, CATEGORY_MERGE_REQUEST)
-        self.assertEqual(parsed_args.blacklist_ids, [1, 2, 3])
+        self.assertEqual(parsed_args.blacklist_ids, ['1', '2', '3'])
         self.assertEqual(parsed_args.max_retries, 5)
         self.assertEqual(parsed_args.sleep_time, 10)
         self.assertEqual(parsed_args.is_oauth_token, True)


### PR DESCRIPTION
This PR extends the BackendCommandArgumentParser by including the param `blacklist`, which allows
to define a list of items IDs (parsed as `str`) to be filtered out.

Tests and the GitLab backend have been modified accordingly. The backend version is set to 0.9.0.