### PR TITLE
[backend] Add support for blacklisting items - v3

### DIFF
--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -20,6 +20,7 @@
 #
 
 import argparse
+import collections
 import hashlib
 import importlib
 import json
@@ -42,6 +43,8 @@ logger = logging.getLogger(__name__)
 
 ARCHIVES_DEFAULT_PATH = '~/.perceval/archives/'
 DEFAULT_SEARCH_FIELD = 'item_id'
+
+OriginUniqueField = collections.namedtuple('OriginUniqueField', 'name type')
 
 
 class Backend:
@@ -118,11 +121,12 @@ class Backend:
     :raises ValueError: raised when `archive` is not an instance of
         `Archive` class
     """
-    version = '0.10.0'
+    version = '0.11.0'
 
     CATEGORIES = []
     CLASSIFIED_FIELDS = []
     EXTRA_SEARCH_FIELDS = {}
+    ORIGIN_UNIQUE_FIELD = None
 
     def __init__(self, origin, tag=None, archive=None):
         self._origin = origin
@@ -154,6 +158,10 @@ class Backend:
     @property
     def categories(self):
         return self.CATEGORIES
+
+    @property
+    def origin_unique_field(self):
+        return self.ORIGIN_UNIQUE_FIELD
 
     @property
     def classified_fields(self):

--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -379,7 +379,7 @@ class BackendCommandArgumentParser:
     types of authentication can be set during the initialization
     of the instance.
 
-    :param categories: set category argument
+    :param backend: backend object
     :param from_date: set from_date argument
     :param to_date: set to_date argument
     :param offset: set offset argument
@@ -392,20 +392,20 @@ class BackendCommandArgumentParser:
         to `True`
     """
 
-    def __init__(self, categories, from_date=False, to_date=False, offset=False,
+    def __init__(self, backend, from_date=False, to_date=False, offset=False,
                  basic_auth=False, token_auth=False, archive=False,
                  aliases=None):
         self._from_date = from_date
         self._to_date = to_date
         self._archive = archive
-        self._categories = categories
+        self._backend = backend
 
         self.aliases = aliases or {}
         self.parser = argparse.ArgumentParser()
 
         group = self.parser.add_argument_group('general arguments')
         group.add_argument('--category', dest='category',
-                           help="type of the items to fetch (%s)" % ','.join(self._categories))
+                           help="type of the items to fetch (%s)" % ','.join(self._backend.CATEGORIES))
         group.add_argument('--tag', dest='tag',
                            help="tag the items generated during the fetching process")
         group.add_argument('--filter-classified', dest='filter_classified',

--- a/perceval/backends/core/askbot.py
+++ b/perceval/backends/core/askbot.py
@@ -532,7 +532,7 @@ class AskbotCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Askbot argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               archive=True)
 

--- a/perceval/backends/core/bugzilla.py
+++ b/perceval/backends/core/bugzilla.py
@@ -354,7 +354,7 @@ class BugzillaCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Bugzilla argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               basic_auth=True,
                                               archive=True)

--- a/perceval/backends/core/bugzillarest.py
+++ b/perceval/backends/core/bugzillarest.py
@@ -460,7 +460,7 @@ class BugzillaRESTCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the BugzillaREST argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               basic_auth=True,
                                               token_auth=True,

--- a/perceval/backends/core/confluence.py
+++ b/perceval/backends/core/confluence.py
@@ -321,7 +321,7 @@ class ConfluenceCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Bugzilla argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               archive=True)
 

--- a/perceval/backends/core/discourse.py
+++ b/perceval/backends/core/discourse.py
@@ -405,7 +405,7 @@ class DiscourseCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Discourse argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               token_auth=True,
                                               archive=True)

--- a/perceval/backends/core/dockerhub.py
+++ b/perceval/backends/core/dockerhub.py
@@ -212,7 +212,7 @@ class DockerHubCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the DockerHub argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               archive=True)
 
         # Required arguments

--- a/perceval/backends/core/gerrit.py
+++ b/perceval/backends/core/gerrit.py
@@ -498,7 +498,7 @@ class GerritCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Gerrit argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               archive=True)
 

--- a/perceval/backends/core/git.py
+++ b/perceval/backends/core/git.py
@@ -344,7 +344,7 @@ class GitCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Git argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               to_date=True)
 

--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -948,7 +948,7 @@ class GitHubCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the GitHub argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               to_date=True,
                                               token_auth=False,

--- a/perceval/backends/core/gitlab.py
+++ b/perceval/backends/core/gitlab.py
@@ -86,7 +86,7 @@ class GitLab(Backend):
         of connection problems
     :param blacklist_ids: ids of items that must not be retrieved
     """
-    version = '0.10.0'
+    version = '0.10.1'
 
     CATEGORIES = [CATEGORY_ISSUE, CATEGORY_MERGE_REQUEST]
     ORIGIN_UNIQUE_FIELD = OriginUniqueField(name='iid', type=int)
@@ -256,6 +256,7 @@ class GitLab(Backend):
                 issue_id = issue['iid']
 
                 if self._skip_item(issue):
+                    self.summary.skipped += 1
                     continue
 
                 self.__init_issue_extra_fields(issue)
@@ -312,6 +313,7 @@ class GitLab(Backend):
                 merge_id = merge['iid']
 
                 if self._skip_item(merge):
+                    self.summary.skipped += 1
                     continue
 
                 # The single merge_request API call returns a more

--- a/perceval/backends/core/gitlab.py
+++ b/perceval/backends/core/gitlab.py
@@ -720,7 +720,7 @@ class GitLabCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the GitLab argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               token_auth=True,
                                               archive=True)

--- a/perceval/backends/core/gitlab.py
+++ b/perceval/backends/core/gitlab.py
@@ -35,6 +35,7 @@ from grimoirelab_toolkit.uris import urijoin
 from ...backend import (Backend,
                         BackendCommand,
                         BackendCommandArgumentParser,
+                        OriginUniqueField,
                         DEFAULT_SEARCH_FIELD)
 from ...client import HttpClient, RateLimitHandler
 from ...utils import DEFAULT_DATETIME
@@ -85,9 +86,10 @@ class GitLab(Backend):
         of connection problems
     :param blacklist_ids: ids of items that must not be retrieved
     """
-    version = '0.9.0'
+    version = '0.10.0'
 
     CATEGORIES = [CATEGORY_ISSUE, CATEGORY_MERGE_REQUEST]
+    ORIGIN_UNIQUE_FIELD = OriginUniqueField(name='iid', type=int)
 
     def __init__(self, owner=None, repository=None, api_token=None,
                  is_oauth_token=False, base_url=None, tag=None, archive=None,
@@ -253,8 +255,7 @@ class GitLab(Backend):
             for issue in issues:
                 issue_id = issue['iid']
 
-                if self.blacklist_ids and issue_id in self.blacklist_ids:
-                    logger.warning("Skipping blacklisted issue %s", issue_id)
+                if self._skip_item(issue):
                     continue
 
                 self.__init_issue_extra_fields(issue)
@@ -310,8 +311,7 @@ class GitLab(Backend):
             for merge in merges:
                 merge_id = merge['iid']
 
-                if self.blacklist_ids and merge_id in self.blacklist_ids:
-                    logger.warning("Skipping blacklisted merge request %s", merge_id)
+                if self._skip_item(merge):
                     continue
 
                 # The single merge_request API call returns a more
@@ -723,7 +723,8 @@ class GitLabCommand(BackendCommand):
         parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               token_auth=True,
-                                              archive=True)
+                                              archive=True,
+                                              blacklist=True)
 
         # GitLab options
         group = parser.parser.add_argument_group('GitLab arguments')
@@ -736,9 +737,6 @@ class GitLabCommand(BackendCommand):
                            default=MIN_RATE_LIMIT, type=int,
                            help="sleep until reset when the rate limit \
                                reaches this value")
-        group.add_argument('--blacklist-ids', dest='blacklist_ids',
-                           nargs='*', type=int,
-                           help="Ids of items that must not be retrieved.")
         group.add_argument('--is-oauth-token', dest='is_oauth_token',
                            action='store_true',
                            help="Set when using OAuth2")

--- a/perceval/backends/core/googlehits.py
+++ b/perceval/backends/core/googlehits.py
@@ -244,7 +244,7 @@ class GoogleHitsCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the GoogleHits argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               archive=True)
 
         group = parser.parser.add_argument_group('GoogleHits arguments')

--- a/perceval/backends/core/groupsio.py
+++ b/perceval/backends/core/groupsio.py
@@ -315,7 +315,7 @@ class GroupsioCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Groupsio argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True)
 
         # Optional arguments

--- a/perceval/backends/core/hyperkitty.py
+++ b/perceval/backends/core/hyperkitty.py
@@ -267,7 +267,7 @@ class HyperKittyCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the HyperKitty argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True)
 
         # Optional arguments

--- a/perceval/backends/core/jenkins.py
+++ b/perceval/backends/core/jenkins.py
@@ -28,7 +28,8 @@ from grimoirelab_toolkit.uris import urijoin
 
 from ...backend import (Backend,
                         BackendCommand,
-                        BackendCommandArgumentParser)
+                        BackendCommandArgumentParser,
+                        OriginUniqueField)
 from ...errors import BackendError
 from ...client import HttpClient
 
@@ -51,21 +52,22 @@ class Jenkins(Backend):
     :param api_token: Jenkins auth token to access the API
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
-    :param blacklist_jobs: exclude the jobs of this list while fetching
     :param detail_depth: control the detail level of the data returned by the API
     :param sleep_time: time (in seconds) to sleep in case
         of connection problems
     :param archive: collect builds already retrieved from an archive
+    :param blacklist_ids: exclude the jobs ID of this list while fetching
     """
-    version = '0.13.0'
+    version = '0.14.0'
 
     CATEGORIES = [CATEGORY_BUILD]
     EXTRA_SEARCH_FIELDS = {
         'number': ['number']
     }
+    ORIGIN_UNIQUE_FIELD = OriginUniqueField(name='url', type=str)
 
     def __init__(self, url, user=None, api_token=None, tag=None, archive=None,
-                 blacklist_jobs=None, detail_depth=DETAIL_DEPTH, sleep_time=SLEEP_TIME):
+                 detail_depth=DETAIL_DEPTH, sleep_time=SLEEP_TIME, blacklist_ids=None):
 
         if (user and not api_token) or (not user and api_token):
             msg = "Authentication method requires user and api_token"
@@ -78,7 +80,7 @@ class Jenkins(Backend):
         self.user = user
         self.api_token = api_token
         self.sleep_time = sleep_time
-        self.blacklist_jobs = blacklist_jobs
+        self.blacklist_ids = blacklist_ids
         self.detail_depth = detail_depth
 
         self.client = None
@@ -198,7 +200,7 @@ class Jenkins(Backend):
         """Init client"""
 
         return JenkinsClient(self.url, self.user, self.api_token,
-                             self.blacklist_jobs, self.detail_depth, self.sleep_time,
+                             self.blacklist_ids, self.detail_depth, self.sleep_time,
                              archive=self.archive, from_archive=from_archive)
 
 
@@ -272,14 +274,12 @@ class JenkinsCommand(BackendCommand):
 
         parser = BackendCommandArgumentParser(cls.BACKEND,
                                               token_auth=True,
-                                              archive=True)
+                                              archive=True,
+                                              blacklist=True)
 
         # Jenkins options
         group = parser.parser.add_argument_group('Jenkins arguments')
         group.add_argument('-u', '--user', dest='user', help="Jenkins user")
-        group.add_argument('--blacklist-jobs', dest='blacklist_jobs',
-                           nargs='*',
-                           help="Wrong jobs that must not be retrieved.")
 
         group.add_argument('--detail-depth', dest='detail_depth',
                            type=int, default=DETAIL_DEPTH,

--- a/perceval/backends/core/jenkins.py
+++ b/perceval/backends/core/jenkins.py
@@ -270,7 +270,7 @@ class JenkinsCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Jenkins argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               token_auth=True,
                                               archive=True)
 

--- a/perceval/backends/core/jenkins.py
+++ b/perceval/backends/core/jenkins.py
@@ -58,7 +58,7 @@ class Jenkins(Backend):
     :param archive: collect builds already retrieved from an archive
     :param blacklist_ids: exclude the jobs ID of this list while fetching
     """
-    version = '0.14.0'
+    version = '0.14.1'
 
     CATEGORIES = [CATEGORY_BUILD]
     EXTRA_SEARCH_FIELDS = {
@@ -128,11 +128,13 @@ class Jenkins(Backend):
                     logger.warning(e)
                     logger.warning("Unable to fetch builds from job %s; skipping",
                                    job['url'])
+                    self.summary.skipped += 1
                     continue
                 else:
                     raise e
 
             if not raw_builds:
+                self.summary.skipped += 1
                 continue
 
             try:
@@ -140,6 +142,7 @@ class Jenkins(Backend):
             except ValueError:
                 logger.warning("Unable to parse builds from job %s; skipping",
                                job['url'])
+                self.summary.skipped += 1
                 continue
 
             builds = builds['builds']

--- a/perceval/backends/core/jira.py
+++ b/perceval/backends/core/jira.py
@@ -417,7 +417,7 @@ class JiraCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Jira argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               basic_auth=True,
                                               archive=True)

--- a/perceval/backends/core/launchpad.py
+++ b/perceval/backends/core/launchpad.py
@@ -475,7 +475,7 @@ class LaunchpadCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Launchpad argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               archive=True,
                                               token_auth=False)

--- a/perceval/backends/core/mattermost.py
+++ b/perceval/backends/core/mattermost.py
@@ -410,7 +410,7 @@ class MattermostCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Meetup argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               token_auth=True,
                                               archive=True)

--- a/perceval/backends/core/mbox.py
+++ b/perceval/backends/core/mbox.py
@@ -331,7 +331,7 @@ class MBoxCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the MBox argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True)
 
         # Required arguments

--- a/perceval/backends/core/mediawiki.py
+++ b/perceval/backends/core/mediawiki.py
@@ -535,7 +535,7 @@ class MediaWikiCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the MediaWiki argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               archive=True)
 

--- a/perceval/backends/core/meetup.py
+++ b/perceval/backends/core/meetup.py
@@ -278,7 +278,7 @@ class MeetupCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Meetup argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               to_date=True,
                                               token_auth=True,

--- a/perceval/backends/core/nntp.py
+++ b/perceval/backends/core/nntp.py
@@ -367,7 +367,7 @@ class NNTPCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the NNTP argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               offset=True,
                                               archive=True)
 

--- a/perceval/backends/core/phabricator.py
+++ b/perceval/backends/core/phabricator.py
@@ -615,7 +615,7 @@ class PhabricatorCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Phabricator argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               token_auth=True,
                                               archive=True)

--- a/perceval/backends/core/pipermail.py
+++ b/perceval/backends/core/pipermail.py
@@ -147,7 +147,7 @@ class PipermailCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Pipermail argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True)
 
         # Optional arguments

--- a/perceval/backends/core/redmine.py
+++ b/perceval/backends/core/redmine.py
@@ -294,7 +294,7 @@ class RedmineCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Redmine argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               token_auth=True,
                                               archive=True)

--- a/perceval/backends/core/rss.py
+++ b/perceval/backends/core/rss.py
@@ -179,7 +179,7 @@ class RSSCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the RSS argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               archive=True)
 
         # Required arguments

--- a/perceval/backends/core/slack.py
+++ b/perceval/backends/core/slack.py
@@ -461,7 +461,7 @@ class SlackCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Slack argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               token_auth=True,
                                               archive=True)

--- a/perceval/backends/core/stackexchange.py
+++ b/perceval/backends/core/stackexchange.py
@@ -307,7 +307,7 @@ class StackExchangeCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the StackExchange argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               token_auth=True,
                                               archive=True)

--- a/perceval/backends/core/supybot.py
+++ b/perceval/backends/core/supybot.py
@@ -270,7 +270,7 @@ class SupybotCommand(BackendCommand):
         aliases = {
             'dirpath': 'ircdir'
         }
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               aliases=aliases)
 

--- a/perceval/backends/core/telegram.py
+++ b/perceval/backends/core/telegram.py
@@ -269,7 +269,7 @@ class TelegramCommand(BackendCommand):
         aliases = {
             'bot_token': 'api_token'
         }
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               offset=True,
                                               token_auth=True,
                                               archive=True,

--- a/perceval/backends/core/twitter.py
+++ b/perceval/backends/core/twitter.py
@@ -366,7 +366,7 @@ class TwitterCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Twitter argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               token_auth=True,
                                               archive=True)
 

--- a/perceval/errors.py
+++ b/perceval/errors.py
@@ -83,3 +83,9 @@ class ParseError(BaseError):
     """Exception raised a parsing errors occurs"""
 
     message = "%(cause)s"
+
+
+class BackendCommandArgumentParserError(BaseError):
+    """Generic error for BackendCommandArgumentParser"""
+
+    message = "%(cause)s"

--- a/tests/test_askbot.py
+++ b/tests/test_askbot.py
@@ -703,7 +703,7 @@ class TestAskbotCommand(unittest.TestCase):
 
         parser = AskbotCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Askbot.CATEGORIES)
+        self.assertEqual(parser._backend, Askbot)
 
         args = ['--tag', 'test',
                 '--from-date', '1970-01-01',

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -43,6 +43,7 @@ from perceval.backend import (Backend,
                               BackendCommandArgumentParser,
                               BackendCommand,
                               BackendItemsGenerator,
+                              OriginUniqueField,
                               Summary,
                               uuid,
                               fetch,
@@ -78,6 +79,7 @@ class MockedBackend(Backend):
     OTHER_CATEGORY = "alt_item"
     CATEGORIES = [DEFAULT_CATEGORY, OTHER_CATEGORY]
     SEARCH_FIELDS = {}
+    ORIGIN_UNIQUE_FIELD = OriginUniqueField(name='item', type=int)
     ITEMS = 5
 
     def __init__(self, origin, tag=None, archive=None):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -184,7 +184,7 @@ class MockedBackendCommand(BackendCommand):
 
     @classmethod
     def setup_cmd_parser(cls):
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               basic_auth=True,
                                               token_auth=True,
@@ -205,7 +205,7 @@ class MockedBackendCommandDefaultPrePostInit(BackendCommand):
 
     @classmethod
     def setup_cmd_parser(cls):
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               basic_auth=True,
                                               token_auth=True,
@@ -237,7 +237,7 @@ class NoArchiveBackendCommand(BackendCommand):
 
     @classmethod
     def setup_cmd_parser(cls):
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               archive=False)
         parser.parser.add_argument('origin')
@@ -714,21 +714,21 @@ class TestBackendCommandArgumentParser(unittest.TestCase):
     def test_argument_parser(self):
         """Test if an argument parser object is created on initialization"""
 
-        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND.CATEGORIES)
+        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND)
         self.assertIsInstance(parser.parser, argparse.ArgumentParser)
 
-    def test_categories(self):
-        """Test whether _categories is initialized"""
+    def test_backend(self):
+        """Test whether _backend is initialized"""
 
-        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND.CATEGORIES)
-        self.assertEqual(parser._categories, MockedBackendCommand.BACKEND.CATEGORIES)
+        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND)
+        self.assertEqual(parser._backend, MockedBackendCommand.BACKEND)
 
     def test_parse_default_args(self):
         """Test if the default configured arguments are parsed"""
 
         args = ['--tag', 'test', '--filter-classified']
 
-        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND.CATEGORIES)
+        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND)
 
         parsed_args = parser.parse(*args)
 
@@ -741,7 +741,7 @@ class TestBackendCommandArgumentParser(unittest.TestCase):
 
         args = []
 
-        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND.CATEGORIES)
+        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND)
         parsed_args = parser.parse(*args)
 
         self.assertEqual(parsed_args.filter_classified, False)
@@ -756,7 +756,7 @@ class TestBackendCommandArgumentParser(unittest.TestCase):
             'from_date': 'tag',
             'notfound': 'backend_token'
         }
-        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND,
                                               from_date=True,
                                               aliases=aliases)
 
@@ -779,7 +779,7 @@ class TestBackendCommandArgumentParser(unittest.TestCase):
     def test_parse_date_args(self):
         """Test if date parameters are parsed"""
 
-        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND,
                                               from_date=True,
                                               to_date=True)
 
@@ -830,7 +830,7 @@ class TestBackendCommandArgumentParser(unittest.TestCase):
     def test_parse_offset_arg(self):
         """Test if offset parameter is parsed"""
 
-        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND,
                                               offset=True)
 
         # Check default value
@@ -849,15 +849,15 @@ class TestBackendCommandArgumentParser(unittest.TestCase):
         """Test if date and offset arguments are incompatible"""
 
         with self.assertRaises(AttributeError):
-            _ = BackendCommandArgumentParser(MockedBackendCommand.BACKEND.CATEGORIES,
+            _ = BackendCommandArgumentParser(MockedBackendCommand.BACKEND,
                                              from_date=True,
                                              offset=True)
         with self.assertRaises(AttributeError):
-            _ = BackendCommandArgumentParser(MockedBackendCommand.BACKEND.CATEGORIES,
+            _ = BackendCommandArgumentParser(MockedBackendCommand.BACKEND,
                                              to_date=True,
                                              offset=True)
         with self.assertRaises(AttributeError):
-            _ = BackendCommandArgumentParser(MockedBackendCommand.BACKEND.CATEGORIES,
+            _ = BackendCommandArgumentParser(MockedBackendCommand.BACKEND,
                                              from_date=True,
                                              to_date=True,
                                              offset=True)
@@ -867,7 +867,7 @@ class TestBackendCommandArgumentParser(unittest.TestCase):
 
         args = ['-u', 'jsmith', '-p', '1234', '-t', 'abcd']
 
-        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND,
                                               basic_auth=True,
                                               token_auth=True)
         parsed_args = parser.parse(*args)
@@ -885,7 +885,7 @@ class TestBackendCommandArgumentParser(unittest.TestCase):
                 '--archived-since', '2016-01-01',
                 '--category', 'mocked']
 
-        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND,
                                               archive=True)
         parsed_args = parser.parse(*args)
 
@@ -902,7 +902,7 @@ class TestBackendCommandArgumentParser(unittest.TestCase):
         """Test if fetch-archive and no-archive arguments are incompatible"""
 
         args = ['--fetch-archive', '--no-archive']
-        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND,
                                               archive=True)
 
         with self.assertRaises(AttributeError):
@@ -912,7 +912,7 @@ class TestBackendCommandArgumentParser(unittest.TestCase):
         """Test if fetch-archive needs a category"""
 
         args = ['--fetch-archive']
-        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND,
                                               archive=True)
 
         with self.assertRaises(AttributeError):
@@ -922,7 +922,7 @@ class TestBackendCommandArgumentParser(unittest.TestCase):
         """Test whether category argument is removed when no value is given"""
 
         args = []
-        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND,
                                               archive=True)
         parsed_args = parser.parse(*args)
 
@@ -931,7 +931,7 @@ class TestBackendCommandArgumentParser(unittest.TestCase):
 
         # An empty string is parsed
         args = ['--category', '']
-        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND,
                                               archive=True)
         parsed_args = parser.parse(*args)
 

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -820,7 +820,7 @@ class TestBugzillaCommand(unittest.TestCase):
 
         parser = BugzillaCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Bugzilla.CATEGORIES)
+        self.assertEqual(parser._backend, Bugzilla)
 
         args = ['--backend-user', 'jsmith@example.com',
                 '--backend-password', '1234',

--- a/tests/test_bugzillarest.py
+++ b/tests/test_bugzillarest.py
@@ -666,7 +666,7 @@ class TestBugzillaRESTCommand(unittest.TestCase):
 
         parser = BugzillaRESTCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, BugzillaREST.CATEGORIES)
+        self.assertEqual(parser._backend, BugzillaREST)
 
         args = ['--backend-user', 'jsmith@example.com',
                 '--backend-password', '1234',

--- a/tests/test_confluence.py
+++ b/tests/test_confluence.py
@@ -557,7 +557,7 @@ class TestConfluenceCommand(unittest.TestCase):
 
         parser = ConfluenceCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Confluence.CATEGORIES)
+        self.assertEqual(parser._backend, Confluence)
 
         args = ['http://example.com',
                 '--tag', 'test', '--no-archive',

--- a/tests/test_discourse.py
+++ b/tests/test_discourse.py
@@ -893,7 +893,7 @@ class TestDiscourseCommand(unittest.TestCase):
 
         parser = DiscourseCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Discourse.CATEGORIES)
+        self.assertEqual(parser._backend, Discourse)
 
         args = ['--tag', 'test', '--no-archive',
                 '--from-date', '1970-01-01',

--- a/tests/test_dockerhub.py
+++ b/tests/test_dockerhub.py
@@ -223,7 +223,7 @@ class TestDockerHubCommand(unittest.TestCase):
 
         parser = DockerHubCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, DockerHub.CATEGORIES)
+        self.assertEqual(parser._backend, DockerHub)
 
         args = ['grimoirelab', 'perceval', '--no-archive']
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -125,5 +125,14 @@ class TestParseError(unittest.TestCase):
         self.assertEqual('error on line 10', str(e))
 
 
+class TestBackendCommandArgumentParserError(unittest.TestCase):
+
+    def test_message(self):
+        """Make sure that prints the correct error"""
+
+        e = errors.BackendCommandArgumentParserError(cause='mock error on backend command argument parser')
+        self.assertEqual('mock error on backend command argument parser', str(e))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -437,7 +437,7 @@ class TestGerritCommand(unittest.TestCase):
 
         parser = GerritCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Gerrit.CATEGORIES)
+        self.assertEqual(parser._backend, Gerrit)
 
         args = [GERRIT_REPO,
                 '--user', GERRIT_USER,

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -114,6 +114,7 @@ class TestGerritBackend(unittest.TestCase):
         self.assertIsNone(gerrit.user)
         self.assertEqual(gerrit.tag, 'test')
         self.assertIsNone(gerrit.client)
+        self.assertIsNone(gerrit.blacklist_ids)
 
         gerrit = Gerrit(GERRIT_REPO, GERRIT_USER, port=1000, max_reviews=100)
         self.assertEqual(gerrit.hostname, GERRIT_REPO)
@@ -122,6 +123,15 @@ class TestGerritBackend(unittest.TestCase):
         self.assertEqual(gerrit.tag, GERRIT_REPO)
         self.assertEqual(gerrit.user, GERRIT_USER)
         self.assertIsNone(gerrit.client)
+        self.assertIsNone(gerrit.blacklist_ids)
+
+        gerrit = Gerrit(GERRIT_REPO, tag='test', blacklist_ids=['willy'])
+        self.assertEqual(gerrit.hostname, GERRIT_REPO)
+        self.assertEqual(gerrit.port, PORT)
+        self.assertEqual(gerrit.max_reviews, MAX_REVIEWS)
+        self.assertIsNone(gerrit.user)
+        self.assertEqual(gerrit.tag, 'test')
+        self.assertListEqual(gerrit.blacklist_ids, ['willy'])
 
     def test_has_archiving(self):
         """Test if it returns True when has_archiving is called"""
@@ -442,7 +452,7 @@ class TestGerritCommand(unittest.TestCase):
         args = [GERRIT_REPO,
                 '--user', GERRIT_USER,
                 '--max-reviews', '5',
-                '--blacklist-reviews', '',
+                '--blacklist-ids', '',
                 '--disable-host-key-check',
                 '--ssh-port', '1000',
                 '--tag', 'test', '--no-archive']
@@ -455,6 +465,25 @@ class TestGerritCommand(unittest.TestCase):
         self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
         self.assertEqual(parsed_args.no_archive, True)
         self.assertEqual(parsed_args.port, 1000)
+        self.assertListEqual(parsed_args.blacklist_ids, [''])
+
+        args = [GERRIT_REPO,
+                '--user', GERRIT_USER,
+                '--max-reviews', '5',
+                '--blacklist-ids', 'willy', 'wolly', 'wally',
+                '--disable-host-key-check',
+                '--ssh-port', '1000',
+                '--tag', 'test', '--no-archive']
+
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.hostname, GERRIT_REPO)
+        self.assertEqual(parsed_args.user, GERRIT_USER)
+        self.assertEqual(parsed_args.max_reviews, 5)
+        self.assertEqual(parsed_args.tag, 'test')
+        self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
+        self.assertEqual(parsed_args.no_archive, True)
+        self.assertEqual(parsed_args.port, 1000)
+        self.assertListEqual(parsed_args.blacklist_ids, ['willy', 'wolly', 'wally'])
 
 
 if __name__ == "__main__":

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -821,7 +821,7 @@ class TestGitCommand(TestCaseGit):
 
         parser = GitCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Git.CATEGORIES)
+        self.assertEqual(parser._backend, Git)
 
         args = ['http://example.com/',
                 '--git-log', os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data/git/git_log.txt'),

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -3291,7 +3291,7 @@ class TestGitHubCommand(unittest.TestCase):
 
         parser = GitHubCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, GitHub.CATEGORIES)
+        self.assertEqual(parser._backend, GitHub)
 
         args = ['--sleep-for-rate',
                 '--min-rate-to-sleep', '1',

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -1807,7 +1807,7 @@ class TestGitLabCommand(unittest.TestCase):
 
         parser = GitLabCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, GitLab.CATEGORIES)
+        self.assertEqual(parser._backend, GitLab)
 
         args = ['--sleep-for-rate',
                 '--min-rate-to-sleep', '1',

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -600,6 +600,10 @@ class TestGitLabBackend(unittest.TestCase):
         self.assertEqual(gitlab.repository, issue['search_fields']['project'])
         self.assertIsNone(issue['search_fields']['groups'])
 
+        self.assertEqual(gitlab.summary.total, 4)
+        self.assertEqual(gitlab.summary.fetched, 4)
+        self.assertEqual(gitlab.summary.skipped, 0)
+
     @httpretty.activate
     def test_search_fields_issues_groups(self):
         """Test whether the search_fields is properly set when the project is in a group"""
@@ -704,6 +708,10 @@ class TestGitLabBackend(unittest.TestCase):
         self.assertEqual(issue['tag'], GITLAB_URL + '/fdroid/fdroiddata')
         self.assertEqual(issue['data']['author']['id'], 2)
         self.assertEqual(issue['data']['author']['username'], 'YoeriNijs')
+
+        self.assertEqual(gitlab.summary.total, 4)
+        self.assertEqual(gitlab.summary.fetched, 1)
+        self.assertEqual(gitlab.summary.skipped, 3)
 
     @httpretty.activate
     def test_fetch_merges(self):

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -692,9 +692,9 @@ class TestGitLabBackend(unittest.TestCase):
 
         with self.assertLogs(level='WARNING') as cm:
             issues = [issues for issues in gitlab.fetch()]
-            self.assertEqual(cm.output[0], 'WARNING:perceval.backends.core.gitlab:Skipping blacklisted issue 1')
-            self.assertEqual(cm.output[1], 'WARNING:perceval.backends.core.gitlab:Skipping blacklisted issue 2')
-            self.assertEqual(cm.output[2], 'WARNING:perceval.backends.core.gitlab:Skipping blacklisted issue 3')
+            self.assertEqual(cm.output[0], 'WARNING:perceval.backend:Skipping blacklisted item iid 1')
+            self.assertEqual(cm.output[1], 'WARNING:perceval.backend:Skipping blacklisted item iid 2')
+            self.assertEqual(cm.output[2], 'WARNING:perceval.backend:Skipping blacklisted item iid 3')
 
         self.assertEqual(len(issues), 1)
 
@@ -867,10 +867,8 @@ class TestGitLabBackend(unittest.TestCase):
 
         with self.assertLogs(level='WARNING') as cm:
             merges = [merges for merges in gitlab.fetch(category=CATEGORY_MERGE_REQUEST)]
-            self.assertEqual(cm.output[0], 'WARNING:perceval.backends.core.gitlab:'
-                                           'Skipping blacklisted merge request 1')
-            self.assertEqual(cm.output[1], 'WARNING:perceval.backends.core.gitlab:'
-                                           'Skipping blacklisted merge request 2')
+            self.assertEqual(cm.output[0], 'WARNING:perceval.backend:Skipping blacklisted item iid 1')
+            self.assertEqual(cm.output[1], 'WARNING:perceval.backend:Skipping blacklisted item iid 2')
 
         self.assertEqual(len(merges), 1)
 

--- a/tests/test_googlehits.py
+++ b/tests/test_googlehits.py
@@ -291,7 +291,7 @@ class TestGoogleHitsCommand(unittest.TestCase):
 
         parser = GoogleHitsCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, GoogleHits.CATEGORIES)
+        self.assertEqual(parser._backend, GoogleHits)
         args = ['', '--no-archive']
 
         parsed_args = parser.parse(*args)

--- a/tests/test_groupsio.py
+++ b/tests/test_groupsio.py
@@ -445,7 +445,7 @@ class TestGroupsioCommand(unittest.TestCase):
 
         parser = GroupsioCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Groupsio.CATEGORIES)
+        self.assertEqual(parser._backend, Groupsio)
 
         args = ['acme_group',
                 '--mboxes-path', '/tmp/perceval/',

--- a/tests/test_hyperkitty.py
+++ b/tests/test_hyperkitty.py
@@ -335,7 +335,7 @@ class TestHyperKittyCommand(unittest.TestCase):
 
         parser = HyperKittyCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, HyperKitty.CATEGORIES)
+        self.assertEqual(parser._backend, HyperKitty)
 
         args = ['http://example.com/archives/list/test@example.com/',
                 '--mboxes-path', '/tmp/perceval/',

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -686,7 +686,7 @@ class TestJenkinsCommand(unittest.TestCase):
 
         parser = JenkinsCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Jenkins.CATEGORIES)
+        self.assertEqual(parser._backend, Jenkins)
 
         args = ['--tag', 'test', '--no-archive', '--sleep-time', '60',
                 '--detail-depth', '2',

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -855,7 +855,7 @@ class TestJiraCommand(unittest.TestCase):
 
         parser = JiraCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Jira.CATEGORIES)
+        self.assertEqual(parser._backend, Jira)
 
         args = ['--backend-user', 'jsmith',
                 '--backend-password', '1234',

--- a/tests/test_launchpad.py
+++ b/tests/test_launchpad.py
@@ -976,7 +976,7 @@ class TestLaunchpadCommand(unittest.TestCase):
 
         parser = LaunchpadCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Launchpad.CATEGORIES)
+        self.assertEqual(parser._backend, Launchpad)
 
         args = ['--tag', 'test', '--no-archive',
                 '--from-date', '1970-01-01',

--- a/tests/test_mattermost.py
+++ b/tests/test_mattermost.py
@@ -405,7 +405,7 @@ class TestMattermostCommand(unittest.TestCase):
 
         parser = MattermostCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Mattermost.CATEGORIES)
+        self.assertEqual(parser._backend, Mattermost)
 
         args = ['https://mattermost.example.com/', 'abcdefghijkl',
                 '--api-token', 'aaaa',

--- a/tests/test_mbox.py
+++ b/tests/test_mbox.py
@@ -564,7 +564,7 @@ class TestMBoxCommand(unittest.TestCase):
 
         parser = MBoxCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, MBox.CATEGORIES)
+        self.assertEqual(parser._backend, MBox)
 
         args = ['http://example.com/', '/tmp/perceval/',
                 '--tag', 'test',

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -689,7 +689,7 @@ class TestMediaWikiCommand(unittest.TestCase):
 
         parser = MediaWikiCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, MediaWiki.CATEGORIES)
+        self.assertEqual(parser._backend, MediaWiki)
 
         args = ['--tag', 'test',
                 '--no-archive', '--from-date', '1970-01-01',

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -688,7 +688,7 @@ class TestMeetupCommand(unittest.TestCase):
 
         parser = MeetupCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Meetup.CATEGORIES)
+        self.assertEqual(parser._backend, Meetup)
 
         args = ['sqlpass-es',
                 '--api-token', 'aaaa',

--- a/tests/test_nntp.py
+++ b/tests/test_nntp.py
@@ -468,7 +468,7 @@ class TestNNTPCommand(unittest.TestCase):
 
         parser = NNTPCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, NNTP.CATEGORIES)
+        self.assertEqual(parser._backend, NNTP)
 
         args = ['nntp.example.com',
                 'example.dev.project-link',

--- a/tests/test_phabricator.py
+++ b/tests/test_phabricator.py
@@ -956,7 +956,7 @@ class TestPhabricatorCommand(unittest.TestCase):
 
         parser = PhabricatorCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Phabricator.CATEGORIES)
+        self.assertEqual(parser._backend, Phabricator)
 
         args = ['http://example.com',
                 '--api-token', '12345678',

--- a/tests/test_pipermail.py
+++ b/tests/test_pipermail.py
@@ -573,7 +573,7 @@ class TestPipermailCommand(unittest.TestCase):
 
         parser = PipermailCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Pipermail.CATEGORIES)
+        self.assertEqual(parser._backend, Pipermail)
 
         args = ['http://example.com/',
                 '--mboxes-path', '/tmp/perceval/',

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -499,7 +499,7 @@ class TestRedmineCommand(unittest.TestCase):
 
         parser = RedmineCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Redmine.CATEGORIES)
+        self.assertEqual(parser._backend, Redmine)
 
         args = ['http://example.com',
                 '--api-token', '12345678',

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -238,7 +238,7 @@ class TestRSSCommand(unittest.TestCase):
 
         parser = RSSCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, RSS.CATEGORIES)
+        self.assertEqual(parser._backend, RSS)
 
         args = ['--tag', 'test',
                 '--no-archive',

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -839,7 +839,7 @@ class TestSlackCommand(unittest.TestCase):
 
         parser = SlackCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Slack.CATEGORIES)
+        self.assertEqual(parser._backend, Slack)
 
         args = ['--tag', 'test', '--no-archive',
                 '--api-token', 'abcdefgh',

--- a/tests/test_stackexchange.py
+++ b/tests/test_stackexchange.py
@@ -469,7 +469,7 @@ class TestStackExchangeCommand(unittest.TestCase):
 
         parser = StackExchangeCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, StackExchange.CATEGORIES)
+        self.assertEqual(parser._backend, StackExchange)
 
         args = ['--site', 'stackoverflow',
                 '--tagged', 'python',

--- a/tests/test_supybot.py
+++ b/tests/test_supybot.py
@@ -208,7 +208,7 @@ class TestSupybotCommand(unittest.TestCase):
 
         parser = SupybotCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Supybot.CATEGORIES)
+        self.assertEqual(parser._backend, Supybot)
 
         args = ['--tag', 'test',
                 '--from-date', '1970-01-01',

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -350,7 +350,7 @@ class TestTelegramCommand(unittest.TestCase):
 
         parser = TelegramCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Telegram.CATEGORIES)
+        self.assertEqual(parser._backend, Telegram)
 
         args = ['mybot',
                 '--api-token', '12345678',

--- a/tests/test_twitter.py
+++ b/tests/test_twitter.py
@@ -397,7 +397,7 @@ class TestTwitterCommand(unittest.TestCase):
 
         parser = TwitterCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Twitter.CATEGORIES)
+        self.assertEqual(parser._backend, Twitter)
 
         args = ['--sleep-for-rate',
                 '--min-rate-to-sleep', '1',


### PR DESCRIPTION
This PR extends Perceval to support the blacklisting of remote items. In a nutshell, the Namedtuple OriginUniqueField is defined to model the origin unique field (composed of a name and type). The OriginUniqueField can be defined in the specific backend and used by the method _skip_item to filter out the blacklisted items.

Gitlab, Jenkins and Gerrit have been updated to use this new feature. Their tests have been updated accordingly.

The signature of the class `BackendCommandArgumentParser` has changed to accept as first parameter the backend object instead its categories. Tests and backends have been updated accordingly.

This PR is the follow up of https://github.com/chaoss/grimoirelab-perceval/pull/575
