### PR TITLE
[backend] Add support for blacklisting items

### DIFF
--- a/perceval/backends/core/git.py
+++ b/perceval/backends/core/git.py
@@ -344,9 +344,10 @@ class GitCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Git argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
-                                              to_date=True)
+                                              to_date=True,
+                                              blacklist=True)
 
         # Optional arguments
         group = parser.parser.add_argument_group('Git arguments')

--- a/perceval/errors.py
+++ b/perceval/errors.py
@@ -83,3 +83,9 @@ class ParseError(BaseError):
     """Exception raised a parsing errors occurs"""
 
     message = "%(cause)s"
+    
+    
+class BackendCommandArgumentParserError(BaseError):
+    """Generic error for BackendCommandArgumentParser"""
+
+    message = "%(cause)s"


### PR DESCRIPTION
This PR extends Perceval to support the blacklisting of remote items. In a nutshell,the Namedtuple OriginUniqueField is defined to model the origin unique field (composed of a `name` and `type`). The OriginUniqueField is defined by each backend and used by the method `_skip_item` to filter
out the blacklisted items.

To showcase this approach, the github and git backends have been modified. 

An example of execution for github is the following:
```
github
chaoss
grimoirelab-perceval
--category
issue
-t
xxxxx
--sleep-for-rate
--no-archive
--from-date
2019-01-01
--blacklist-ids
394074979
```

output:
```
[2019-09-13 16:43:59,184] - Sir Perceval is on his quest.
[2019-09-13 16:44:01,546] - Skipping blacklisted item id 394074979
[2019-09-13 16:44:01,547] - Getting info for https://api.github.com/users/valeriocos
[2019-09-13 16:44:02,196] - Getting info for https://api.github.com/users/coveralls
[2019-09-13 16:44:02,855] - Getting info for https://api.github.com/users/lukaszgryglicki
{
    "backend_name": "GitHub",
    "backend_version": "0.22.2",
    "category": "issue",
    "classified_fields_filtered": null,
...
```

An example of exception is shown when using the git backend:
```
git
https://github.com/Bitergia/raistlin
--blacklist-ids
1
```

output:
```
[2019-09-19 08:33:37,418] - Sir Perceval is on his quest.
Traceback (most recent call last):
  File "/home/slimbook/Escritorio/sources/perceval/bin/perceval", line 157, in <module>
    main()
  File "/home/slimbook/Escritorio/sources/perceval/bin/perceval", line 102, in main
    cmd = klass(*args.backend_args)
  File "/home/slimbook/Escritorio/sources/perceval/perceval/backend.py", line 565, in __init__
    parser = self.setup_cmd_parser()
  File "/home/slimbook/Escritorio/sources/perceval/perceval/backends/core/git.py", line 350, in setup_cmd_parser
    blacklist=True)
  File "/home/slimbook/Escritorio/sources/perceval/perceval/backend.py", line 456, in __init__
    raise BackendCommandArgumentParserError(cause=msg)
perceval.errors.BackendCommandArgumentParserError: Origin unique field not defined for Git backend
```