### PR TITLE
[perceval] Include summary of fetch executions

### DIFF
--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -75,6 +75,14 @@ class Backend:
     Classified data filtering and archiving are not compatible to prevent
     data leaks or security issues.
 
+    Each fetch operation generates a summary, available via the property
+    `summary`. By default, it includes the last UUID generated, number
+    of items fetched, skipped and their sum, plus the min, max and last
+    updated_on times. Furthermore, for backends using offsets, the
+    corresponding summary contains the min and max offsets retrieved. Finally,
+    the summary also includes some extra fields, which can be used by any
+    backend to include fetch-specific information.
+
     :param origin: identifier of the repository
     :param tag: tag items using this label
     :param archive: archive to store/retrieve data
@@ -82,7 +90,7 @@ class Backend:
     :raises ValueError: raised when `archive` is not an instance of
         `Archive` class
     """
-    version = '0.8.0'
+    version = '0.9.0'
 
     CATEGORIES = []
     CLASSIFIED_FIELDS = []
@@ -91,10 +99,15 @@ class Backend:
         self._origin = origin
         self.tag = tag if tag else origin
         self.archive = archive or None
+        self._summary = None
 
     @property
     def origin(self):
         return self._origin
+
+    @property
+    def summary(self):
+        return self._summary
 
     @property
     def archive(self):
@@ -145,6 +158,8 @@ class Backend:
         :raises BackendError: either when the category is not valid or
             'filter_classified' and 'archive' are active at the same time.
         """
+        self._summary = Summary()
+
         if category not in self.categories:
             cause = "%s category not valid for %s" % (category, self.__class__.__name__)
             raise BackendError(cause=cause)
@@ -163,7 +178,10 @@ class Backend:
             if filter_classified:
                 item = self.filter_classified_data(item)
 
-            yield self.metadata(item, filter_classified=filter_classified)
+            metadata_item = self.metadata(item, filter_classified=filter_classified)
+            self.summary.update(metadata_item)
+
+            yield metadata_item
 
     def fetch_from_archive(self):
         """Fetch the questions from an archive.
@@ -178,10 +196,14 @@ class Backend:
         if not self.archive:
             raise ArchiveError(cause="archive instance was not provided")
 
+        self._summary = Summary()
         self.client = self._init_client(from_archive=True)
 
         for item in self.fetch_items(self.archive.category, **self.archive.backend_params):
-            yield self.metadata(item)
+            metadata_item = self.metadata(item)
+            self.summary.update(metadata_item)
+
+            yield metadata_item
 
     def filter_classified_data(self, item):
         """Remove classified or confidential data from an item.
@@ -522,7 +544,6 @@ class Summary:
     includes some extra fields, which can be used by any backend
     to include fetch-specific information.
     """
-
     def __init__(self):
         self.fetched = 0
         self.skipped = 0

--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -50,7 +50,7 @@ class Backend:
     will be named as 'origin'. During the initialization, an `Archive`
     object can be provided for archiving raw data from the repositories.
 
-    Derivated classes have to implement `fetch_items`, `has_archiving` and
+    Derived classes have to implement `fetch_items`, `has_archiving` and
     `has_resuming` methods. Otherwise, `NotImplementedError`
     exception will be raised. Metadata decorator can be used together with
     fetch methods but requires the implementation of `metadata_id`,
@@ -438,15 +438,15 @@ class BackendCommand:
     """Abstract class to run backends from the command line.
 
     When the class is initialized, it parses the given arguments using
-    the defined argument parser on `setump_cmd_parser` method. Those
+    the defined argument parser on `setup_cmd_parser` method. Those
     arguments will be stored in the attribute `parsed_args`.
 
-    The arguments will be used to inizialize and run the `Backend` object
+    The arguments will be used to initialize and run the `Backend` object
     assigned to this command. The backend used to run the command is stored
     under `BACKEND` class attributed. Any class derived from this and must
     set its own `Backend` class.
 
-    Moreover, the method `setup_cmd_parser` must be implemented to exectute
+    Moreover, the method `setup_cmd_parser` must be implemented to execute
     the backend.
     """
     BACKEND = None
@@ -512,7 +512,7 @@ class BackendCommand:
         pass
 
     def _initialize_archive(self):
-        """Initialize archive based on the parsed parameters"""
+        """Initialize archive based on the parsed parameters."""
 
         if 'archive_path' not in self.parsed_args:
             manager = None
@@ -536,13 +536,14 @@ class BackendCommand:
 class BackendItemsGenerator:
     """BackendItemsGenerator class.
 
-    This class provides a generator through the `items` attribute that will fetch
-    items from any data source and/or archive in a transparent way. A summary
-    with the result of the process can be accessed via the attribute `summary`.
+    This class provides a generator through the `items` attribute that
+    will fetch items from any data source and/or archive in a transparent
+    way. A summary with the result of the process can be accessed via
+    the attribute `summary`.
 
-    To initialize an instance is necessary to pass the backend that will be used
-    to fetch data, its parameters and other useful data as the category of the items
-    to retrieve and the archive options.
+    To initialize an instance is necessary to pass the backend that will
+    be used to fetch data, its parameters and other useful data as the
+    category of the items to retrieve and the archive options.
 
     This object can also be used as a context manager.
 
@@ -662,11 +663,13 @@ class Summary:
 
     This class models the summary of a fetch execution. It includes
     the last UUID, number of items fetched, skipped and their sum,
-    plus the min, max and last updated_on times. Furthermore, for
-    backends using offsets, the corresponding summary contains the
-    min, max and last offsets retrieved. Finally, the summary also
-    includes some extra fields, which can be used by any backend
-    to include fetch-specific information.
+    plus the minimum, maximum and last updated_on times.
+
+    Furthermore, for backends using offsets, the corresponding summary
+    contains the minimum, maximum and last offsets retrieved.
+
+    Finally, the summary also includes some extra fields, which can
+    be used by any backend to include fetch-specific information.
     """
     def __init__(self):
         self.fetched = 0
@@ -682,10 +685,12 @@ class Summary:
 
     @property
     def total(self):
+        """Number of items retrieved. This includes fetched and skipped items."""
+
         return self.fetched + self.skipped
 
     def update(self, item):
-        """Update the summary attributes by accessing the item data
+        """Update the summary attributes by accessing the item data.
 
         :param item: a Perceval item
         """

--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -550,14 +550,16 @@ class BackendItemsGenerator:
     :param backend_args: dict of arguments needed to fetch the items
     :param category: category of the items to retrieve
        If None, it will use the default backend category
+    :param filter_classified: remove classified fields from the
+        resulting items. Note that filter classified is not supported
+        for archived items.
     :param manager: archive manager where the items will be retrieved
     :param fetch_archive: If enabled, items are fetched from archives
-    :param filter_classified: remove classified fields from the resulting items. Note that
-        filter classified is not supported for archived items.
     :param archived_after: return items archived after this date
     """
-    def __init__(self, backend_class, backend_args, category, manager=None,
-                 fetch_archive=False, filter_classified=False, archived_after=None):
+    def __init__(self, backend_class, backend_args, category,
+                 filter_classified=False, manager=None,
+                 fetch_archive=False, archived_after=None):
         init_args = find_signature_parameters(backend_class.__init__,
                                               backend_args)
 
@@ -565,10 +567,12 @@ class BackendItemsGenerator:
             archive = manager.create_archive() if manager else None
             init_args['archive'] = archive
             self.backend = backend_class(**init_args)
-            items = self.__fetch(backend_args, category, filter_classified, manager)
+            items = self.__fetch(backend_args, category,
+                                 filter_classified=filter_classified,
+                                 manager=manager)
         else:
             self.backend = backend_class(**init_args)
-            items = self.__fetch_from_archive(manager, category, archived_after)
+            items = self.__fetch_from_archive(category, manager, archived_after)
 
         self.items = items
 
@@ -590,17 +594,18 @@ class BackendItemsGenerator:
         """Fetch items using the given backend.
 
         Generator to get items using the backend. When an archive manager
-        is given, this function will store the fetched items in an
-        `Archive`. If an exception is raised, this archive will be
-        removed to avoid corrupted archives.
+        is given, this function will store the fetched items in an `Archive`.
+        If an exception is raised, this archive will be removed to avoid
+        corrupted archives.
 
         The parameters needed to get the items are given using the
         `backend_args` dict parameter.
 
         :param backend_args: dict of arguments needed to fetch the items
         :param category: category of the items to retrieve.
-           If None, it will use the default backend category
-        :param filter_classified: remove classified fields from the resulting items
+            If None, it will use the default backend category
+        :param filter_classified: remove classified fields from the resulting
+            items
         :param manager: archive manager needed to store the items
 
         :returns: a generator of items
@@ -623,15 +628,15 @@ class BackendItemsGenerator:
                 manager.remove_archive(archive_path)
             raise e
 
-    def __fetch_from_archive(self, manager, category, archived_after):
+    def __fetch_from_archive(self, category, manager, archived_after):
         """Fetch items from an archive manager.
 
         Generator to get the items of a category (previously fetched
         by the backend) from an archive manager. Only those items
         archived after the given date will be returned.
 
-        :param manager: archive manager where the items will be retrieved
         :param category: category of the items to retrieve
+        :param manager: archive manager where the items will be retrieved
         :param archived_after: return items archived after this date
 
         :returns: a generator of archived items

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -42,6 +42,7 @@ from perceval.archive import Archive, ArchiveManager
 from perceval.backend import (Backend,
                               BackendCommandArgumentParser,
                               BackendCommand,
+                              BackendItemsGenerator,
                               Summary,
                               uuid,
                               fetch,
@@ -1439,7 +1440,6 @@ class TestBackendItemsGenerator(unittest.TestCase):
             self.assertIsNone(summary.max_offset)
 
 
->>>>>>> 08dcd13... x
 class TestSummary(unittest.TestCase):
     """Unit tests for Summary"""
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -42,6 +42,7 @@ from perceval.archive import Archive, ArchiveManager
 from perceval.backend import (Backend,
                               BackendCommandArgumentParser,
                               BackendCommand,
+                              Summary,
                               uuid,
                               fetch,
                               fetch_from_archive,
@@ -312,6 +313,25 @@ class TestBackend(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             b.archive = 8
+
+    def test_summary(self):
+        """Test whether the summary is properly calculated"""
+
+        b = MockedBackend('test')
+
+        _ = [item for item in b.fetch()]
+
+        self.assertEqual(b.summary.fetched, 5)
+        self.assertIsNone(b.summary.extras)
+        self.assertIsNone(b.summary.min_offset)
+        self.assertIsNone(b.summary.max_offset)
+        self.assertIsNone(b.summary.last_offset)
+        self.assertEqual(b.summary.min_updated_on.isoformat(), '2016-01-01T00:00:00+00:00')
+        self.assertEqual(b.summary.max_updated_on.isoformat(), '2016-01-01T00:00:00+00:00')
+        self.assertEqual(b.summary.last_updated_on.isoformat(), '2016-01-01T00:00:00+00:00')
+        self.assertEqual(b.summary.last_uuid, '82475202a5efc42c75add425c47ac032340f4f3d')
+        self.assertEqual(b.summary.skipped, 0)
+        self.assertEqual(b.summary.total, 5)
 
     def test_init_archive(self):
         """Test whether the archive is properly initialized when executing the fetch method"""
@@ -1121,6 +1141,445 @@ class TestBackendCommand(unittest.TestCase):
                 },
             }
             self.assertDictEqual(item['data'], expected)
+
+
+class TestBackendItemsGenerator(unittest.TestCase):
+    """Unit tests for BackendItemsGenerator"""
+
+    def setUp(self):
+        self.test_path = tempfile.mkdtemp(prefix='perceval_')
+
+    def tearDown(self):
+        shutil.rmtree(self.test_path)
+
+    def test_init_items(self):
+        """Test whether a set of items is returned"""
+
+        category = 'mock_item'
+        args = {
+            'origin': 'http://example.com/',
+            'tag': 'test',
+            'subtype': 'mocksubtype',
+            'from-date': str_to_datetime('2015-01-01')
+        }
+
+        with BackendItemsGenerator(CommandBackend, args, category, manager=None) as big:
+            self.assertIsInstance(big, BackendItemsGenerator)
+            items = [item for item in big.items]
+
+            self.assertEqual(big.backend.origin, args['origin'])
+            self.assertEqual(big.backend.tag, args['tag'])
+            self.assertEqual(len(items), 5)
+
+        for x in range(5):
+            item = items[x]
+            expected_uuid = uuid('http://example.com/', str(x))
+
+            self.assertEqual(item['data']['item'], x)
+            self.assertEqual(item['origin'], 'http://example.com/')
+            self.assertEqual(item['uuid'], expected_uuid)
+            self.assertEqual(item['tag'], 'test')
+            self.assertEqual(item['classified_fields_filtered'], None)
+
+    def test_init_items_from_archive(self):
+        """Test whether a set of items is fetched from the archive"""
+
+        manager = ArchiveManager(self.test_path)
+
+        category = 'mock_item'
+        args = {
+            'origin': 'http://example.com/',
+            'tag': 'test',
+            'subtype': 'mocksubtype',
+            'from-date': str_to_datetime('2015-01-01')
+        }
+
+        with BackendItemsGenerator(CommandBackend, args, category, manager=manager) as big:
+            self.assertIsInstance(big, BackendItemsGenerator)
+            items = [item for item in big.items]
+            self.assertEqual(big.backend.origin, args['origin'])
+            self.assertEqual(big.backend.tag, args['tag'])
+            self.assertEqual(len(items), 5)
+
+        with BackendItemsGenerator(CommandBackend, args, category, manager=manager) as big:
+            self.assertIsInstance(big, BackendItemsGenerator)
+            items = [item for item in big.items]
+            self.assertEqual(big.backend.origin, args['origin'])
+            self.assertEqual(big.backend.tag, args['tag'])
+            self.assertEqual(len(items), 5)
+
+        with BackendItemsGenerator(CommandBackend, args, category, fetch_archive=True, manager=manager,
+                                   archived_after=str_to_datetime('1970-01-01')) as big:
+            self.assertIsInstance(big, BackendItemsGenerator)
+            items = [item for item in big.items]
+
+        self.assertEqual(len(items), 10)
+
+        for x in range(2):
+            for y in range(5):
+                item = items[y + (x * 5)]
+                expected_uuid = uuid('http://example.com/', str(y))
+
+                self.assertEqual(item['data']['item'], y)
+                self.assertEqual(item['data']['archive'], True)
+                self.assertEqual(item['origin'], 'http://example.com/')
+                self.assertEqual(item['uuid'], expected_uuid)
+                self.assertEqual(item['tag'], 'test')
+                self.assertEqual(item['classified_fields_filtered'], None)
+
+    def test_init_items_from_archive_after(self):
+        """Test if only those items archived after a date are returned"""
+
+        manager = ArchiveManager(self.test_path)
+
+        category = 'mock_item'
+        args = {
+            'origin': 'http://example.com/',
+            'tag': 'test',
+            'subtype': 'mocksubtype',
+            'from-date': str_to_datetime('2015-01-01')
+        }
+
+        with BackendItemsGenerator(CommandBackend, args, category, manager=manager) as big:
+            self.assertIsInstance(big, BackendItemsGenerator)
+            items = [item for item in big.items]
+            self.assertEqual(big.backend.origin, args['origin'])
+            self.assertEqual(big.backend.tag, args['tag'])
+            self.assertEqual(len(items), 5)
+
+        archived_dt = datetime_utcnow()
+
+        with BackendItemsGenerator(CommandBackend, args, category, manager=manager) as big:
+            self.assertIsInstance(big, BackendItemsGenerator)
+            items = [item for item in big.items]
+            self.assertEqual(big.backend.origin, args['origin'])
+            self.assertEqual(big.backend.tag, args['tag'])
+            self.assertEqual(len(items), 5)
+
+        # Fetch items from the archive
+        with BackendItemsGenerator(CommandBackend, args, category, fetch_archive=True, manager=manager,
+                                   archived_after=str_to_datetime('1970-01-01')) as big:
+            self.assertIsInstance(big, BackendItemsGenerator)
+            items = [item for item in big.items]
+            self.assertEqual(big.backend.origin, args['origin'])
+            self.assertEqual(big.backend.tag, args['tag'])
+            self.assertEqual(len(items), 10)
+
+        # Fetch items archived after the given date
+        with BackendItemsGenerator(CommandBackend, args, category, fetch_archive=True, manager=manager,
+                                   archived_after=archived_dt) as big:
+            self.assertIsInstance(big, BackendItemsGenerator)
+            items = [item for item in big.items]
+            self.assertEqual(len(items), 5)
+
+    def test_init_items_filter_classified_fields(self):
+        """Test whether classified fields are removed from the items"""
+
+        category = 'mock_item'
+        args = {
+            'origin': 'http://example.com/',
+            'tag': 'test',
+            'subtype': 'mocksubtype',
+            'from-date': str_to_datetime('2015-01-01')
+        }
+
+        with BackendItemsGenerator(ClassifiedFieldsBackend, args, category,
+                                   filter_classified=True, manager=None) as big:
+            items = [item for item in big.items]
+
+        self.assertEqual(len(items), 5)
+
+        for x in range(5):
+            item = items[x]
+
+            expected_uuid = uuid('http://example.com/', str(x))
+            self.assertEqual(item['origin'], 'http://example.com/')
+            self.assertEqual(item['uuid'], expected_uuid)
+            self.assertEqual(item['tag'], 'test')
+            self.assertEqual(item['classified_fields_filtered'],
+                             ['my.classified.field', 'classified'])
+
+            # Fields in CLASSIFIED_FIELDS are deleted
+            expected = {
+                'category': 'mock_item',
+                'item': x,
+                'my': {
+                    'classified': {},
+                    'field': x,
+                }
+            }
+            self.assertDictEqual(item['data'], expected)
+
+    def test_init_archive_on_error(self):
+        """Test whether an archive is removed when an unhandled exception occurs"""
+
+        manager = ArchiveManager(self.test_path)
+
+        category = 'mock_item'
+        args = {
+            'origin': 'http://example.com/',
+            'tag': 'test',
+            'subtype': 'mocksubtype',
+            'from-date': str_to_datetime('2015-01-01')
+        }
+
+        with self.assertRaises(BackendError):
+            big = BackendItemsGenerator(ErrorCommandBackend, args, category, manager=manager)
+            _ = [item for item in big.items]
+
+        filepaths = manager.search('http://example.com/', 'ErrorCommandBackend',
+                                   'mock_item', str_to_datetime('1970-01-01'))
+
+        self.assertEqual(len(filepaths), 0)
+
+    def test_init_no_archived_items(self):
+        """Test when no archived items are available"""
+
+        manager = ArchiveManager(self.test_path)
+
+        category = 'mock_item'
+        args = {
+            'origin': 'http://example.com/',
+            'tag': 'test',
+            'subtype': 'mocksubtype',
+            'from-date': str_to_datetime('2015-01-01')
+        }
+
+        with BackendItemsGenerator(CommandBackend, args, category, manager=manager) as big:
+            items = [item for item in big.items]
+
+        self.assertEqual(len(items), 5)
+
+        # There aren't items for this category
+        with BackendItemsGenerator(CommandBackend, args, 'alt_item', manager=manager,
+                                   archived_after=str_to_datetime('1970-01-01'), fetch_archive=True) as big:
+            items = [item for item in big.items]
+            self.assertEqual(len(items), 0)
+
+    def test_init_ignore_corrupted_archive(self):
+        """Check if a corrupted archive is ignored while fetching from archive"""
+
+        def delete_rows(db, table_name):
+            conn = sqlite3.connect(db)
+            cursor = conn.cursor()
+            cursor.execute("DELETE FROM " + table_name)
+            cursor.close()
+            conn.commit()
+
+        manager = ArchiveManager(self.test_path)
+
+        category = 'mock_item'
+        args = {
+            'origin': 'http://example.com/',
+            'tag': 'test',
+            'subtype': 'mocksubtype',
+            'from-date': str_to_datetime('2015-01-01')
+        }
+
+        # First, fetch the items twice to check if several archive
+        # are used
+        with BackendItemsGenerator(CommandBackend, args, category, manager=manager) as big:
+            items = [item for item in big.items]
+            self.assertEqual(len(items), 5)
+
+        with BackendItemsGenerator(CommandBackend, args, category, manager=manager) as big:
+            items = [item for item in big.items]
+            self.assertEqual(len(items), 5)
+
+        # Find archive names to delete the rows of one of them to make it
+        # corrupted
+        filepaths = manager.search('http://example.com/', 'CommandBackend',
+                                   category, str_to_datetime('1970-01-01'))
+        self.assertEqual(len(filepaths), 2)
+
+        to_remove = filepaths[0]
+        delete_rows(to_remove, 'archive')
+
+        # Fetch items from the archive
+        with BackendItemsGenerator(CommandBackend, args, category, manager=manager,
+                                   archived_after=str_to_datetime('1970-01-01'), fetch_archive=True) as big:
+            items = [item for item in big.items]
+            self.assertEqual(len(items), 5)
+
+        for x in range(5):
+            item = items[x]
+            expected_uuid = uuid('http://example.com/', str(x))
+
+            self.assertEqual(item['data']['item'], x)
+            self.assertEqual(item['data']['archive'], True)
+            self.assertEqual(item['origin'], 'http://example.com/')
+            self.assertEqual(item['uuid'], expected_uuid)
+            self.assertEqual(item['tag'], 'test')
+            self.assertEqual(item['classified_fields_filtered'], None)
+
+    def test_summary(self):
+        """Test whether the method summary properly works"""
+
+        category = 'mock_item'
+        args = {
+            'origin': 'http://example.com/',
+            'tag': 'test',
+            'subtype': 'mocksubtype',
+            'from-date': str_to_datetime('2015-01-01')
+        }
+
+        with BackendItemsGenerator(CommandBackend, args, category, manager=None) as big:
+            self.assertIsInstance(big, BackendItemsGenerator)
+            _ = [item for item in big.items]
+
+            summary = big.summary
+            self.assertEqual(summary.fetched, 5)
+            self.assertEqual(summary.skipped, 0)
+            self.assertEqual(summary.total, 5)
+            self.assertEqual(summary.min_updated_on.timestamp(), 1451606400.0)
+            self.assertEqual(summary.max_updated_on.timestamp(), 1451606400.0)
+            self.assertEqual(summary.last_updated_on.timestamp(), 1451606400.0)
+            self.assertEqual(summary.last_uuid, "6130c145435d661565bd7d402be403bea7cfb6b5")
+            self.assertIsNone(summary.min_offset)
+            self.assertIsNone(summary.max_offset)
+
+
+>>>>>>> 08dcd13... x
+class TestSummary(unittest.TestCase):
+    """Unit tests for Summary"""
+
+    def test_init(self):
+        """Test whether the attributes are correctly initialized"""
+
+        summary = Summary()
+
+        self.assertEqual(summary.fetched, 0)
+        self.assertEqual(summary.skipped, 0)
+        self.assertEqual(summary.total, 0)
+        self.assertIsNone(summary.min_updated_on)
+        self.assertIsNone(summary.max_updated_on)
+        self.assertIsNone(summary.last_updated_on)
+        self.assertIsNone(summary.last_uuid)
+        self.assertIsNone(summary.min_offset)
+        self.assertIsNone(summary.max_offset)
+        self.assertIsNone(summary.last_offset)
+        self.assertIsNone(summary.extras)
+
+    def test_update(self):
+        """Test whether the method update properly works"""
+
+        items = [
+            {
+                "updated_on": 1483228800.0,
+                "uuid": "0fa16dc4edab9130a14914a8d797f634d13b4ff4"
+            },
+            {
+                "updated_on": 1483228900.0,
+                "uuid": "0fa16dc4edab9130a14914a8d797f634d13b4aa4"
+            },
+            {
+                "updated_on": 1483228700.0,
+                "uuid": "0fa16dc4edab9130a14914a8d797f634d13b4bb4"
+            }
+        ]
+
+        summary = Summary()
+
+        item = items[0]
+        summary.update(item)
+        self.assertEqual(summary.fetched, 1)
+        self.assertEqual(summary.skipped, 0)
+        self.assertEqual(summary.total, 1)
+        self.assertEqual(summary.min_updated_on.timestamp(), 1483228800.0)
+        self.assertEqual(summary.max_updated_on.timestamp(), 1483228800.0)
+        self.assertEqual(summary.last_updated_on.timestamp(), 1483228800.0)
+        self.assertEqual(summary.last_uuid, "0fa16dc4edab9130a14914a8d797f634d13b4ff4")
+        self.assertIsNone(summary.min_offset)
+        self.assertIsNone(summary.max_offset)
+        self.assertIsNone(summary.last_offset)
+
+        item = items[1]
+        summary.update(item)
+        self.assertEqual(summary.fetched, 2)
+        self.assertEqual(summary.skipped, 0)
+        self.assertEqual(summary.total, 2)
+        self.assertEqual(summary.min_updated_on.timestamp(), 1483228800.0)
+        self.assertEqual(summary.max_updated_on.timestamp(), 1483228900.0)
+        self.assertEqual(summary.last_updated_on.timestamp(), 1483228900.0)
+        self.assertEqual(summary.last_uuid, "0fa16dc4edab9130a14914a8d797f634d13b4aa4")
+        self.assertIsNone(summary.min_offset)
+        self.assertIsNone(summary.max_offset)
+        self.assertIsNone(summary.last_offset)
+
+        item = items[2]
+        summary.update(item)
+        self.assertEqual(summary.fetched, 3)
+        self.assertEqual(summary.skipped, 0)
+        self.assertEqual(summary.total, 3)
+        self.assertEqual(summary.min_updated_on.timestamp(), 1483228700.0)
+        self.assertEqual(summary.max_updated_on.timestamp(), 1483228900.0)
+        self.assertEqual(summary.last_updated_on.timestamp(), 1483228700.0)
+        self.assertEqual(summary.last_uuid, "0fa16dc4edab9130a14914a8d797f634d13b4bb4")
+        self.assertIsNone(summary.min_offset)
+        self.assertIsNone(summary.max_offset)
+        self.assertIsNone(summary.last_offset)
+
+    def test_update_offset(self):
+        """Test whether the method update properly works on offset attributes"""
+
+        items = [
+            {
+                "updated_on": 1483228800.0,
+                "uuid": "0fa16dc4edab9130a14914a8d797f634d13b4ff4",
+                "offset": 0
+            },
+            {
+                "updated_on": 1483228900.0,
+                "uuid": "0fa16dc4edab9130a14914a8d797f634d13b4aa4",
+                "offset": 2
+            },
+            {
+                "updated_on": 1483228700.0,
+                "uuid": "0fa16dc4edab9130a14914a8d797f634d13b4bb4",
+                "offset": 1
+            },
+        ]
+
+        summary = Summary()
+
+        item = items[0]
+        summary.update(item)
+        self.assertEqual(summary.fetched, 1)
+        self.assertEqual(summary.skipped, 0)
+        self.assertEqual(summary.total, 1)
+        self.assertEqual(summary.min_updated_on.timestamp(), 1483228800.0)
+        self.assertEqual(summary.max_updated_on.timestamp(), 1483228800.0)
+        self.assertEqual(summary.last_updated_on.timestamp(), 1483228800.0)
+        self.assertEqual(summary.last_uuid, "0fa16dc4edab9130a14914a8d797f634d13b4ff4")
+        self.assertEqual(summary.min_offset, 0)
+        self.assertEqual(summary.max_offset, 0)
+        self.assertEqual(summary.last_offset, 0)
+
+        item = items[1]
+        summary.update(item)
+        self.assertEqual(summary.fetched, 2)
+        self.assertEqual(summary.skipped, 0)
+        self.assertEqual(summary.total, 2)
+        self.assertEqual(summary.min_updated_on.timestamp(), 1483228800.0)
+        self.assertEqual(summary.max_updated_on.timestamp(), 1483228900.0)
+        self.assertEqual(summary.last_updated_on.timestamp(), 1483228900.0)
+        self.assertEqual(summary.last_uuid, "0fa16dc4edab9130a14914a8d797f634d13b4aa4")
+        self.assertEqual(summary.min_offset, 0)
+        self.assertEqual(summary.max_offset, 2)
+        self.assertEqual(summary.last_offset, 2)
+
+        item = items[2]
+        summary.update(item)
+        self.assertEqual(summary.fetched, 3)
+        self.assertEqual(summary.skipped, 0)
+        self.assertEqual(summary.total, 3)
+        self.assertEqual(summary.min_updated_on.timestamp(), 1483228700.0)
+        self.assertEqual(summary.max_updated_on.timestamp(), 1483228900.0)
+        self.assertEqual(summary.last_updated_on.timestamp(), 1483228700.0)
+        self.assertEqual(summary.last_uuid, "0fa16dc4edab9130a14914a8d797f634d13b4bb4")
+        self.assertEqual(summary.min_offset, 0)
+        self.assertEqual(summary.max_offset, 2)
+        self.assertEqual(summary.last_offset, 1)
 
 
 class TestMetadata(unittest.TestCase):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -53,6 +53,23 @@ from perceval.utils import DEFAULT_DATETIME
 from base import TestCaseBackendArchive
 
 
+SUMMARY_LOG_REPORT = """INFO:perceval.backend:Summary of results
+
+\t   Total items: \t5
+\tItems produced: \t5
+\t Items skipped: \t0
+
+\tLast item UUID: \t6130c145435d661565bd7d402be403bea7cfb6b5
+\tLast item date: \t2016-01-01 00:00:04+00:00
+
+\tMin. item date: \t2016-01-01 00:00:00+00:00
+\tMax. item date: \t2016-01-01 00:00:04+00:00
+
+\tMin. offset: \t-\tMax. offset: \t-\tLast offset: \t-
+
+"""
+
+
 class MockedBackend(Backend):
     """Mocked backend for testing"""
 
@@ -1183,6 +1200,27 @@ class TestBackendCommand(unittest.TestCase):
                 },
             }
             self.assertDictEqual(item['data'], expected)
+
+    def test_summary_logging(self):
+        """Test if the summary is written to the log"""
+
+        args = ['-u', 'jsmith', '-p', '1234', '-t', 'abcd',
+                '--archive-path', self.test_path, '--category', MockedBackend.DEFAULT_CATEGORY,
+                '--subtype', 'mocksubtype',
+                '--from-date', '2015-01-01', '--tag', 'test',
+                '--output', self.fout_path, 'http://example.com/']
+
+        with self.assertLogs('perceval.backend', level='INFO') as cm:
+            cmd = MockedBackendCommand(*args)
+            cmd.run()
+            cmd.outfile.close()
+
+            items = [item for item in convert_cmd_output_to_json(self.fout_path)]
+
+            self.assertEqual(len(items), 5)
+
+            # The last message should be the summary output
+            self.assertEqual(cm.output[-1], SUMMARY_LOG_REPORT)
 
 
 class TestBackendItemsGenerator(unittest.TestCase):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -90,7 +90,7 @@ class MockedBackend(Backend):
 
     @staticmethod
     def metadata_updated_on(item):
-        return str_to_datetime('2016-01-01').timestamp()
+        return str_to_datetime('2016-01-01').timestamp() + item['item']
 
     @staticmethod
     def metadata_category(item):
@@ -348,8 +348,8 @@ class TestBackend(unittest.TestCase):
         self.assertIsNone(b.summary.max_offset)
         self.assertIsNone(b.summary.last_offset)
         self.assertEqual(b.summary.min_updated_on.isoformat(), '2016-01-01T00:00:00+00:00')
-        self.assertEqual(b.summary.max_updated_on.isoformat(), '2016-01-01T00:00:00+00:00')
-        self.assertEqual(b.summary.last_updated_on.isoformat(), '2016-01-01T00:00:00+00:00')
+        self.assertEqual(b.summary.max_updated_on.isoformat(), '2016-01-01T00:00:04+00:00')
+        self.assertEqual(b.summary.last_updated_on.isoformat(), '2016-01-01T00:00:04+00:00')
         self.assertEqual(b.summary.last_uuid, '82475202a5efc42c75add425c47ac032340f4f3d')
         self.assertEqual(b.summary.skipped, 0)
         self.assertEqual(b.summary.total, 5)
@@ -1479,8 +1479,8 @@ class TestBackendItemsGenerator(unittest.TestCase):
             self.assertEqual(summary.skipped, 0)
             self.assertEqual(summary.total, 5)
             self.assertEqual(summary.min_updated_on.timestamp(), 1451606400.0)
-            self.assertEqual(summary.max_updated_on.timestamp(), 1451606400.0)
-            self.assertEqual(summary.last_updated_on.timestamp(), 1451606400.0)
+            self.assertEqual(summary.max_updated_on.timestamp(), 1451606404.0)
+            self.assertEqual(summary.last_updated_on.timestamp(), 1451606404.0)
             self.assertEqual(summary.last_uuid, "6130c145435d661565bd7d402be403bea7cfb6b5")
             self.assertIsNone(summary.min_offset)
             self.assertIsNone(summary.max_offset)
@@ -1641,6 +1641,7 @@ class TestMetadata(unittest.TestCase):
             item = items[x]
 
             expected_uuid = uuid('test', str(x))
+            expected_updated_on = 1451606400.0 + item['data']['item']
 
             self.assertEqual(item['data']['item'], x)
             self.assertEqual(item['backend_name'], 'MockedBackend')
@@ -1648,7 +1649,7 @@ class TestMetadata(unittest.TestCase):
             self.assertEqual(item['perceval_version'], __version__)
             self.assertEqual(item['origin'], 'test')
             self.assertEqual(item['uuid'], expected_uuid)
-            self.assertEqual(item['updated_on'], 1451606400.0)
+            self.assertEqual(item['updated_on'], expected_updated_on)
             self.assertEqual(item['category'], 'mock_item')
             self.assertEqual(item['classified_fields_filtered'], None)
             self.assertEqual(item['tag'], 'mytag')
@@ -1667,6 +1668,7 @@ class TestMetadata(unittest.TestCase):
             item = items[x]
 
             expected_uuid = uuid('test', str(x))
+            expected_updated_on = 1451606400.0 + item['data']['item']
 
             self.assertEqual(item['data']['item'], x)
             self.assertEqual(item['backend_name'], 'MockedBackend')
@@ -1674,7 +1676,7 @@ class TestMetadata(unittest.TestCase):
             self.assertEqual(item['perceval_version'], __version__)
             self.assertEqual(item['origin'], 'test')
             self.assertEqual(item['uuid'], expected_uuid)
-            self.assertEqual(item['updated_on'], 1451606400.0)
+            self.assertEqual(item['updated_on'], expected_updated_on)
             self.assertEqual(item['category'], 'mock_item')
             self.assertEqual(item['classified_fields_filtered'], [])
             self.assertEqual(item['tag'], 'mytag')

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1250,7 +1250,8 @@ class TestBackendItemsGenerator(unittest.TestCase):
             self.assertEqual(big.backend.tag, args['tag'])
             self.assertEqual(len(items), 5)
 
-        with BackendItemsGenerator(CommandBackend, args, category, fetch_archive=True, manager=manager,
+        with BackendItemsGenerator(CommandBackend, args, category,
+                                   manager=manager, fetch_archive=True,
                                    archived_after=str_to_datetime('1970-01-01')) as big:
             self.assertIsInstance(big, BackendItemsGenerator)
             items = [item for item in big.items]
@@ -1299,7 +1300,8 @@ class TestBackendItemsGenerator(unittest.TestCase):
             self.assertEqual(len(items), 5)
 
         # Fetch items from the archive
-        with BackendItemsGenerator(CommandBackend, args, category, fetch_archive=True, manager=manager,
+        with BackendItemsGenerator(CommandBackend, args, category,
+                                   manager=manager, fetch_archive=True,
                                    archived_after=str_to_datetime('1970-01-01')) as big:
             self.assertIsInstance(big, BackendItemsGenerator)
             items = [item for item in big.items]
@@ -1308,7 +1310,8 @@ class TestBackendItemsGenerator(unittest.TestCase):
             self.assertEqual(len(items), 10)
 
         # Fetch items archived after the given date
-        with BackendItemsGenerator(CommandBackend, args, category, fetch_archive=True, manager=manager,
+        with BackendItemsGenerator(CommandBackend, args, category,
+                                   manager=manager, fetch_archive=True,
                                    archived_after=archived_dt) as big:
             self.assertIsInstance(big, BackendItemsGenerator)
             items = [item for item in big.items]
@@ -1393,8 +1396,9 @@ class TestBackendItemsGenerator(unittest.TestCase):
         self.assertEqual(len(items), 5)
 
         # There aren't items for this category
-        with BackendItemsGenerator(CommandBackend, args, 'alt_item', manager=manager,
-                                   archived_after=str_to_datetime('1970-01-01'), fetch_archive=True) as big:
+        with BackendItemsGenerator(CommandBackend, args, 'alt_item',
+                                   manager=manager, fetch_archive=True,
+                                   archived_after=str_to_datetime('1970-01-01')) as big:
             items = [item for item in big.items]
             self.assertEqual(len(items), 0)
 
@@ -1438,8 +1442,9 @@ class TestBackendItemsGenerator(unittest.TestCase):
         delete_rows(to_remove, 'archive')
 
         # Fetch items from the archive
-        with BackendItemsGenerator(CommandBackend, args, category, manager=manager,
-                                   archived_after=str_to_datetime('1970-01-01'), fetch_archive=True) as big:
+        with BackendItemsGenerator(CommandBackend, args, category,
+                                   manager=manager, fetch_archive=True,
+                                   archived_after=str_to_datetime('1970-01-01')) as big:
             items = [item for item in big.items]
             self.assertEqual(len(items), 5)
 


### PR DESCRIPTION
This PR allows to calculate and return the summary of fetch executions. By default, it includes the last UUID generated, number of items fetched, skipped and their sum, plus the min, max and last updated_on times. Furthermore, for backends using offsets, the corresponding summary contains the last, min and max offsets retrieved. Finally, the summary also includes some extra fields, which can be used by any backend to include fetch-specific information.

The summary is available through the context manager class `BackendItemsGenerator`, which initializes a backend, performs the fetch operations (i.e., fetch or fetch_from_archive) and returns a summary of the results.

Tests have been added accordingly. The backend version is now 0.9.0.