### PR TITLE
[meetup] Pass oauth2 token via headers

### DIFF
--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -165,8 +165,8 @@ def setup_http_server(rate_limit=-1, reset_rate_limit=-1):
 class MockedMeetupClient(MeetupClient):
     """Mocked meetup client for testing"""
 
-    def __init__(self, token, is_oauth_token, max_items, min_rate_to_sleep, sleep_for_rate):
-        super().__init__(token, is_oauth_token=is_oauth_token, max_items=max_items,
+    def __init__(self, token, max_items, min_rate_to_sleep, sleep_for_rate):
+        super().__init__(token, max_items=max_items,
                          min_rate_to_sleep=min_rate_to_sleep,
                          sleep_for_rate=sleep_for_rate)
         self.rate_limit_reset_ts = -1
@@ -189,36 +189,16 @@ class TestMeetupBackend(unittest.TestCase):
         self.assertEqual(meetup.group, 'mygroup')
         self.assertEqual(meetup.max_items, 5)
         self.assertIsNone(meetup.client)
-        self.assertFalse(meetup.is_oauth_token)
 
         # When tag is empty or None it will be set to
         # the value in URL
         meetup = Meetup('mygroup', 'aaaa')
         self.assertEqual(meetup.origin, 'https://meetup.com/')
         self.assertEqual(meetup.tag, 'https://meetup.com/')
-        self.assertFalse(meetup.is_oauth_token)
 
         meetup = Meetup('mygroup', 'aaaa', tag='')
         self.assertEqual(meetup.origin, 'https://meetup.com/')
         self.assertEqual(meetup.tag, 'https://meetup.com/')
-        self.assertFalse(meetup.is_oauth_token)
-
-    def test_initialization_oauth(self):
-        """Test whether attributes are initialized with an oauth token"""
-
-        meetup = Meetup('mygroup', 'aaaa', is_oauth_token=True, max_items=5, tag='test',
-                        sleep_for_rate=True, min_rate_to_sleep=10, sleep_time=60)
-
-        self.assertEqual(meetup.origin, 'https://meetup.com/')
-        self.assertEqual(meetup.tag, 'test')
-        self.assertEqual(meetup.group, 'mygroup')
-        self.assertEqual(meetup.max_items, 5)
-        self.assertIsNone(meetup.client)
-        self.assertTrue(meetup.is_oauth_token)
-
-    def test_initialization_warning(self):
-        with self.assertWarns(DeprecationWarning):
-            _ = Meetup('mygroup', 'aaaa')
 
     def test_has_archiving(self):
         """Test if it returns True when has_archiving is called"""
@@ -263,129 +243,37 @@ class TestMeetupBackend(unittest.TestCase):
         expected = [
             {
                 'fields': ['event_hosts,featured,group_topics,plain_text_description,rsvpable,series'],
-                'key': ['aaaa'],
-                'order': ['updated'],
-                'page': ['2'],
-                'scroll': ['since:1970-01-01T00:00:00.000Z'],
-                'sign': ['true'],
-                'status': ['cancelled,upcoming,past,proposed,suggested']
-            },
-            {
-                'key': ['aaaa'],
-                'page': ['2'],
-                'sign': ['true']
-            },
-            {
-                'fields': ['attendance_status'],
-                'key': ['aaaa'],
-                'page': ['2'],
-                'response': ['yes,no'],
-                'sign': ['true']
-            },
-            {
-                'key': ['aaaa'],
-                'page': ['2'],
-                'sign': ['true']
-            },
-            {
-                'fields': ['attendance_status'],
-                'key': ['aaaa'],
-                'page': ['2'],
-                'response': ['yes,no'],
-                'sign': ['true']
-            },
-            {
-                'key': ['aaaa'],
-                'sign': ['true']
-            },
-            {
-                'key': ['aaaa'],
-                'page': ['2'],
-                'sign': ['true']
-            },
-            {
-                'fields': ['attendance_status'],
-                'key': ['aaaa'],
-                'page': ['2'],
-                'response': ['yes,no'],
-                'sign': ['true']
-            }
-        ]
-
-        self.assertEqual(len(http_requests), len(expected))
-
-        for i in range(len(expected)):
-            self.assertDictEqual(http_requests[i].querystring, expected[i])
-
-    @httpretty.activate
-    def test_fetch_oauth_token(self):
-        """Test whether it fetches a set of events when using an oauth token"""
-
-        http_requests = setup_http_server()
-
-        meetup = Meetup('sqlpass-es', 'aaaa', is_oauth_token=True, max_items=2)
-        events = [event for event in meetup.fetch(from_date=None)]
-
-        expected = [('1', '0d07fe36f994a6c78dfcf60fb73674bcf158cb5a', 1460065164.0, 2, 3),
-                    ('2', '24b47b622eb33965676dd951b18eea7689b1d81c', 1465503498.0, 2, 3),
-                    ('3', 'a42b7cf556c17b17f05b951e2eb5e07a7cb0a731', 1474842748.0, 2, 3)]
-
-        self.assertEqual(len(events), len(expected))
-
-        for x in range(len(events)):
-            event = events[x]
-            expc = expected[x]
-            self.assertEqual(event['data']['id'], expc[0])
-            self.assertEqual(event['uuid'], expc[1])
-            self.assertEqual(event['origin'], 'https://meetup.com/')
-            self.assertEqual(event['updated_on'], expc[2])
-            self.assertEqual(event['category'], 'event')
-            self.assertEqual(event['tag'], 'https://meetup.com/')
-            self.assertEqual(event['classified_fields_filtered'], None)
-            self.assertIn('topics', event['data']['group'])
-            self.assertEqual(len(event['data']['comments']), expc[3])
-            self.assertEqual(len(event['data']['rsvps']), expc[4])
-
-        # Check requests
-        expected = [
-            {
-                'fields': ['event_hosts,featured,group_topics,plain_text_description,rsvpable,series'],
-                'access_token': ['aaaa'],
                 'order': ['updated'],
                 'page': ['2'],
                 'scroll': ['since:1970-01-01T00:00:00.000Z'],
                 'status': ['cancelled,upcoming,past,proposed,suggested']
             },
             {
-                'access_token': ['aaaa'],
                 'page': ['2']
             },
             {
                 'fields': ['attendance_status'],
-                'access_token': ['aaaa'],
                 'page': ['2'],
                 'response': ['yes,no']
             },
             {
-                'access_token': ['aaaa'],
                 'page': ['2']
             },
             {
                 'fields': ['attendance_status'],
-                'access_token': ['aaaa'],
                 'page': ['2'],
                 'response': ['yes,no']
             },
             {
-                'access_token': ['aaaa']
+                'order': ['updated'],
+                'page': ['2'],
+                'scroll': ['since:1970-01-01T00:00:00.000Z']
             },
             {
-                'access_token': ['aaaa'],
                 'page': ['2']
             },
             {
                 'fields': ['attendance_status'],
-                'access_token': ['aaaa'],
                 'page': ['2'],
                 'response': ['yes,no']
             }
@@ -394,6 +282,7 @@ class TestMeetupBackend(unittest.TestCase):
         self.assertEqual(len(http_requests), len(expected))
 
         for i in range(len(expected)):
+            self.assertIn((MeetupClient.PKEY_OAUTH2, 'Bearer aaaa'), http_requests[i].headers._headers)
             self.assertDictEqual(http_requests[i].querystring, expected[i])
 
     @httpretty.activate
@@ -428,30 +317,25 @@ class TestMeetupBackend(unittest.TestCase):
         expected = [
             {
                 'fields': ['event_hosts,featured,group_topics,plain_text_description,rsvpable,series'],
-                'key': ['aaaa'],
                 'order': ['updated'],
                 'page': ['2'],
                 'scroll': ['since:2016-09-25T00:00:00.000Z'],
-                'sign': ['true'],
                 'status': ['cancelled,upcoming,past,proposed,suggested']
             },
             {
-                'key': ['aaaa'],
-                'page': ['2'],
-                'sign': ['true']
+                'page': ['2']
             },
             {
                 'fields': ['attendance_status'],
-                'key': ['aaaa'],
                 'page': ['2'],
-                'response': ['yes,no'],
-                'sign': ['true']
+                'response': ['yes,no']
             }
         ]
 
         self.assertEqual(len(http_requests), len(expected))
 
         for i in range(len(expected)):
+            self.assertIn((MeetupClient.PKEY_OAUTH2, 'Bearer aaaa'), http_requests[i].headers._headers)
             self.assertDictEqual(http_requests[i].querystring, expected[i])
 
     @httpretty.activate
@@ -487,58 +371,46 @@ class TestMeetupBackend(unittest.TestCase):
         expected = [
             {
                 'fields': ['event_hosts,featured,group_topics,plain_text_description,rsvpable,series'],
-                'key': ['aaaa'],
                 'order': ['updated'],
                 'page': ['2'],
                 'scroll': ['since:1970-01-01T00:00:00.000Z'],
-                'sign': ['true'],
                 'status': ['cancelled,upcoming,past,proposed,suggested']
             },
             {
-                'key': ['aaaa'],
-                'page': ['2'],
-                'sign': ['true']
+                'page': ['2']
             },
             {
                 'fields': ['attendance_status'],
-                'key': ['aaaa'],
                 'page': ['2'],
-                'response': ['yes,no'],
-                'sign': ['true']
+                'response': ['yes,no']
             },
             {
-                'key': ['aaaa'],
-                'page': ['2'],
-                'sign': ['true']
+                'page': ['2']
             },
             {
                 'fields': ['attendance_status'],
-                'key': ['aaaa'],
                 'page': ['2'],
-                'response': ['yes,no'],
-                'sign': ['true']
+                'response': ['yes,no']
             },
             {
-                'key': ['aaaa'],
-                'sign': ['true']
+                'order': ['updated'],
+                'page': ['2'],
+                'scroll': ['since:1970-01-01T00:00:00.000Z']
             },
             {
-                'key': ['aaaa'],
-                'page': ['2'],
-                'sign': ['true']
+                'page': ['2']
             },
             {
                 'fields': ['attendance_status'],
-                'key': ['aaaa'],
                 'page': ['2'],
-                'response': ['yes,no'],
-                'sign': ['true']
+                'response': ['yes,no']
             }
         ]
 
         self.assertEqual(len(http_requests), len(expected))
 
         for i in range(len(expected)):
+            self.assertIn((MeetupClient.PKEY_OAUTH2, 'Bearer aaaa'), http_requests[i].headers._headers)
             self.assertDictEqual(http_requests[i].querystring, expected[i])
 
     @httpretty.activate
@@ -571,30 +443,25 @@ class TestMeetupBackend(unittest.TestCase):
         expected = [
             {
                 'fields': ['event_hosts,featured,group_topics,plain_text_description,rsvpable,series'],
-                'key': ['aaaa'],
                 'order': ['updated'],
                 'page': ['2'],
                 'scroll': ['since:2016-04-08T00:00:00.000Z'],
-                'sign': ['true'],
                 'status': ['cancelled,upcoming,past,proposed,suggested']
             },
             {
-                'key': ['aaaa'],
-                'page': ['2'],
-                'sign': ['true']
+                'page': ['2']
             },
             {
                 'fields': ['attendance_status'],
-                'key': ['aaaa'],
                 'page': ['2'],
-                'response': ['yes,no'],
-                'sign': ['true']
+                'response': ['yes,no']
             }
         ]
 
         self.assertEqual(len(http_requests), len(expected))
 
         for i in range(len(expected)):
+            self.assertIn((MeetupClient.PKEY_OAUTH2, 'Bearer aaaa'), http_requests[i].headers._headers)
             self.assertDictEqual(http_requests[i].querystring, expected[i])
 
     @httpretty.activate
@@ -635,58 +502,46 @@ class TestMeetupBackend(unittest.TestCase):
         expected = [
             {
                 'fields': ['event_hosts,featured,group_topics,plain_text_description,rsvpable,series'],
-                'key': ['aaaa'],
                 'order': ['updated'],
                 'page': ['2'],
                 'scroll': ['since:1970-01-01T00:00:00.000Z'],
-                'sign': ['true'],
                 'status': ['cancelled,upcoming,past,proposed,suggested']
             },
             {
-                'key': ['aaaa'],
-                'page': ['2'],
-                'sign': ['true']
+                'page': ['2']
             },
             {
                 'fields': ['attendance_status'],
-                'key': ['aaaa'],
                 'page': ['2'],
-                'response': ['yes,no'],
-                'sign': ['true']
+                'response': ['yes,no']
             },
             {
-                'key': ['aaaa'],
-                'page': ['2'],
-                'sign': ['true']
+                'page': ['2']
             },
             {
                 'fields': ['attendance_status'],
-                'key': ['aaaa'],
                 'page': ['2'],
-                'response': ['yes,no'],
-                'sign': ['true']
+                'response': ['yes,no']
             },
             {
-                'key': ['aaaa'],
-                'sign': ['true']
+                'order': ['updated'],
+                'page': ['2'],
+                'scroll': ['since:1970-01-01T00:00:00.000Z']
             },
             {
-                'key': ['aaaa'],
-                'page': ['2'],
-                'sign': ['true']
+                'page': ['2']
             },
             {
                 'fields': ['attendance_status'],
-                'key': ['aaaa'],
                 'page': ['2'],
-                'response': ['yes,no'],
-                'sign': ['true']
+                'response': ['yes,no']
             }
         ]
 
         self.assertEqual(len(http_requests), len(expected))
 
         for i in range(len(expected)):
+            self.assertIn((MeetupClient.PKEY_OAUTH2, 'Bearer aaaa'), http_requests[i].headers._headers)
             self.assertDictEqual(http_requests[i].querystring, expected[i])
 
     @httpretty.activate
@@ -705,15 +560,14 @@ class TestMeetupBackend(unittest.TestCase):
         # Check requests
         expected = {
             'fields': ['event_hosts,featured,group_topics,plain_text_description,rsvpable,series'],
-            'key': ['aaaa'],
             'order': ['updated'],
             'page': ['2'],
             'scroll': ['since:2017-01-01T00:00:00.000Z'],
-            'sign': ['true'],
             'status': ['cancelled,upcoming,past,proposed,suggested']
         }
 
         self.assertEqual(len(http_requests), 1)
+        self.assertIn((MeetupClient.PKEY_OAUTH2, 'Bearer aaaa'), http_requests[0].headers._headers)
         self.assertDictEqual(http_requests[0].querystring, expected)
 
     def test_parse_json(self):
@@ -833,29 +687,6 @@ class TestMeetupCommand(unittest.TestCase):
         self.assertEqual(parsed_args.min_rate_to_sleep, 10)
         self.assertEqual(parsed_args.sleep_time, 10)
         self.assertTrue(parsed_args.filter_classified)
-        self.assertFalse(parsed_args.is_oauth_token)
-
-        args = ['sqlpass-es',
-                '--api-token', 'aaaa',
-                '--max-items', '5',
-                '--tag', 'test',
-                '--no-archive',
-                '--sleep-for-rate',
-                '--min-rate-to-sleep', '10',
-                '--sleep-time', '10',
-                '--is-oauth-token']
-
-        parsed_args = parser.parse(*args)
-        self.assertEqual(parsed_args.group, 'sqlpass-es')
-        self.assertEqual(parsed_args.api_token, 'aaaa')
-        self.assertEqual(parsed_args.max_items, 5)
-        self.assertEqual(parsed_args.tag, 'test')
-        self.assertTrue(parsed_args.no_archive)
-        self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
-        self.assertTrue(parsed_args.sleep_for_rate)
-        self.assertEqual(parsed_args.min_rate_to_sleep, 10)
-        self.assertEqual(parsed_args.sleep_time, 10)
-        self.assertTrue(parsed_args.is_oauth_token)
 
 
 class TestMeetupClient(unittest.TestCase):
@@ -870,37 +701,24 @@ class TestMeetupClient(unittest.TestCase):
         """Test initialization"""
 
         client = MeetupClient('aaaa', max_items=10)
-        self.assertEqual(client.api_key, 'aaaa')
+        self.assertEqual(client.api_token, 'aaaa')
         self.assertEqual(client.max_items, 10)
         self.assertFalse(client.sleep_for_rate)
         self.assertEqual(client.min_rate_to_sleep, MIN_RATE_LIMIT)
-        self.assertFalse(client.is_oauth_token)
 
         client = MeetupClient('aaaa', max_items=10,
                               sleep_for_rate=True,
                               min_rate_to_sleep=4)
-        self.assertEqual(client.api_key, 'aaaa')
+        self.assertEqual(client.api_token, 'aaaa')
         self.assertEqual(client.max_items, 10)
         self.assertTrue(client.sleep_for_rate)
         self.assertEqual(client.min_rate_to_sleep, 4)
-        self.assertFalse(client.is_oauth_token)
 
         # Max rate limit is never overtaken
         client = MeetupClient('aaaa', max_items=10,
                               sleep_for_rate=True,
                               min_rate_to_sleep=100000000)
         self.assertEqual(client.min_rate_to_sleep, client.MAX_RATE_LIMIT)
-        self.assertFalse(client.is_oauth_token)
-
-    def test_init_oauth_token(self):
-        """Test initialization with an oauth token"""
-
-        client = MeetupClient('aaaa', is_oauth_token=True, max_items=10)
-        self.assertEqual(client.api_key, 'aaaa')
-        self.assertEqual(client.max_items, 10)
-        self.assertFalse(client.sleep_for_rate)
-        self.assertEqual(client.min_rate_to_sleep, MIN_RATE_LIMIT)
-        self.assertTrue(client.is_oauth_token)
 
     @httpretty.activate
     def test_group_gone(self):
@@ -951,16 +769,15 @@ class TestMeetupClient(unittest.TestCase):
         expected = [
             {
                 'fields': ['event_hosts,featured,group_topics,plain_text_description,rsvpable,series'],
-                'key': ['aaaa'],
                 'order': ['updated'],
                 'page': ['2'],
                 'scroll': ['since:2016-01-01T00:00:00.000Z'],
-                'sign': ['true'],
                 'status': ['cancelled,upcoming,past,proposed,suggested']
             },
             {
-                'key': ['aaaa'],
-                'sign': ['true']
+                'order': ['updated'],
+                'page': ['2'],
+                'scroll': ['since:2016-01-01T00:00:00.000Z']
             }
         ]
 
@@ -970,44 +787,7 @@ class TestMeetupClient(unittest.TestCase):
             req = http_requests[x]
             self.assertEqual(req.method, 'GET')
             self.assertRegex(req.path, '/sqlpass-es/events')
-            self.assertDictEqual(req.querystring, expected[x])
-
-    @httpretty.activate
-    def test_events_oauth_token(self):
-        """Test events API call with oauth token"""
-
-        http_requests = setup_http_server()
-
-        client = MeetupClient('aaaa', is_oauth_token=True, max_items=2)
-
-        from_date = datetime.datetime(2016, 1, 1)
-
-        # Call API
-        events = client.events('sqlpass-es', from_date=from_date)
-        result = [event for event in events]
-
-        self.assertEqual(len(result), 2)
-
-        expected = [
-            {
-                'fields': ['event_hosts,featured,group_topics,plain_text_description,rsvpable,series'],
-                'access_token': ['aaaa'],
-                'order': ['updated'],
-                'page': ['2'],
-                'scroll': ['since:2016-01-01T00:00:00.000Z'],
-                'status': ['cancelled,upcoming,past,proposed,suggested']
-            },
-            {
-                'access_token': ['aaaa']
-            }
-        ]
-
-        self.assertEqual(len(http_requests), 2)
-
-        for x in range(0, len(http_requests)):
-            req = http_requests[x]
-            self.assertEqual(req.method, 'GET')
-            self.assertRegex(req.path, '/sqlpass-es/events')
+            self.assertIn((MeetupClient.PKEY_OAUTH2, 'Bearer aaaa'), req.headers._headers)
             self.assertDictEqual(req.querystring, expected[x])
 
     @httpretty.activate
@@ -1025,34 +805,6 @@ class TestMeetupClient(unittest.TestCase):
         self.assertEqual(len(result), 1)
 
         expected = {
-            'key': ['aaaa'],
-            'page': ['2'],
-            'sign': ['true']
-        }
-
-        self.assertEqual(len(http_requests), 1)
-
-        req = http_requests[0]
-        self.assertEqual(req.method, 'GET')
-        self.assertRegex(req.path, '/sqlpass-es/events/1/comments')
-        self.assertDictEqual(req.querystring, expected)
-
-    @httpretty.activate
-    def test_comments_oauth_token(self):
-        """Test comments API call with oauth token"""
-
-        http_requests = setup_http_server()
-
-        client = MeetupClient('aaaa', is_oauth_token=True, max_items=2)
-
-        # Call API
-        comments = client.comments('sqlpass-es', '1')
-        result = [comment for comment in comments]
-
-        self.assertEqual(len(result), 1)
-
-        expected = {
-            'access_token': ['aaaa'],
             'page': ['2']
         }
 
@@ -1061,6 +813,7 @@ class TestMeetupClient(unittest.TestCase):
         req = http_requests[0]
         self.assertEqual(req.method, 'GET')
         self.assertRegex(req.path, '/sqlpass-es/events/1/comments')
+        self.assertIn((MeetupClient.PKEY_OAUTH2, 'Bearer aaaa'), req.headers._headers)
         self.assertDictEqual(req.querystring, expected)
 
     @httpretty.activate
@@ -1079,36 +832,6 @@ class TestMeetupClient(unittest.TestCase):
 
         expected = {
             'fields': ['attendance_status'],
-            'key': ['aaaa'],
-            'page': ['2'],
-            'response': ['yes,no'],
-            'sign': ['true']
-        }
-
-        self.assertEqual(len(http_requests), 1)
-
-        req = http_requests[0]
-        self.assertEqual(req.method, 'GET')
-        self.assertRegex(req.path, '/sqlpass-es/events/1/rsvps')
-        self.assertDictEqual(req.querystring, expected)
-
-    @httpretty.activate
-    def test_rsvps_oauth_token(self):
-        """Test rsvps API call with oauth token"""
-
-        http_requests = setup_http_server()
-
-        client = MeetupClient('aaaa', is_oauth_token=True, max_items=2)
-
-        # Call API
-        rsvps = client.rsvps('sqlpass-es', '1')
-        result = [rsvp for rsvp in rsvps]
-
-        self.assertEqual(len(result), 1)
-
-        expected = {
-            'fields': ['attendance_status'],
-            'access_token': ['aaaa'],
             'page': ['2'],
             'response': ['yes,no']
         }
@@ -1118,24 +841,13 @@ class TestMeetupClient(unittest.TestCase):
         req = http_requests[0]
         self.assertEqual(req.method, 'GET')
         self.assertRegex(req.path, '/sqlpass-es/events/1/rsvps')
+        self.assertIn((MeetupClient.PKEY_OAUTH2, 'Bearer aaaa'), req.headers._headers)
         self.assertDictEqual(req.querystring, expected)
 
     def test_calculate_time_to_reset(self):
         """Test whether the time to reset is zero if the sleep time is negative"""
 
-        client = MockedMeetupClient('aaaa', is_oauth_token=False,
-                                    max_items=2,
-                                    min_rate_to_sleep=2,
-                                    sleep_for_rate=True)
-
-        time_to_reset = client.calculate_time_to_reset()
-        self.assertEqual(time_to_reset, 0)
-
-    def test_calculate_time_to_reset_oauth_token(self):
-        """Test whether the time to reset is zero if the sleep time is negative"""
-
-        # Rate limit headers don't differ when using oauth tokens and api keys
-        client = MockedMeetupClient('aaaa', is_oauth_token=True,
+        client = MockedMeetupClient('aaaa',
                                     max_items=2,
                                     min_rate_to_sleep=2,
                                     sleep_for_rate=True)
@@ -1169,16 +881,15 @@ class TestMeetupClient(unittest.TestCase):
         expected = [
             {
                 'fields': ['event_hosts,featured,group_topics,plain_text_description,rsvpable,series'],
-                'key': ['aaaa'],
                 'order': ['updated'],
                 'page': ['2'],
                 'scroll': ['since:1970-01-01T00:00:00.000Z'],
-                'sign': ['true'],
                 'status': ['cancelled,upcoming,past,proposed,suggested']
             },
             {
-                'key': ['aaaa'],
-                'sign': ['true']
+                'order': ['updated'],
+                'page': ['2'],
+                'scroll': ['since:1970-01-01T00:00:00.000Z']
             }
         ]
 
@@ -1188,52 +899,7 @@ class TestMeetupClient(unittest.TestCase):
             req = http_requests[x]
             self.assertEqual(req.method, 'GET')
             self.assertRegex(req.path, '/sqlpass-es/events')
-            self.assertDictEqual(req.querystring, expected[x])
-
-    @httpretty.activate
-    def test_sleep_for_rate_oauth_token(self):
-        """ Test if the clients sleeps when the rate limit is reached when using an oauth token"""
-
-        wait_to_reset = 1
-
-        http_requests = setup_http_server(rate_limit=0,
-                                          reset_rate_limit=wait_to_reset)
-
-        client = MeetupClient('aaaa', is_oauth_token=True,
-                              max_items=2,
-                              min_rate_to_sleep=2,
-                              sleep_for_rate=True)
-
-        # Call API
-        before = float(time.time())
-        events = client.events('sqlpass-es')
-        results = [event for event in events]
-        after = float(time.time())
-        diff = after - before
-
-        self.assertGreaterEqual(diff, wait_to_reset)
-        self.assertEqual(len(results), 2)
-
-        expected = [
-            {
-                'fields': ['event_hosts,featured,group_topics,plain_text_description,rsvpable,series'],
-                'access_token': ['aaaa'],
-                'order': ['updated'],
-                'page': ['2'],
-                'scroll': ['since:1970-01-01T00:00:00.000Z'],
-                'status': ['cancelled,upcoming,past,proposed,suggested']
-            },
-            {
-                'access_token': ['aaaa']
-            }
-        ]
-
-        self.assertEqual(len(http_requests), 2)
-
-        for x in range(0, len(http_requests)):
-            req = http_requests[x]
-            self.assertEqual(req.method, 'GET')
-            self.assertRegex(req.path, '/sqlpass-es/events')
+            self.assertIn((MeetupClient.PKEY_OAUTH2, 'Bearer aaaa'), req.headers._headers)
             self.assertDictEqual(req.querystring, expected[x])
 
     @httpretty.activate
@@ -1253,39 +919,6 @@ class TestMeetupClient(unittest.TestCase):
 
         expected = {
             'fields': ['event_hosts,featured,group_topics,plain_text_description,rsvpable,series'],
-            'key': ['aaaa'],
-            'order': ['updated'],
-            'page': ['2'],
-            'scroll': ['since:1970-01-01T00:00:00.000Z'],
-            'sign': ['true'],
-            'status': ['cancelled,upcoming,past,proposed,suggested']
-        }
-
-        self.assertEqual(len(http_requests), 1)
-
-        req = http_requests[0]
-        self.assertEqual(req.method, 'GET')
-        self.assertRegex(req.path, '/sqlpass-es/events')
-        self.assertDictEqual(req.querystring, expected)
-
-    @httpretty.activate
-    def test_rate_limit_error_oauth_token(self):
-        """Test if a rate limit error is raised when rate is exhausted for the oauth token"""
-
-        http_requests = setup_http_server(rate_limit=0,
-                                          reset_rate_limit=1)
-
-        client = MeetupClient('aaaa', is_oauth_token=True, max_items=2)
-
-        # Call API
-        events = client.events('sqlpass-es')
-
-        with self.assertRaises(RateLimitError):
-            _ = [event for event in events]
-
-        expected = {
-            'fields': ['event_hosts,featured,group_topics,plain_text_description,rsvpable,series'],
-            'access_token': ['aaaa'],
             'order': ['updated'],
             'page': ['2'],
             'scroll': ['since:1970-01-01T00:00:00.000Z'],
@@ -1297,6 +930,7 @@ class TestMeetupClient(unittest.TestCase):
         req = http_requests[0]
         self.assertEqual(req.method, 'GET')
         self.assertRegex(req.path, '/sqlpass-es/events')
+        self.assertIn((MeetupClient.PKEY_OAUTH2, 'Bearer aaaa'), req.headers._headers)
         self.assertDictEqual(req.querystring, expected)
 
     @httpretty.activate
@@ -1322,37 +956,18 @@ class TestMeetupClient(unittest.TestCase):
         """Test whether the sanitize method works properly"""
 
         url = "http://example.com"
-        headers = "headers-information"
-        payload = {
-            'page': 2,
-            'sign': ('true',),
-            'order': 'updated',
-            'scroll': 'since:2016-01-01T00:00:00.000Z',
-            'key': 'aaaa'
+        headers = {
+            MeetupClient.PKEY_OAUTH2: 'Bear aaaa'
         }
 
-        s_url, s_headers, s_payload = MeetupClient.sanitize_for_archive(url, headers, copy.deepcopy(payload))
-        payload.pop('key')
-        payload.pop('sign')
-
-        self.assertEqual(url, s_url)
-        self.assertEqual(headers, s_headers)
-        self.assertEqual(payload, s_payload)
-
-    def test_sanitize_for_archive_oauth_token(self):
-        """Test whether the sanitize method works properly when using an oauth token"""
-
-        url = "http://example.com"
-        headers = "headers-information"
         payload = {
             'page': 2,
             'order': 'updated',
-            'scroll': 'since:2016-01-01T00:00:00.000Z',
-            'access_token': 'aaaa'
+            'scroll': 'since:2016-01-01T00:00:00.000Z'
         }
 
-        s_url, s_headers, s_payload = MeetupClient.sanitize_for_archive(url, headers, copy.deepcopy(payload))
-        payload.pop('access_token')
+        s_url, s_headers, s_payload = MeetupClient.sanitize_for_archive(url, copy.deepcopy(headers), payload)
+        headers.pop(MeetupClient.PKEY_OAUTH2)
 
         self.assertEqual(url, s_url)
         self.assertEqual(headers, s_headers)


### PR DESCRIPTION
This PR tackles https://github.com/chaoss/grimoirelab-perceval/issues/567.

The oauth2 token was passed as payload of the requests when issuing petitions to the Meetup API. This was causing a potential security leak for failing petitions, since the URL with the corresponding payload was fully exposed.

Now the token is passed through the headers, which are then sanitized before storing them to the archive.

Since API tokens have been decommissioned in favor of oauth2 token, API token support has been removed from the backend.

Tests have been changed accordingly.
Backend version is now 0.15.0.