### PR TITLE
[github] Make fetching owners information from GitHub API optional

### DIFF
--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -259,7 +259,7 @@ class Backend:
 
         for cf in self.CLASSIFIED_FIELDS:
             try:
-                _remove_key_from_nested_dict(item, cf)
+                _remove_key_from_nested_dictlist(item, cf)
             except KeyError:
                 logger.debug("Classified field '%s' not found for item %s; field ignored",
                              '.'.join(cf), item_uuid)
@@ -379,16 +379,19 @@ def _find_value_from_nested_dict(nested_dict, path_to_field):
         return _find_value_from_nested_dict(nested_dict[key], path_to_field[1:])
 
 
-def _remove_key_from_nested_dict(nested_dict, path_to_field):
+def _remove_key_from_nested_dictlist(nested_dictlist, path_to_field):
     if len(path_to_field) == 0:
         return
 
-    key = path_to_field[0]
-
-    if len(path_to_field) == 1:
-        nested_dict.pop(key)
+    if isinstance(nested_dictlist, list):
+        for item in nested_dictlist:
+            _remove_key_from_nested_dictlist(item, path_to_field)
     else:
-        _remove_key_from_nested_dict(nested_dict[key], path_to_field[1:])
+        key = path_to_field[0]
+        if len(path_to_field) == 1:
+            nested_dictlist.pop(key)
+        else:
+            _remove_key_from_nested_dictlist(nested_dictlist[key], path_to_field[1:])
 
 
 class BackendCommandArgumentParser:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -183,6 +183,7 @@ class ClassifiedFieldsBackend(MockedBackend):
     """Mocked backend for testing classified fields filtering"""
 
     CLASSIFIED_FIELDS = [
+        ['my', 'list_classified', 'dict_classified', 'field'],
         ['my', 'classified', 'field'],
         ['classified']
     ]
@@ -195,7 +196,8 @@ class ClassifiedFieldsBackend(MockedBackend):
         for item in super().fetch_items(category, **kwargs):
             item['my'] = {
                 'classified': {'field': i},
-                'field': i
+                'field': i,
+                'list_classified': [{'field': i, 'dict_classified': {'field': i}}]
             }
             item['classified'] = i
             i += 1
@@ -384,7 +386,9 @@ class TestBackend(unittest.TestCase):
         self.assertListEqual(b.classified_fields, [])
 
         b = ClassifiedFieldsBackend('test')
-        self.assertListEqual(b.classified_fields, ['my.classified.field', 'classified'])
+        self.assertListEqual(b.classified_fields, ['my.list_classified.dict_classified.field',
+                                                   'my.classified.field',
+                                                   'classified'])
 
     def test_has_archiving(self):
         """Test whether an NotImplementedError exception is thrown"""
@@ -670,7 +674,8 @@ class TestClassifiedFieldsFiltering(unittest.TestCase):
             self.assertEqual(item['tag'], 'test')
             self.assertEqual(item['category'], ClassifiedFieldsBackend.DEFAULT_CATEGORY)
             self.assertEqual(item['classified_fields_filtered'],
-                             ['my.classified.field', 'classified'])
+                             ['my.list_classified.dict_classified.field',
+                              'my.classified.field', 'classified'])
 
             # Fields in CLASSIFIED_FIELDS are deleted
             expected = {
@@ -679,6 +684,7 @@ class TestClassifiedFieldsFiltering(unittest.TestCase):
                 'my': {
                     'classified': {},
                     'field': x,
+                    'list_classified': [{'dict_classified': {}, 'field': x}]
                 }
             }
             self.assertDictEqual(item['data'], expected)
@@ -709,6 +715,7 @@ class TestClassifiedFieldsFiltering(unittest.TestCase):
                 'my': {
                     'classified': {'field': x},
                     'field': x,
+                    'list_classified': [{'dict_classified': {'field': x}, 'field': x}]
                 },
             }
             self.assertDictEqual(item['data'], expected)
@@ -739,6 +746,7 @@ class TestClassifiedFieldsFiltering(unittest.TestCase):
                 'my': {
                     'classified': {'field': x},
                     'field': x,
+                    'list_classified': [{'dict_classified': {'field': x}, 'field': x}]
                 },
             }
             self.assertDictEqual(item['data'], expected)
@@ -1451,7 +1459,8 @@ class TestBackendCommand(unittest.TestCase):
             self.assertEqual(item['tag'], 'test')
             self.assertEqual(item['category'], ClassifiedFieldsBackend.DEFAULT_CATEGORY)
             self.assertEqual(item['classified_fields_filtered'],
-                             ['my.classified.field', 'classified'])
+                             ['my.list_classified.dict_classified.field',
+                              'my.classified.field', 'classified'])
 
             expected = {
                 'category': 'mock_item',
@@ -1459,6 +1468,7 @@ class TestBackendCommand(unittest.TestCase):
                 'my': {
                     'classified': {},
                     'field': x,
+                    'list_classified': [{'dict_classified': {}, 'field': x}],
                 },
             }
             self.assertDictEqual(item['data'], expected)
@@ -1678,7 +1688,8 @@ class TestBackendItemsGenerator(unittest.TestCase):
             self.assertEqual(item['uuid'], expected_uuid)
             self.assertEqual(item['tag'], 'test')
             self.assertEqual(item['classified_fields_filtered'],
-                             ['my.classified.field', 'classified'])
+                             ['my.list_classified.dict_classified.field',
+                              'my.classified.field', 'classified'])
 
             # Fields in CLASSIFIED_FIELDS are deleted
             expected = {
@@ -1687,6 +1698,7 @@ class TestBackendItemsGenerator(unittest.TestCase):
                 'my': {
                     'classified': {},
                     'field': x,
+                    'list_classified': [{'dict_classified': {}, 'field': x}],
                 }
             }
             self.assertDictEqual(item['data'], expected)
@@ -2152,7 +2164,8 @@ class TestFetch(unittest.TestCase):
             self.assertEqual(item['uuid'], expected_uuid)
             self.assertEqual(item['tag'], 'test')
             self.assertEqual(item['classified_fields_filtered'],
-                             ['my.classified.field', 'classified'])
+                             ['my.list_classified.dict_classified.field',
+                              'my.classified.field', 'classified'])
 
             # Fields in CLASSIFIED_FIELDS are deleted
             expected = {
@@ -2161,6 +2174,7 @@ class TestFetch(unittest.TestCase):
                 'my': {
                     'classified': {},
                     'field': x,
+                    'list_classified': [{'dict_classified': {}, 'field': x}],
                 }
             }
             self.assertDictEqual(item['data'], expected)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -124,7 +124,7 @@ class TestGitHubBackend(unittest.TestCase):
         self.assertEqual(github.origin, 'https://github.com/zhquan_example/repo')
         self.assertEqual(github.tag, 'test')
         self.assertEqual(github.max_items, MAX_CATEGORY_ITEMS_PER_PAGE)
-
+        self.assertFalse(github.exclude_user_data)
         self.assertEqual(github.categories, [CATEGORY_ISSUE, CATEGORY_PULL_REQUEST, CATEGORY_REPO])
 
         # When tag is empty or None it will be set to the value in origin
@@ -254,6 +254,237 @@ class TestGitHubBackend(unittest.TestCase):
         self.assertEqual(len(issue['data']['comments_data'][0]['reactions_data']),
                          issue['data']['comments_data'][0]['reactions']['total_count'])
         self.assertEqual(issue['data']['comments_data'][0]['reactions_data'][0]['user_data']['login'], 'zhquan_example')
+
+    @httpretty.activate
+    def test_fetch_issues_no_user_data(self):
+        """Test whether a list of issues is returned without user data"""
+
+        body = read_file('data/github/github_request')
+        login = read_file('data/github/github_login')
+        orgs = read_file('data/github/github_orgs')
+        comments = read_file('data/github/github_issue_comments_1')
+        reactions = read_file('data/github/github_issue_comment_1_reactions')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUES_URL,
+                               body=body,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUE_1_COMMENTS_URL,
+                               body=comments, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUE_COMMENT_1_REACTION_URL,
+                               body=reactions, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_USER_URL,
+                               body=login, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ORGS_URL,
+                               body=orgs, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        github = GitHub("zhquan_example", "repo", ["aaa"])
+        issues = [issues for issues in github.fetch(from_date=None, to_date=None, filter_classified=True)]
+
+        self.assertEqual(len(issues), 1)
+
+        issue = issues[0]
+        self.assertEqual(issue['origin'], 'https://github.com/zhquan_example/repo')
+        self.assertEqual(issue['uuid'], '58c073fd2a388c44043b9cc197c73c5c540270ac')
+        self.assertEqual(issue['updated_on'], 1454328801.0)
+        self.assertEqual(issue['category'], CATEGORY_ISSUE)
+        self.assertEqual(issue['tag'], 'https://github.com/zhquan_example/repo')
+        self.assertNotIn('assignee_data', issue['data'])
+        self.assertEqual(len(issue['data']['comments_data']), 1)
+        self.assertNotIn('user_data', issue['data']['comments_data'][0])
+        self.assertEqual(len(issue['data']['comments_data'][0]['reactions_data']),
+                         issue['data']['comments_data'][0]['reactions']['total_count'])
+        self.assertNotIn('user_data', issue['data']['comments_data'][0]['reactions_data'][0])
+
+    @httpretty.activate
+    def test_fetch_filtering_classified_fields(self):
+        """Test if it removes classified fields from a set of fetched items"""
+
+        body = read_file('data/github/github_request')
+        login = read_file('data/github/github_login')
+        orgs = read_file('data/github/github_orgs')
+        rate_limit = read_file('data/github/rate_limit')
+        # Issue
+        comments = read_file('data/github/github_issue_comments_1')
+        reactions = read_file('data/github/github_issue_comment_1_reactions')
+        # Pull request
+        pull = read_file('data/github/github_request_pull_request_1')
+        pull_comments = read_file('data/github/github_request_pull_request_1_comments')
+        pull_reviews_1 = read_file('data/github/github_request_pull_request_1_reviews')
+        pull_commits = read_file('data/github/github_request_pull_request_1_commits')
+        pull_comment_2_reactions = read_file('data/github/github_request_pull_request_1_comment_2_reactions')
+        pull_requested_reviewers = read_file('data/github/github_request_requested_reviewers')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUES_URL,
+                               body=body,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUE_1_COMMENTS_URL,
+                               body=comments, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUE_COMMENT_1_REACTION_URL,
+                               body=reactions, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_USER_URL,
+                               body=login, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ORGS_URL,
+                               body=orgs, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_1_URL,
+                               body=pull,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_1_COMMENTS,
+                               body=pull_comments,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_1_REVIEWS,
+                               body=pull_reviews_1,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_1_COMMITS,
+                               body=pull_commits,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_1_COMMENTS_2_REACTIONS,
+                               body=pull_comment_2_reactions,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_1_REQUESTED_REVIEWERS_URL,
+                               body=pull_requested_reviewers, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        github = GitHub("zhquan_example", "repo", ["aaa"])
+
+        # Issues
+        issues = [issues for issues in github.fetch(from_date=None, to_date=None, filter_classified=True)]
+        for issue in issues:
+            self.assertEqual(issue['classified_fields_filtered'], ['user_data',
+                                                                   'merged_by_data',
+                                                                   'assignee_data',
+                                                                   'assignees_data',
+                                                                   'requested_reviewers_data',
+                                                                   'comments_data.user_data',
+                                                                   'comments_data.reactions_data.user_data',
+                                                                   'reviews_data.user_data',
+                                                                   'review_comments_data.user_data',
+                                                                   'review_comments_data.reactions_data.user_data'])
+            self.assertNotIn('user_data', issue['data'])
+            self.assertNotIn('assignee_data', issue['data'])
+            self.assertNotIn('assignees_data', issue['data'])
+            self.assertNotIn('user_data', issue['data']['comments_data'][0])
+            self.assertNotIn('user_data', issue['data']['comments_data'][0]['reactions_data'][0])
+
+        # Pulls
+        pulls = [pulls for pulls in github.fetch(category=CATEGORY_PULL_REQUEST,
+                                                 from_date=None,
+                                                 to_date=None,
+                                                 filter_classified=True)]
+        for pull in pulls:
+            self.assertEqual(pull['classified_fields_filtered'], ['user_data',
+                                                                  'merged_by_data',
+                                                                  'assignee_data',
+                                                                  'assignees_data',
+                                                                  'requested_reviewers_data',
+                                                                  'comments_data.user_data',
+                                                                  'comments_data.reactions_data.user_data',
+                                                                  'reviews_data.user_data',
+                                                                  'review_comments_data.user_data',
+                                                                  'review_comments_data.reactions_data.user_data'])
+
+            self.assertNotIn('merged_by_data', pull['data'])
+            self.assertNotIn('requested_reviewers_data', pull['data'])
+            self.assertNotIn('user_data', pull['data']['review_comments_data'][1]['reactions_data'][0])
+            self.assertNotIn('user_data', pull['data']['review_comments_data'][1])
+            self.assertNotIn('user_data', pull['data']['reviews_data'][0])
 
     @httpretty.activate
     def test_search_fields_issues(self):
@@ -441,6 +672,130 @@ class TestGitHubBackend(unittest.TestCase):
         self.assertEqual(len(pull['data']['commits_data']), 1)
         self.assertEqual(len(pull['data']['reviews_data']), 2)
         self.assertEqual(pull['data']['reviews_data'][0]['user_data']['login'], 'zhquan_example')
+
+    @httpretty.activate
+    def test_fetch_pulls_no_user_data(self):
+        """Test whether a list of pull requests is returned without user data"""
+
+        body = read_file('data/github/github_request')
+        login = read_file('data/github/github_login')
+        orgs = read_file('data/github/github_orgs')
+        pull = read_file('data/github/github_request_pull_request_1')
+        pull_comments = read_file('data/github/github_request_pull_request_1_comments')
+        pull_reviews_1 = read_file('data/github/github_request_pull_request_1_reviews')
+        pull_commits = read_file('data/github/github_request_pull_request_1_commits')
+        pull_comment_2_reactions = read_file('data/github/github_request_pull_request_1_comment_2_reactions')
+        pull_requested_reviewers = read_file('data/github/github_request_requested_reviewers')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUES_URL,
+                               body=body,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_1_URL,
+                               body=pull,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_1_COMMENTS,
+                               body=pull_comments,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_1_REVIEWS,
+                               body=pull_reviews_1,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_1_COMMITS,
+                               body=pull_commits,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_1_COMMENTS_2_REACTIONS,
+                               body=pull_comment_2_reactions,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_1_REQUESTED_REVIEWERS_URL,
+                               body=pull_requested_reviewers, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_USER_URL,
+                               body=login, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ORGS_URL,
+                               body=orgs, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        github = GitHub("zhquan_example", "repo", ["aaa"])
+        pulls = [pulls for pulls in github.fetch(category=CATEGORY_PULL_REQUEST,
+                                                 from_date=None,
+                                                 to_date=None,
+                                                 filter_classified=True)]
+
+        self.assertEqual(len(pulls), 1)
+
+        pull = pulls[0]
+        self.assertEqual(pull['origin'], 'https://github.com/zhquan_example/repo')
+        self.assertEqual(pull['uuid'], '58c073fd2a388c44043b9cc197c73c5c540270ac')
+        self.assertEqual(pull['updated_on'], 1451929343.0)
+        self.assertEqual(pull['category'], CATEGORY_PULL_REQUEST)
+        self.assertEqual(pull['tag'], 'https://github.com/zhquan_example/repo')
+        self.assertNotIn('merged_by_data', pull['data'])
+        self.assertNotIn('requested_reviewers_data', pull['data'])
+        self.assertEqual(len(pull['data']['review_comments_data']), 2)
+        self.assertEqual(len(pull['data']['review_comments_data'][0]['reactions_data']), 0)
+        self.assertEqual(len(pull['data']['review_comments_data'][1]['reactions_data']), 5)
+        self.assertEqual(pull['data']['review_comments_data'][1]['reactions_data'][0]['content'], 'heart')
+        self.assertNotIn('user_data', pull['data']['review_comments_data'][1]['reactions_data'][0])
+        self.assertEqual(len(pull['data']['commits_data']), 1)
+        self.assertEqual(len(pull['data']['reviews_data']), 2)
+        self.assertNotIn('user_data', pull['data']['reviews_data'][0])
 
     @httpretty.activate
     def test_search_fields_pulls(self):
@@ -957,6 +1312,337 @@ class TestGitHubBackend(unittest.TestCase):
                              'Missing user info for https://api.github.com/repos/zhquan_example/repo/pulls/comments/2')
 
             self.assertEqual(cm.output[2],
+                             'WARNING:perceval.backends.core.github:'
+                             'Missing user info for https://api.github.com/repos/zhquan_example/repo/pulls/comments/2')
+
+    @httpretty.activate
+    def test_fetch_more_issues_no_user_data(self):
+        """Test whether a list of issues is returned without user data"""
+
+        login = read_file('data/github/github_login')
+        orgs = read_file('data/github/github_orgs')
+        issue_1 = read_file('data/github/github_issue_1')
+        issue_2 = read_file('data/github/github_issue_2')
+        issue_2_reactions = read_file('data/github/github_issue_2_reactions')
+        issue_1_comments = read_file('data/github/github_issue_comments_1')
+        issue_2_comments = read_file('data/github/github_issue_comments_2')
+        issue_comment_1_reactions = read_file('data/github/github_issue_comment_1_reactions')
+        issue_comment_2_reactions = read_file('data/github/github_empty_request')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUES_URL,
+                               body=issue_1,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '5',
+                                   'Link': '<' + GITHUB_ISSUES_URL + '/?&page=2>; rel="next", <' +
+                                           GITHUB_ISSUES_URL + '/?&page=3>; rel="last"'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUE_1_COMMENTS_URL,
+                               body=issue_1_comments, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUE_COMMENT_1_REACTION_URL,
+                               body=issue_comment_1_reactions, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUES_URL + '/?&page=2',
+                               body=issue_2,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '5'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUE_2_REACTION_URL,
+                               body=issue_2_reactions, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUE_2_COMMENTS_URL,
+                               body=issue_2_comments, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUE_COMMENT_2_REACTION_URL,
+                               body=issue_comment_2_reactions, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_USER_URL,
+                               body=login, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '5'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ORGS_URL,
+                               body=orgs, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '5'
+                               })
+
+        github = GitHub("zhquan_example", "repo", ["aaa"])
+        issues = [issues for issues in github.fetch(filter_classified=True)]
+
+        self.assertEqual(len(issues), 2)
+
+        issue = issues[0]
+        self.assertEqual(issue['origin'], 'https://github.com/zhquan_example/repo')
+        self.assertEqual(issue['uuid'], '58c073fd2a388c44043b9cc197c73c5c540270ac')
+        self.assertEqual(issue['updated_on'], 1458035782.0)
+        self.assertEqual(issue['category'], CATEGORY_ISSUE)
+        self.assertEqual(issue['tag'], 'https://github.com/zhquan_example/repo')
+        self.assertNotIn('assignee_data', issue['data'])
+        self.assertEqual(len(issue['data']['comments_data']), 1)
+        self.assertEqual(issue['data']['reactions']['total_count'], len(issue['data']['reactions_data']))
+        self.assertNotIn('user_data', issue['data']['comments_data'][0])
+        self.assertEqual(issue['data']['comments_data'][0]['reactions']['total_count'],
+                         len(issue['data']['comments_data'][0]['reactions_data']))
+
+        issue = issues[1]
+        self.assertEqual(issue['origin'], 'https://github.com/zhquan_example/repo')
+        self.assertEqual(issue['uuid'], '4236619ac2073491640f1698b5c4e169895aaf69')
+        self.assertEqual(issue['updated_on'], 1463324969.0)
+        self.assertEqual(issue['category'], CATEGORY_ISSUE)
+        self.assertEqual(issue['tag'], 'https://github.com/zhquan_example/repo')
+        self.assertNotIn('assignees_data', issue['data'])
+        self.assertEqual(len(issue['data']['comments_data']), 1)
+        self.assertEqual(issue['data']['reactions']['total_count'], len(issue['data']['reactions_data']))
+        self.assertNotIn('user_data', issue['data']['comments_data'][0])
+        self.assertEqual(issue['data']['comments_data'][0]['reactions']['total_count'],
+                         len(issue['data']['comments_data'][0]['reactions_data']))
+
+    @httpretty.activate
+    def test_fetch_more_pulls_no_user_data(self):
+        """Test whether a list of pull requests is returned without user data"""
+
+        login = read_file('data/github/github_login')
+        orgs = read_file('data/github/github_orgs')
+        issue_1 = read_file('data/github/github_issue_1')
+        issue_2 = read_file('data/github/github_issue_2_with_pr')
+        pull_1 = read_file('data/github/github_request_pull_request_1')
+        pull_1_comments = read_file('data/github/github_request_pull_request_1_comments')
+        pull_1_reviews = read_file('data/github/github_request_pull_request_1_reviews')
+        pull_1_commits = read_file('data/github/github_request_pull_request_1_commits')
+        pull_1_comment_2_reactions = read_file('data/github/github_request_pull_request_1_comment_2_reactions')
+        pull_requested_reviewers = read_file('data/github/github_request_requested_reviewers')
+        pull_2 = read_file('data/github/github_request_pull_request_2')
+        pull_2_comments = read_file('data/github/github_request_pull_request_2_comments')
+        pull_2_reviews = read_file('data/github/github_request_pull_request_2_reviews')
+        pull_2_commits = read_file('data/github/github_request_pull_request_2_commits')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUES_URL,
+                               body=issue_1,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '5',
+                                   'Link': '<' + GITHUB_ISSUES_URL + '/?&page=2>; rel="next", <' +
+                                           GITHUB_ISSUES_URL + '/?&page=3>; rel="last"'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUES_URL + '/?&page=2',
+                               body=issue_2,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '5'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_1_URL,
+                               body=pull_1,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_1_COMMENTS,
+                               body=pull_1_comments,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_1_COMMITS,
+                               body=pull_1_commits,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_1_COMMENTS_2_REACTIONS,
+                               body=pull_1_comment_2_reactions,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_1_REVIEWS,
+                               body=pull_1_reviews, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_1_REQUESTED_REVIEWERS_URL,
+                               body=pull_requested_reviewers, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_2_URL,
+                               body=pull_2,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_2_COMMENTS,
+                               body=pull_2_comments,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_2_COMMITS,
+                               body=pull_2_commits,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_2_REVIEWS,
+                               body=pull_2_reviews,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_2_REQUESTED_REVIEWERS_URL,
+                               body=[],
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_USER_URL,
+                               body=login, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '5'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ORGS_URL,
+                               body=orgs, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '5'
+                               })
+
+        github = GitHub("zhquan_example", "repo", ["aaa"])
+
+        with self.assertLogs(logger) as cm:
+            pulls = [pulls for pulls in github.fetch(category=CATEGORY_PULL_REQUEST,
+                                                     from_date=None,
+                                                     filter_classified=True)]
+
+            self.assertEqual(len(pulls), 2)
+
+            pull = pulls[0]
+            self.assertEqual(pull['origin'], 'https://github.com/zhquan_example/repo')
+            self.assertEqual(pull['uuid'], '58c073fd2a388c44043b9cc197c73c5c540270ac')
+            self.assertEqual(pull['updated_on'], 1451929343.0)
+            self.assertEqual(pull['category'], CATEGORY_PULL_REQUEST)
+            self.assertEqual(pull['tag'], 'https://github.com/zhquan_example/repo')
+            self.assertNotIn('merged_by_data', pull['data'])
+            self.assertNotIn('requested_reviewers_data', pull['data'])
+            self.assertEqual(len(pull['data']['review_comments_data']), 2)
+            self.assertEqual(len(pull['data']['review_comments_data'][0]['reactions_data']), 0)
+            self.assertEqual(len(pull['data']['review_comments_data'][1]['reactions_data']), 5)
+            self.assertEqual(pull['data']['review_comments_data'][1]['reactions_data'][0]['content'], 'heart')
+            self.assertEqual(len(pull['data']['reviews_data']), 2)
+            self.assertNotIn('user_data', pull['data']['reviews_data'][0])
+            self.assertEqual(len(pull['data']['commits_data']), 1)
+
+            pull = pulls[1]
+            self.assertEqual(pull['origin'], 'https://github.com/zhquan_example/repo')
+            self.assertEqual(pull['uuid'], '58c073fd2a388c44043b9cc197c73c5c540270ac')
+            self.assertEqual(pull['updated_on'], 1457113343.0)
+            self.assertEqual(pull['category'], CATEGORY_PULL_REQUEST)
+            self.assertEqual(pull['tag'], 'https://github.com/zhquan_example/repo')
+            self.assertNotIn('merged_by_data', pull['data'])
+            self.assertNotIn('requested_reviewers_data', pull['data'])
+            self.assertEqual(len(pull['data']['review_comments_data']), 4)
+            self.assertEqual(len(pull['data']['review_comments_data'][0]['reactions_data']), 0)
+            self.assertEqual(len(pull['data']['review_comments_data'][1]['reactions_data']), 0)
+            self.assertEqual(len(pull['data']['commits_data']), 1)
+            self.assertEqual(len(pull['data']['reviews_data']), 1)
+            self.assertNotIn('user_data', pull['data']['reviews_data'][0])
+            self.assertNotIn('user_data', pull['data']['review_comments_data'][0])
+            self.assertNotIn('user_data', pull['data']['review_comments_data'][2])
+
+            self.assertEqual(cm.output[0],
+                             "INFO:perceval.backends.core.github:"
+                             "Excluding user data. Personal user information won't be collected from the API.")
+
+            self.assertEqual(cm.output[1],
+                             'WARNING:perceval.backends.core.github:'
+                             'Missing user info for https://github.com/zhquan_example/repo/pull/88#pullrequestreview-205729183')
+
+            self.assertEqual(cm.output[2],
+                             'WARNING:perceval.backends.core.github:'
+                             'Missing user info for https://api.github.com/repos/zhquan_example/repo/pulls/comments/2')
+
+            self.assertEqual(cm.output[3],
                              'WARNING:perceval.backends.core.github:'
                              'Missing user info for https://api.github.com/repos/zhquan_example/repo/pulls/comments/2')
 


### PR DESCRIPTION
This code makes it optional to obtain user information from the GitHub API. This way you can choose to not collect personal information from users.
