### PR TITLE
[jenkins] Handle workflow multibranch job builds

### DIFF
--- a/tests/data/jenkins/jenkins_job_builds.json
+++ b/tests/data/jenkins/jenkins_job_builds.json
@@ -1,1 +1,7106 @@
-{"actions":[{"parameterDefinitions":[{"defaultParameterValue":{"name":"PROJECT","value":"apex"},"description":"JJB configured PROJECT parameter to identify an opnfv Gerrit project","name":"PROJECT","type":"StringParameterDefinition"},{"defaultParameterValue":{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},"description":"URL to Google Storage.","name":"GS_BASE","type":"StringParameterDefinition"},{"defaultParameterValue":{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},"description":"URL to Google Storage proxy","name":"GS_BASE_PROXY","type":"StringParameterDefinition"},{"defaultParameterValue":{"name":"ARTIFACT_NAME","value":"latest"},"description":"RPM Artifact name that will be appended to GS_URL to deploy a specific artifact","name":"ARTIFACT_NAME","type":"StringParameterDefinition"},{"defaultParameterValue":{"name":"ARTIFACT_VERSION","value":"daily"},"description":"Artifact version type","name":"ARTIFACT_VERSION","type":"StringParameterDefinition"},{"defaultParameterValue":{"name":"BUILD_DIRECTORY","value":"$WORKSPACE/build"},"description":"Directory where the build artifact will be located upon the completion of the build.","name":"BUILD_DIRECTORY","type":"StringParameterDefinition"},{"defaultParameterValue":{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},"description":"Directory where the cache to be used during the build is located.","name":"CACHE_DIRECTORY","type":"StringParameterDefinition"},{"defaultParameterValue":{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},"description":"Used for overriding the GIT URL coming from Global Jenkins configuration in case if the stuff is done on none-LF HW.","name":"GIT_BASE","type":"StringParameterDefinition"},{"defaultParameterValue":{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},"description":"URL to Google Storage.","name":"GS_URL","type":"StringParameterDefinition"},{"defaultParameterValue":{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},"description":"Scenario to deploy with.","name":"DEPLOY_SCENARIO","type":"StringParameterDefinition"},{"defaultParameterValue":{"name":"OPNFV_CLEAN","value":"no"},"description":"Use yes in lower case to invoke clean. Indicates if the deploy environment should be cleaned before deployment","name":"OPNFV_CLEAN","type":"StringParameterDefinition"}]}],"description":"<!-- Managed by Jenkins Job Builder -->","displayName":"apex-deploy-virtual-os-onos-nofeature-ha-master","displayNameOrNull":null,"name":"apex-deploy-virtual-os-onos-nofeature-ha-master","url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/","buildable":true,"builds":[{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 609","upstreamBuild":609,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":107,"buildResult":null,"marked":{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","branch":[{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","branch":[{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","branch":[{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#107","duration":3177872,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #107","id":"107","keepLog":false,"number":107,"queueId":7729,"result":"SUCCESS","timestamp":1458874078582,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/107/","builtOn":"intel-pod7","changeSet":{"items":[{"affectedPaths":["ci/clean.sh"],"commitId":"5f38edb9a96df7d5927d9b91039144bf4d5f0912","timestamp":1458848756000,"author":{"absoluteUrl":"https://build.opnfv.org/ci/user/fpan","fullName":"fpan"},"comment":"Fixes occasional VM stoage deleltion failure\n\nRemoves --remove-all-storage option in ci/clean.sh\n\nJIRA: APEX-121\n\nChange-Id: Ia8063112333d12d09cfb16dd1a02e14551dae7d7\nSigned-off-by: Feng Pan <fpan@redhat.com>\n","date":"2016-03-24T19:45:56+0000 -0400","id":"5f38edb9a96df7d5927d9b91039144bf4d5f0912","msg":"Fixes occasional VM stoage deleltion failure","paths":[{"editType":"edit","file":"ci/clean.sh"}]}],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/fpan","description":null,"fullName":"fpan","id":"fpan","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"fpan@redhat.com"},{}]}]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 607","upstreamBuild":607,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":106,"buildResult":null,"marked":{"SHA1":"e45742b51011e726f13739698bdae94594709ecd","branch":[{"SHA1":"e45742b51011e726f13739698bdae94594709ecd","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"e45742b51011e726f13739698bdae94594709ecd","branch":[{"SHA1":"e45742b51011e726f13739698bdae94594709ecd","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"e45742b51011e726f13739698bdae94594709ecd","branch":[{"SHA1":"e45742b51011e726f13739698bdae94594709ecd","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#106","duration":3418548,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #106","id":"106","keepLog":false,"number":106,"queueId":7689,"result":"SUCCESS","timestamp":1458854340139,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/106/","builtOn":"intel-pod7","changeSet":{"items":[{"affectedPaths":["build/opnfv-tripleo-heat-templates.patch"],"commitId":"89ac4d397e3a40cdfa2a807b89896c2a5e547634","timestamp":1458782317000,"author":{"absoluteUrl":"https://build.opnfv.org/ci/user/fpan","fullName":"fpan"},"comment":"Adds L3 agent for no-sdn no-ha scenario\n\nJIRA: APEX-110\n\nChange-Id: Ifbca9328f7ee502232b51b8641eb0c5dc90a487b\nSigned-off-by: Feng Pan <fpan@redhat.com>\n","date":"2016-03-24T01:18:37+0000 +0000","id":"89ac4d397e3a40cdfa2a807b89896c2a5e547634","msg":"Adds L3 agent for no-sdn no-ha scenario","paths":[{"editType":"edit","file":"build/opnfv-tripleo-heat-templates.patch"}]}],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/fpan","description":null,"fullName":"fpan","id":"fpan","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"fpan@redhat.com"},{}]}]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 606","upstreamBuild":606,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":105,"buildResult":null,"marked":{"SHA1":"673897bcb5a8e1cb7a58941c8b6f7a4c0052c8fe","branch":[{"SHA1":"673897bcb5a8e1cb7a58941c8b6f7a4c0052c8fe","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"673897bcb5a8e1cb7a58941c8b6f7a4c0052c8fe","branch":[{"SHA1":"673897bcb5a8e1cb7a58941c8b6f7a4c0052c8fe","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"673897bcb5a8e1cb7a58941c8b6f7a4c0052c8fe","branch":[{"SHA1":"673897bcb5a8e1cb7a58941c8b6f7a4c0052c8fe","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#105","duration":3263756,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #105","id":"105","keepLog":false,"number":105,"queueId":7654,"result":"SUCCESS","timestamp":1458842674184,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/105/","builtOn":"intel-pod7","changeSet":{"items":[{"affectedPaths":["build/overcloud-opendaylight.sh"],"commitId":"673897bcb5a8e1cb7a58941c8b6f7a4c0052c8fe","timestamp":1458827467000,"author":{"absoluteUrl":"https://build.opnfv.org/ci/user/dradez","fullName":"dradez"},"comment":"updating to OpenDaylight Beryllium SR1\n\nChange-Id: Idaf267854b6629a38c458b3c4c1c14af37b7d57c\n","date":"2016-03-24T13:51:07+0000 -0400","id":"673897bcb5a8e1cb7a58941c8b6f7a4c0052c8fe","msg":"updating to OpenDaylight Beryllium SR1","paths":[{"editType":"edit","file":"build/overcloud-opendaylight.sh"}]}],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/dradez","description":null,"fullName":"dradez","id":"dradez","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"dradez@redhat.com"}]}]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 605","upstreamBuild":605,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":104,"buildResult":null,"marked":{"SHA1":"81e8d7b55fbc27d8f25031817baf92d9b100f322","branch":[{"SHA1":"81e8d7b55fbc27d8f25031817baf92d9b100f322","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"81e8d7b55fbc27d8f25031817baf92d9b100f322","branch":[{"SHA1":"81e8d7b55fbc27d8f25031817baf92d9b100f322","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"81e8d7b55fbc27d8f25031817baf92d9b100f322","branch":[{"SHA1":"81e8d7b55fbc27d8f25031817baf92d9b100f322","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#104","duration":3148854,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #104","id":"104","keepLog":false,"number":104,"queueId":7624,"result":"SUCCESS","timestamp":1458831639674,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/104/","builtOn":"intel-pod7","changeSet":{"items":[{"affectedPaths":["build/cache.sh","build/Makefile","ci/deploy.sh","build/opnfv-tripleo-heat-templates.patch","build/cache.mk","build/opnfv-apex-undercloud.spec","docs/installation-instructions/virtualinstall.rst","config/network/network_settings.yaml","build/undercloud.sh","config/deploy/network/network_settings.yaml","include/build.sh.debug","ci/clean.sh","build/opnfv-apex-onos.spec","ci/build.sh","build/config.mk","build/opnfv-apex-opendaylight-sfc.spec","build/overcloud-onos.sh","lib/installer/onos/onos_gw_mac_update.sh","build/overcloud-opendaylight.sh","build/opnfv-apex.spec","build/opnfv-apex-common.spec","build/instack.sh","build/variables.sh","build/overcloud-opendaylight-sfc.sh","build/overcloud-full.sh"],"commitId":"a90fc16a988cd5eb53de383d0830648f758edaff","timestamp":1458736462000,"author":{"absoluteUrl":"https://build.opnfv.org/ci/user/dradez","fullName":"dradez"},"comment":"updating vm creation for virt deployment\n\n- replacing brbm with logical names br-netname\n- replacing instack-virt-setup with tripleo scripts\n\nJIRA: APEX-90, APEX-80\n\nChange-Id: I58a15dee8de882e034c8af8a3368ca0647741b13\nSigned-off-by: Dan Radez <dradez@redhat.com>\n","date":"2016-03-23T12:34:22+0000 -0400","id":"a90fc16a988cd5eb53de383d0830648f758edaff","msg":"updating vm creation for virt deployment","paths":[{"editType":"edit","file":"ci/clean.sh"},{"editType":"edit","file":"docs/installation-instructions/virtualinstall.rst"},{"editType":"delete","file":"build/instack.sh"},{"editType":"edit","file":"ci/build.sh"},{"editType":"add","file":"config/network/network_settings.yaml"},{"editType":"edit","file":"build/opnfv-tripleo-heat-templates.patch"},{"editType":"add","file":"build/overcloud-full.sh"},{"editType":"add","file":"build/opnfv-apex-onos.spec"},{"editType":"delete","file":"include/build.sh.debug"},{"editType":"add","file":"build/overcloud-opendaylight-sfc.sh"},{"editType":"edit","file":"ci/deploy.sh"},{"editType":"add","file":"build/undercloud.sh"},{"editType":"add","file":"build/variables.sh"},{"editType":"edit","file":"build/opnfv-apex.spec"},{"editType":"edit","file":"lib/installer/onos/onos_gw_mac_update.sh"},{"editType":"edit","file":"build/opnfv-apex-opendaylight-sfc.spec"},{"editType":"add","file":"build/overcloud-onos.sh"},{"editType":"edit","file":"build/Makefile"},{"editType":"edit","file":"build/opnfv-apex-undercloud.spec"},{"editType":"edit","file":"build/opnfv-apex-common.spec"},{"editType":"delete","file":"build/config.mk"},{"editType":"add","file":"build/cache.sh"},{"editType":"add","file":"build/overcloud-opendaylight.sh"},{"editType":"delete","file":"config/deploy/network/network_settings.yaml"},{"editType":"delete","file":"build/cache.mk"}]},{"affectedPaths":["ci/deploy.sh"],"commitId":"4b5e79294eecf7e10bfb1459c55f9186312c32bf","timestamp":1458758222000,"author":{"absoluteUrl":"https://build.opnfv.org/ci/user/dradez","fullName":"dradez"},"comment":"Allow 2+ compute node for none HA installs APEX-117\n\nChanged the number of compute nodes to no longer be\nhard coded to 1 and now calculate to be total_nodes -1\nfor non-HA deployments.\n\nRebased to new build.\n\nChange-Id: I8dc135876a8b436714806b79d4193d225761534d\nSigned-off-by: randyl <r.levensalor@cablelabs.com>\n","date":"2016-03-23T18:37:02+0000 -0400","id":"4b5e79294eecf7e10bfb1459c55f9186312c32bf","msg":"Allow 2+ compute node for none HA installs APEX-117","paths":[{"editType":"edit","file":"ci/deploy.sh"}]}],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/dradez","description":null,"fullName":"dradez","id":"dradez","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"dradez@redhat.com"}]}]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 600","upstreamBuild":600,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":103,"buildResult":null,"marked":{"SHA1":"a896444c04552b866a9460bbe70ae3488e4877d9","branch":[{"SHA1":"a896444c04552b866a9460bbe70ae3488e4877d9","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"a896444c04552b866a9460bbe70ae3488e4877d9","branch":[{"SHA1":"a896444c04552b866a9460bbe70ae3488e4877d9","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"a896444c04552b866a9460bbe70ae3488e4877d9","branch":[{"SHA1":"a896444c04552b866a9460bbe70ae3488e4877d9","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#103","duration":3424142,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #103","id":"103","keepLog":false,"number":103,"queueId":7468,"result":"SUCCESS","timestamp":1458764722848,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/103/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 596","upstreamBuild":596,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":102,"buildResult":null,"marked":{"SHA1":"a896444c04552b866a9460bbe70ae3488e4877d9","branch":[{"SHA1":"a896444c04552b866a9460bbe70ae3488e4877d9","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"a896444c04552b866a9460bbe70ae3488e4877d9","branch":[{"SHA1":"a896444c04552b866a9460bbe70ae3488e4877d9","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"a896444c04552b866a9460bbe70ae3488e4877d9","branch":[{"SHA1":"a896444c04552b866a9460bbe70ae3488e4877d9","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#102","duration":3433144,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #102","id":"102","keepLog":false,"number":102,"queueId":7399,"result":"SUCCESS","timestamp":1458740779456,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/102/","builtOn":"intel-pod7","changeSet":{"items":[{"affectedPaths":["docs/installation-instructions/baremetal.rst","LICENSE.rst"],"commitId":"a896444c04552b866a9460bbe70ae3488e4877d9","timestamp":1458669391000,"author":{"absoluteUrl":"https://build.opnfv.org/ci/user/r.levensalor","fullName":"r.levensalor"},"comment":"Fixed minor warnings in .rst files\n\nSome of the titles in LICENSE.rst and baremetal.rst\nhad extra underline characters.  These should match\nthe length of the line above.\n\nVery minor and low priorty changes, but we should fix\nany of the warnings that we can.\n\nChange-Id: Idaa7c8272ef034b5000360c7720d99a89357d0b6\nSigned-off-by: randyl <r.levensalor@cablelabs.com>\n","date":"2016-03-22T17:56:31+0000 -0600","id":"a896444c04552b866a9460bbe70ae3488e4877d9","msg":"Fixed minor warnings in .rst files","paths":[{"editType":"edit","file":"docs/installation-instructions/baremetal.rst"},{"editType":"edit","file":"LICENSE.rst"}]}],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/r.levensalor","description":null,"fullName":"r.levensalor","id":"r.levensalor","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"r.levensalor@cablelabs.com"}]}]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 594","upstreamBuild":594,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":101,"buildResult":null,"marked":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#101","duration":3007635,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #101","id":"101","keepLog":false,"number":101,"queueId":7297,"result":"FAILURE","timestamp":1458687074485,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/101/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 592","upstreamBuild":592,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":100,"buildResult":null,"marked":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#100","duration":3329249,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #100","id":"100","keepLog":false,"number":100,"queueId":7248,"result":"SUCCESS","timestamp":1458662464685,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/100/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 591","upstreamBuild":591,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":99,"buildResult":null,"marked":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#99","duration":3454904,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #99","id":"99","keepLog":false,"number":99,"queueId":7116,"result":"SUCCESS","timestamp":1458596193695,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/99/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 587","upstreamBuild":587,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":98,"buildResult":null,"marked":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#98","duration":3371998,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #98","id":"98","keepLog":false,"number":98,"queueId":6733,"result":"SUCCESS","timestamp":1458317164057,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/98/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 586","upstreamBuild":586,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":97,"buildResult":null,"marked":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#97","duration":1807226,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #97","id":"97","keepLog":false,"number":97,"queueId":6689,"result":"FAILURE","timestamp":1458303613770,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/97/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 580","upstreamBuild":580,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":96,"buildResult":null,"marked":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#96","duration":3389159,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #96","id":"96","keepLog":false,"number":96,"queueId":6522,"result":"SUCCESS","timestamp":1458233230260,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/96/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 577","upstreamBuild":577,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":95,"buildResult":null,"marked":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#95","duration":6011229,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #95","id":"95","keepLog":false,"number":95,"queueId":6150,"result":"FAILURE","timestamp":1458005126299,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/95/","builtOn":"opnfv-jump-1","changeSet":{"items":[],"kind":"git"},"culprits":[]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 573","upstreamBuild":573,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":94,"buildResult":null,"marked":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#94","duration":4507245,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #94","id":"94","keepLog":false,"number":94,"queueId":5807,"result":"SUCCESS","timestamp":1457715586283,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/94/","builtOn":"opnfv-jump-1","changeSet":{"items":[],"kind":"git"},"culprits":[]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 569","upstreamBuild":569,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":93,"buildResult":null,"marked":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#93","duration":2579393,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #93","id":"93","keepLog":false,"number":93,"queueId":5567,"result":"SUCCESS","timestamp":1457666574839,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/93/","builtOn":"opnfv-jump-1","changeSet":{"items":[],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/trozet","description":null,"fullName":"trozet","id":"trozet","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"trozet@redhat.com"},{}]},{"absoluteUrl":"https://build.opnfv.org/ci/user/viktor.tikkanen","description":null,"fullName":"viktor.tikkanen","id":"viktor.tikkanen","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"viktor.tikkanen@nokia.com"}]}]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 567","upstreamBuild":567,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":92,"buildResult":null,"marked":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#92","duration":2601096,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #92","id":"92","keepLog":false,"number":92,"queueId":5515,"result":"FAILURE","timestamp":1457624018970,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/92/","builtOn":"opnfv-jump-1","changeSet":{"items":[{"affectedPaths":["docs/installation-instructions/baremetal.rst"],"commitId":"c77d98309557308e909c08f6879e566c87b92315","timestamp":1457523201000,"author":{"absoluteUrl":"https://build.opnfv.org/ci/user/viktor.tikkanen","fullName":"viktor.tikkanen"},"comment":"Corrected a couple of errors in the installation instructions\n\nChange-Id: I52889fd3a29b03e46fcb84c60feb7d3b67fe44c7\nSigned-off-by: Viktor Tikkanen <viktor.tikkanen@nokia.com>\n","date":"2016-03-09T11:33:21+0000 +0200","id":"c77d98309557308e909c08f6879e566c87b92315","msg":"Corrected a couple of errors in the installation instructions","paths":[{"editType":"edit","file":"docs/installation-instructions/baremetal.rst"}]}],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/trozet","description":null,"fullName":"trozet","id":"trozet","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"trozet@redhat.com"},{}]},{"absoluteUrl":"https://build.opnfv.org/ci/user/viktor.tikkanen","description":null,"fullName":"viktor.tikkanen","id":"viktor.tikkanen","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"viktor.tikkanen@nokia.com"}]}]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"OPNFV_CLEAN","value":"yes"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 564","upstreamBuild":564,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":91,"buildResult":null,"marked":{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","branch":[{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","branch":[{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","branch":[{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#91","duration":3130609,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #91","id":"91","keepLog":false,"number":91,"queueId":5386,"result":"FAILURE","timestamp":1457542916260,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/91/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/trozet","description":null,"fullName":"trozet","id":"trozet","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"trozet@redhat.com"},{}]}]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"OPNFV_CLEAN","value":"yes"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"}]},{"causes":[{"shortDescription":"Started by user radez","userId":"radez","userName":"radez"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":90,"buildResult":null,"marked":{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","branch":[{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","branch":[{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","branch":[{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#90","duration":3625631,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #90","id":"90","keepLog":false,"number":90,"queueId":5344,"result":"FAILURE","timestamp":1457531557423,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/90/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/trozet","description":null,"fullName":"trozet","id":"trozet","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"trozet@redhat.com"},{}]}]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"aprx-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"OPNFV_CLEAN","value":"yes"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"}]},{"causes":[{"shortDescription":"Started by user radez","userId":"radez","userName":"radez"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":89,"buildResult":null,"marked":{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","branch":[{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","branch":[{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","branch":[{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#89","duration":3370,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #89","id":"89","keepLog":false,"number":89,"queueId":5343,"result":"FAILURE","timestamp":1457531512898,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/89/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/trozet","description":null,"fullName":"trozet","id":"trozet","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"trozet@redhat.com"},{}]}]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"OPNFV_CLEAN","value":"yes"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"}]},{"causes":[{"shortDescription":"Started by user radez","userId":"radez","userName":"radez"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":88,"buildResult":null,"marked":{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","branch":[{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","branch":[{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","branch":[{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#88","duration":16004,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #88","id":"88","keepLog":false,"number":88,"queueId":5342,"result":"FAILURE","timestamp":1457531436772,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/88/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/trozet","description":null,"fullName":"trozet","id":"trozet","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"trozet@redhat.com"},{}]}]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"OPNFV_CLEAN","value":"yes"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 563","upstreamBuild":563,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":87,"buildResult":null,"marked":{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","branch":[{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","branch":[{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","branch":[{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#87","duration":4142,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #87","id":"87","keepLog":false,"number":87,"queueId":5291,"result":"FAILURE","timestamp":1457502514335,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/87/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/trozet","description":null,"fullName":"trozet","id":"trozet","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"trozet@redhat.com"},{}]}]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"OPNFV_CLEAN","value":"'yes'"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 561","upstreamBuild":561,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":86,"buildResult":null,"marked":{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","branch":[{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","branch":[{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","branch":[{"SHA1":"67566f2f8c700f8c4b78bfac557f70721a243834","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#86","duration":3884,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #86","id":"86","keepLog":false,"number":86,"queueId":5243,"result":"FAILURE","timestamp":1457481225612,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/86/","builtOn":"intel-pod7","changeSet":{"items":[{"affectedPaths":["build/opendaylight-puppet-neutron.patch","build/opnfv-puppet-tripleo.patch","build/opnfv-tripleo-heat-templates.patch","build/instack.sh","build/opendaylight.yaml","build/network-environment.yaml"],"commitId":"67566f2f8c700f8c4b78bfac557f70721a243834","timestamp":1457271814000,"author":{"absoluteUrl":"https://build.opnfv.org/ci/user/trozet","fullName":"trozet"},"comment":"Adds OpenDaylight HA (OVSDB Clustering)\n\nOVSDB Clustering changes include:\n - Modifications to create an OpenDaylight\n   VIP for communication between Neutron SB <-> ODL NB.\n - OpenDaylight configured in HA mode in THT via puppet-opendaylight\n - OVS instances configured with managers pointing to all 3 ODL\n   instances for HA mode\n - Build now points to latest Beryllium release\n - Modified puppet-neutron in build to pull latest stable/liberty\n\nJIRA: APEX-107\n\nChange-Id: Iab510db922dfcd2fbd4962b9751cd2f7e5724f44\nSigned-off-by: Tim Rozet <trozet@redhat.com>\n","date":"2016-03-06T13:43:34+0000 -0500","id":"67566f2f8c700f8c4b78bfac557f70721a243834","msg":"Adds OpenDaylight HA (OVSDB Clustering)","paths":[{"editType":"edit","file":"build/network-environment.yaml"},{"editType":"add","file":"build/opnfv-puppet-tripleo.patch"},{"editType":"delete","file":"build/opendaylight.yaml"},{"editType":"edit","file":"build/opnfv-tripleo-heat-templates.patch"},{"editType":"delete","file":"build/opendaylight-puppet-neutron.patch"},{"editType":"edit","file":"build/instack.sh"}]}],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/trozet","description":null,"fullName":"trozet","id":"trozet","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"trozet@redhat.com"},{}]}]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 545","upstreamBuild":545,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":85,"buildResult":null,"marked":{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","branch":[{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","branch":[{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","branch":[{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#85","duration":3225200,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #85","id":"85","keepLog":false,"number":85,"queueId":4875,"result":"SUCCESS","timestamp":1457279067422,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/85/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 544","upstreamBuild":544,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":84,"buildResult":null,"marked":{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","branch":[{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","branch":[{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","branch":[{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#84","duration":6223527,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #84","id":"84","keepLog":false,"number":84,"queueId":4828,"result":"FAILURE","timestamp":1457237232789,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/84/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 539","upstreamBuild":539,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":83,"buildResult":null,"marked":{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","branch":[{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","branch":[{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","branch":[{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#83","duration":3206030,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #83","id":"83","keepLog":false,"number":83,"queueId":4646,"result":"SUCCESS","timestamp":1457106431319,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/83/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 537","upstreamBuild":537,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":82,"buildResult":null,"marked":{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","branch":[{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","branch":[{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","branch":[{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#82","duration":3257519,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #82","id":"82","keepLog":false,"number":82,"queueId":4559,"result":"SUCCESS","timestamp":1457073386167,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/82/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/dradez","description":null,"fullName":"dradez","id":"dradez","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"dradez@redhat.com"}]}]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 529","upstreamBuild":529,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":81,"buildResult":null,"marked":{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","branch":[{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","branch":[{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","branch":[{"SHA1":"17c3afc75f082e9374eb1344068c792d178c0d35","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#81","duration":6216519,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #81","id":"81","keepLog":false,"number":81,"queueId":4228,"result":"FAILURE","timestamp":1456887239044,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/81/","builtOn":"intel-pod7","changeSet":{"items":[{"affectedPaths":["build/Makefile"],"commitId":"7f1312c63dff70df8a2c29bfe4a16b6e159e4c44","timestamp":1456757123000,"author":{"absoluteUrl":"https://build.opnfv.org/ci/user/dradez","fullName":"dradez"},"comment":"updating the centos dvd version\n\nChange-Id: I2ab43f43858745b5ac5ed695301ad09290b2c320\nSigned-off-by: Dan Radez <dradez@redhat.com>\n","date":"2016-02-29T14:45:23+0000 -0500","id":"7f1312c63dff70df8a2c29bfe4a16b6e159e4c44","msg":"updating the centos dvd version","paths":[{"editType":"edit","file":"build/Makefile"}]},{"affectedPaths":["ci/deploy.sh"],"commitId":"796cb23d09f15790cf397aa30a892bfe670c648f","timestamp":1456777447000,"author":{"absoluteUrl":"https://build.opnfv.org/ci/user/dradez","fullName":"dradez"},"comment":"updates to fix the --flat option\n\nJIRA: APEX-84\n\nChange-Id: Ic806118c3c3032abff6cebe5c93ad62a6a0a23c7\nSigned-off-by: Dan Radez <dradez@redhat.com>\n","date":"2016-02-29T20:24:07+0000 -0500","id":"796cb23d09f15790cf397aa30a892bfe670c648f","msg":"updates to fix the --flat option","paths":[{"editType":"edit","file":"ci/deploy.sh"}]},{"affectedPaths":["build/instack.sh"],"commitId":"17c3afc75f082e9374eb1344068c792d178c0d35","timestamp":1456778658000,"author":{"absoluteUrl":"https://build.opnfv.org/ci/user/dradez","fullName":"dradez"},"comment":"AMT Power Management fixes\n\n- Teal Box uses AMT power management, this fixes the support for the AMT power Management so the Ironic AMT driver can\nbe used.\n\nChange-Id: If7c3c89cf6063c18a97524ade387e4ae841f6c80\nSigned-off-by: Dan Radez <dradez@redhat.com>\n","date":"2016-02-29T20:44:18+0000 -0500","id":"17c3afc75f082e9374eb1344068c792d178c0d35","msg":"AMT Power Management fixes","paths":[{"editType":"edit","file":"build/instack.sh"}]}],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/dradez","description":null,"fullName":"dradez","id":"dradez","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"dradez@redhat.com"}]}]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 523","upstreamBuild":523,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":80,"buildResult":null,"marked":{"SHA1":"034166ea6f9330310789407d8a124812042f305d","branch":[{"SHA1":"034166ea6f9330310789407d8a124812042f305d","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"034166ea6f9330310789407d8a124812042f305d","branch":[{"SHA1":"034166ea6f9330310789407d8a124812042f305d","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"034166ea6f9330310789407d8a124812042f305d","branch":[{"SHA1":"034166ea6f9330310789407d8a124812042f305d","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#80","duration":3267434,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #80","id":"80","keepLog":false,"number":80,"queueId":4095,"result":"SUCCESS","timestamp":1456818216523,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/80/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 522","upstreamBuild":522,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":79,"buildResult":null,"marked":{"SHA1":"034166ea6f9330310789407d8a124812042f305d","branch":[{"SHA1":"034166ea6f9330310789407d8a124812042f305d","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"034166ea6f9330310789407d8a124812042f305d","branch":[{"SHA1":"034166ea6f9330310789407d8a124812042f305d","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"034166ea6f9330310789407d8a124812042f305d","branch":[{"SHA1":"034166ea6f9330310789407d8a124812042f305d","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#79","duration":3204325,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #79","id":"79","keepLog":false,"number":79,"queueId":4078,"result":"SUCCESS","timestamp":1456803828790,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/79/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 521","upstreamBuild":521,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":78,"buildResult":null,"marked":{"SHA1":"034166ea6f9330310789407d8a124812042f305d","branch":[{"SHA1":"034166ea6f9330310789407d8a124812042f305d","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"034166ea6f9330310789407d8a124812042f305d","branch":[{"SHA1":"034166ea6f9330310789407d8a124812042f305d","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"034166ea6f9330310789407d8a124812042f305d","branch":[{"SHA1":"034166ea6f9330310789407d8a124812042f305d","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#78","duration":5202826,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #78","id":"78","keepLog":false,"number":78,"queueId":4041,"result":"SUCCESS","timestamp":1456787398571,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/78/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 497","upstreamBuild":497,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":77,"buildResult":null,"marked":{"SHA1":"034166ea6f9330310789407d8a124812042f305d","branch":[{"SHA1":"034166ea6f9330310789407d8a124812042f305d","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"034166ea6f9330310789407d8a124812042f305d","branch":[{"SHA1":"034166ea6f9330310789407d8a124812042f305d","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"034166ea6f9330310789407d8a124812042f305d","branch":[{"SHA1":"034166ea6f9330310789407d8a124812042f305d","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#77","duration":2606511,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #77","id":"77","keepLog":false,"number":77,"queueId":3410,"result":"SUCCESS","timestamp":1456439122321,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/77/","builtOn":"opnfv-jump-1","changeSet":{"items":[{"affectedPaths":["ci/deploy.sh"],"commitId":"034166ea6f9330310789407d8a124812042f305d","timestamp":1456327079000,"author":{"absoluteUrl":"https://build.opnfv.org/ci/user/trozet","fullName":"trozet"},"comment":"fix bug in ci/build.sh\n\nThis patch fixes bug in ci/build.sh that cause the following error\nmessage:\n\n    /bin/opnfv-deploy: line 197: [: too many arguments\n\nChange-Id: I92419473262a51806baee849669af9b84b94045c\nSigned-off-by: Ryota MIBU <r-mibu@cq.jp.nec.com>\n","date":"2016-02-24T15:17:59+0000 +0000","id":"034166ea6f9330310789407d8a124812042f305d","msg":"fix bug in ci/build.sh","paths":[{"editType":"edit","file":"ci/deploy.sh"}]}],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/trozet","description":null,"fullName":"trozet","id":"trozet","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"trozet@redhat.com"},{}]}]},{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 493","upstreamBuild":493,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":76,"buildResult":null,"marked":{"SHA1":"5fece9e6f4bca1f7551dfbf50c385300f264f4f4","branch":[{"SHA1":"5fece9e6f4bca1f7551dfbf50c385300f264f4f4","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"5fece9e6f4bca1f7551dfbf50c385300f264f4f4","branch":[{"SHA1":"5fece9e6f4bca1f7551dfbf50c385300f264f4f4","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"5fece9e6f4bca1f7551dfbf50c385300f264f4f4","branch":[{"SHA1":"5fece9e6f4bca1f7551dfbf50c385300f264f4f4","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#76","duration":2697138,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #76","id":"76","keepLog":false,"number":76,"queueId":2914,"result":"SUCCESS","timestamp":1456357766112,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/76/","builtOn":"opnfv-jump-1","changeSet":{"items":[{"affectedPaths":["ci/deploy.sh","config/deploy/deploy_settings.yaml","config/deploy/os-nosdn-nofeature-ha.yaml","build/opnfv-tripleo-heat-templates.patch","config/deploy/os-odl_l2-sfc-noha.yaml","config/deploy/os-opencontrail-nofeature-ha.yaml","config/deploy/os-odl_l2-nofeature-ha.yaml","config/deploy/os-onos-nofeature-ha.yaml","config/deploy/os-odl_l3-nofeature-ha.yaml","build/instack.sh","config/deploy/os-odl_l2-sdnvpn-ha.yaml"],"commitId":"c86bd1f24647646b7489cd72e0a0bb91f4a505f1","timestamp":1456110872000,"author":{"absoluteUrl":"https://build.opnfv.org/ci/user/woppin","fullName":"woppin"},"comment":"Adding SDNVPN support\n\nChange-Id: Id2d6d46a53129d4ae2f93fad835536da067e42df\nJIRA: APEX-51\nSigned-off-by: Dan Radez <dradez@redhat.com>\n","date":"2016-02-22T03:14:32+0000 +1100","id":"c86bd1f24647646b7489cd72e0a0bb91f4a505f1","msg":"Adding SDNVPN support","paths":[{"editType":"edit","file":"config/deploy/os-onos-nofeature-ha.yaml"},{"editType":"edit","file":"config/deploy/os-odl_l3-nofeature-ha.yaml"},{"editType":"edit","file":"config/deploy/os-odl_l2-nofeature-ha.yaml"},{"editType":"edit","file":"build/opnfv-tripleo-heat-templates.patch"},{"editType":"edit","file":"config/deploy/os-opencontrail-nofeature-ha.yaml"},{"editType":"add","file":"config/deploy/os-odl_l2-sdnvpn-ha.yaml"},{"editType":"edit","file":"config/deploy/os-nosdn-nofeature-ha.yaml"},{"editType":"edit","file":"build/instack.sh"},{"editType":"edit","file":"config/deploy/os-odl_l2-sfc-noha.yaml"},{"editType":"edit","file":"config/deploy/deploy_settings.yaml"},{"editType":"edit","file":"ci/deploy.sh"}]},{"affectedPaths":["docs/release-notes/release-notes.rst"],"commitId":"eaab4d01e838a13211c812d4c11200b07a6c36d3","timestamp":1456260844000,"author":{"absoluteUrl":"https://build.opnfv.org/ci/user/dradez","fullName":"dradez"},"comment":"adding know issues to release docs for Brahmaputra\n\nChange-Id: I7be396d98a4a1e42852576e9819510513ebf9a85\nSigned-off-by: Dan Radez <dradez@redhat.com>\n","date":"2016-02-23T20:54:04+0000 -0500","id":"eaab4d01e838a13211c812d4c11200b07a6c36d3","msg":"adding know issues to release docs for Brahmaputra","paths":[{"editType":"edit","file":"docs/release-notes/release-notes.rst"}]}],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/dradez","description":null,"fullName":"dradez","id":"dradez","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"dradez@redhat.com"}]},{"absoluteUrl":"https://build.opnfv.org/ci/user/woppin","description":null,"fullName":"woppin","id":"woppin","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"woppin@gmail.com"}]}]}],"color":"blue","firstBuild":{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 493","upstreamBuild":493,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":76,"buildResult":null,"marked":{"SHA1":"5fece9e6f4bca1f7551dfbf50c385300f264f4f4","branch":[{"SHA1":"5fece9e6f4bca1f7551dfbf50c385300f264f4f4","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"5fece9e6f4bca1f7551dfbf50c385300f264f4f4","branch":[{"SHA1":"5fece9e6f4bca1f7551dfbf50c385300f264f4f4","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"5fece9e6f4bca1f7551dfbf50c385300f264f4f4","branch":[{"SHA1":"5fece9e6f4bca1f7551dfbf50c385300f264f4f4","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#76","duration":2697138,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #76","id":"76","keepLog":false,"number":76,"queueId":2914,"result":"SUCCESS","timestamp":1456357766112,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/76/","builtOn":"opnfv-jump-1","changeSet":{"items":[{"affectedPaths":["ci/deploy.sh","config/deploy/deploy_settings.yaml","config/deploy/os-nosdn-nofeature-ha.yaml","build/opnfv-tripleo-heat-templates.patch","config/deploy/os-odl_l2-sfc-noha.yaml","config/deploy/os-opencontrail-nofeature-ha.yaml","config/deploy/os-odl_l2-nofeature-ha.yaml","config/deploy/os-onos-nofeature-ha.yaml","config/deploy/os-odl_l3-nofeature-ha.yaml","build/instack.sh","config/deploy/os-odl_l2-sdnvpn-ha.yaml"],"commitId":"c86bd1f24647646b7489cd72e0a0bb91f4a505f1","timestamp":1456110872000,"author":{"absoluteUrl":"https://build.opnfv.org/ci/user/woppin","fullName":"woppin"},"comment":"Adding SDNVPN support\n\nChange-Id: Id2d6d46a53129d4ae2f93fad835536da067e42df\nJIRA: APEX-51\nSigned-off-by: Dan Radez <dradez@redhat.com>\n","date":"2016-02-22T03:14:32+0000 +1100","id":"c86bd1f24647646b7489cd72e0a0bb91f4a505f1","msg":"Adding SDNVPN support","paths":[{"editType":"edit","file":"config/deploy/os-onos-nofeature-ha.yaml"},{"editType":"edit","file":"config/deploy/os-odl_l3-nofeature-ha.yaml"},{"editType":"edit","file":"config/deploy/os-odl_l2-nofeature-ha.yaml"},{"editType":"edit","file":"build/opnfv-tripleo-heat-templates.patch"},{"editType":"edit","file":"config/deploy/os-opencontrail-nofeature-ha.yaml"},{"editType":"add","file":"config/deploy/os-odl_l2-sdnvpn-ha.yaml"},{"editType":"edit","file":"config/deploy/os-nosdn-nofeature-ha.yaml"},{"editType":"edit","file":"build/instack.sh"},{"editType":"edit","file":"config/deploy/os-odl_l2-sfc-noha.yaml"},{"editType":"edit","file":"config/deploy/deploy_settings.yaml"},{"editType":"edit","file":"ci/deploy.sh"}]},{"affectedPaths":["docs/release-notes/release-notes.rst"],"commitId":"eaab4d01e838a13211c812d4c11200b07a6c36d3","timestamp":1456260844000,"author":{"absoluteUrl":"https://build.opnfv.org/ci/user/dradez","fullName":"dradez"},"comment":"adding know issues to release docs for Brahmaputra\n\nChange-Id: I7be396d98a4a1e42852576e9819510513ebf9a85\nSigned-off-by: Dan Radez <dradez@redhat.com>\n","date":"2016-02-23T20:54:04+0000 -0500","id":"eaab4d01e838a13211c812d4c11200b07a6c36d3","msg":"adding know issues to release docs for Brahmaputra","paths":[{"editType":"edit","file":"docs/release-notes/release-notes.rst"}]}],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/dradez","description":null,"fullName":"dradez","id":"dradez","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"dradez@redhat.com"}]},{"absoluteUrl":"https://build.opnfv.org/ci/user/woppin","description":null,"fullName":"woppin","id":"woppin","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"woppin@gmail.com"}]}]},"healthReport":[{"description":"Build stability: No recent builds failed.","iconClassName":"icon-health-80plus","iconUrl":"health-80plus.png","score":100}],"inQueue":false,"keepDependencies":false,"lastBuild":{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 609","upstreamBuild":609,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":107,"buildResult":null,"marked":{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","branch":[{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","branch":[{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","branch":[{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#107","duration":3177872,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #107","id":"107","keepLog":false,"number":107,"queueId":7729,"result":"SUCCESS","timestamp":1458874078582,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/107/","builtOn":"intel-pod7","changeSet":{"items":[{"affectedPaths":["ci/clean.sh"],"commitId":"5f38edb9a96df7d5927d9b91039144bf4d5f0912","timestamp":1458848756000,"author":{"absoluteUrl":"https://build.opnfv.org/ci/user/fpan","fullName":"fpan"},"comment":"Fixes occasional VM stoage deleltion failure\n\nRemoves --remove-all-storage option in ci/clean.sh\n\nJIRA: APEX-121\n\nChange-Id: Ia8063112333d12d09cfb16dd1a02e14551dae7d7\nSigned-off-by: Feng Pan <fpan@redhat.com>\n","date":"2016-03-24T19:45:56+0000 -0400","id":"5f38edb9a96df7d5927d9b91039144bf4d5f0912","msg":"Fixes occasional VM stoage deleltion failure","paths":[{"editType":"edit","file":"ci/clean.sh"}]}],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/fpan","description":null,"fullName":"fpan","id":"fpan","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"fpan@redhat.com"},{}]}]},"lastCompletedBuild":{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 609","upstreamBuild":609,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":107,"buildResult":null,"marked":{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","branch":[{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","branch":[{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","branch":[{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#107","duration":3177872,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #107","id":"107","keepLog":false,"number":107,"queueId":7729,"result":"SUCCESS","timestamp":1458874078582,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/107/","builtOn":"intel-pod7","changeSet":{"items":[{"affectedPaths":["ci/clean.sh"],"commitId":"5f38edb9a96df7d5927d9b91039144bf4d5f0912","timestamp":1458848756000,"author":{"absoluteUrl":"https://build.opnfv.org/ci/user/fpan","fullName":"fpan"},"comment":"Fixes occasional VM stoage deleltion failure\n\nRemoves --remove-all-storage option in ci/clean.sh\n\nJIRA: APEX-121\n\nChange-Id: Ia8063112333d12d09cfb16dd1a02e14551dae7d7\nSigned-off-by: Feng Pan <fpan@redhat.com>\n","date":"2016-03-24T19:45:56+0000 -0400","id":"5f38edb9a96df7d5927d9b91039144bf4d5f0912","msg":"Fixes occasional VM stoage deleltion failure","paths":[{"editType":"edit","file":"ci/clean.sh"}]}],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/fpan","description":null,"fullName":"fpan","id":"fpan","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"fpan@redhat.com"},{}]}]},"lastFailedBuild":{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 594","upstreamBuild":594,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":101,"buildResult":null,"marked":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#101","duration":3007635,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #101","id":"101","keepLog":false,"number":101,"queueId":7297,"result":"FAILURE","timestamp":1458687074485,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/101/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[]},"lastStableBuild":{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 609","upstreamBuild":609,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":107,"buildResult":null,"marked":{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","branch":[{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","branch":[{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","branch":[{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#107","duration":3177872,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #107","id":"107","keepLog":false,"number":107,"queueId":7729,"result":"SUCCESS","timestamp":1458874078582,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/107/","builtOn":"intel-pod7","changeSet":{"items":[{"affectedPaths":["ci/clean.sh"],"commitId":"5f38edb9a96df7d5927d9b91039144bf4d5f0912","timestamp":1458848756000,"author":{"absoluteUrl":"https://build.opnfv.org/ci/user/fpan","fullName":"fpan"},"comment":"Fixes occasional VM stoage deleltion failure\n\nRemoves --remove-all-storage option in ci/clean.sh\n\nJIRA: APEX-121\n\nChange-Id: Ia8063112333d12d09cfb16dd1a02e14551dae7d7\nSigned-off-by: Feng Pan <fpan@redhat.com>\n","date":"2016-03-24T19:45:56+0000 -0400","id":"5f38edb9a96df7d5927d9b91039144bf4d5f0912","msg":"Fixes occasional VM stoage deleltion failure","paths":[{"editType":"edit","file":"ci/clean.sh"}]}],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/fpan","description":null,"fullName":"fpan","id":"fpan","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"fpan@redhat.com"},{}]}]},"lastSuccessfulBuild":{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 609","upstreamBuild":609,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":107,"buildResult":null,"marked":{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","branch":[{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","branch":[{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","branch":[{"SHA1":"9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#107","duration":3177872,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #107","id":"107","keepLog":false,"number":107,"queueId":7729,"result":"SUCCESS","timestamp":1458874078582,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/107/","builtOn":"intel-pod7","changeSet":{"items":[{"affectedPaths":["ci/clean.sh"],"commitId":"5f38edb9a96df7d5927d9b91039144bf4d5f0912","timestamp":1458848756000,"author":{"absoluteUrl":"https://build.opnfv.org/ci/user/fpan","fullName":"fpan"},"comment":"Fixes occasional VM stoage deleltion failure\n\nRemoves --remove-all-storage option in ci/clean.sh\n\nJIRA: APEX-121\n\nChange-Id: Ia8063112333d12d09cfb16dd1a02e14551dae7d7\nSigned-off-by: Feng Pan <fpan@redhat.com>\n","date":"2016-03-24T19:45:56+0000 -0400","id":"5f38edb9a96df7d5927d9b91039144bf4d5f0912","msg":"Fixes occasional VM stoage deleltion failure","paths":[{"editType":"edit","file":"ci/clean.sh"}]}],"kind":"git"},"culprits":[{"absoluteUrl":"https://build.opnfv.org/ci/user/fpan","description":null,"fullName":"fpan","id":"fpan","property":[{},{},{},{},{"insensitiveSearch":false},{"address":"fpan@redhat.com"},{}]}]},"lastUnstableBuild":null,"lastUnsuccessfulBuild":{"actions":[{"parameters":[{"name":"PROJECT","value":"apex"},{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},{"name":"ARTIFACT_NAME","value":"latest"},{"name":"ARTIFACT_VERSION","value":"daily"},{"name":"BUILD_DIRECTORY","value":"apex-verify-master/build_output"},{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},{"name":"OPNFV_CLEAN","value":"yes"}]},{},{"causes":[{"shortDescription":"Started by upstream project \"apex-verify-master\" build number 594","upstreamBuild":594,"upstreamProject":"apex-verify-master","upstreamUrl":"job/apex-verify-master/"}]},{},{"buildsByBranchName":{"refs/remotes/origin/master":{"buildNumber":101,"buildResult":null,"marked":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"revision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]}}},"lastBuiltRevision":{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","branch":[{"SHA1":"c77d98309557308e909c08f6879e566c87b92315","name":"refs/remotes/origin/master"}]},"remoteUrls":["$GIT_BASE"],"scmName":""},{"tags":[]},{}],"artifacts":[],"building":false,"description":null,"displayName":"#101","duration":3007635,"estimatedDuration":3286725,"executor":null,"fullDisplayName":"apex-deploy-virtual-os-onos-nofeature-ha-master #101","id":"101","keepLog":false,"number":101,"queueId":7297,"result":"FAILURE","timestamp":1458687074485,"url":"https://build.opnfv.org/ci/job/apex-deploy-virtual-os-onos-nofeature-ha-master/101/","builtOn":"intel-pod7","changeSet":{"items":[],"kind":"git"},"culprits":[]},"nextBuildNumber":108,"property":[{},{},{"parameterDefinitions":[{"defaultParameterValue":{"name":"PROJECT","value":"apex"},"description":"JJB configured PROJECT parameter to identify an opnfv Gerrit project","name":"PROJECT","type":"StringParameterDefinition"},{"defaultParameterValue":{"name":"GS_BASE","value":"artifacts.opnfv.org/$PROJECT"},"description":"URL to Google Storage.","name":"GS_BASE","type":"StringParameterDefinition"},{"defaultParameterValue":{"name":"GS_BASE_PROXY","value":"build.opnfv.org/artifacts/$PROJECT"},"description":"URL to Google Storage proxy","name":"GS_BASE_PROXY","type":"StringParameterDefinition"},{"defaultParameterValue":{"name":"ARTIFACT_NAME","value":"latest"},"description":"RPM Artifact name that will be appended to GS_URL to deploy a specific artifact","name":"ARTIFACT_NAME","type":"StringParameterDefinition"},{"defaultParameterValue":{"name":"ARTIFACT_VERSION","value":"daily"},"description":"Artifact version type","name":"ARTIFACT_VERSION","type":"StringParameterDefinition"},{"defaultParameterValue":{"name":"BUILD_DIRECTORY","value":"$WORKSPACE/build"},"description":"Directory where the build artifact will be located upon the completion of the build.","name":"BUILD_DIRECTORY","type":"StringParameterDefinition"},{"defaultParameterValue":{"name":"CACHE_DIRECTORY","value":"$HOME/opnfv/cache"},"description":"Directory where the cache to be used during the build is located.","name":"CACHE_DIRECTORY","type":"StringParameterDefinition"},{"defaultParameterValue":{"name":"GIT_BASE","value":"https://gerrit.opnfv.org/gerrit/$PROJECT"},"description":"Used for overriding the GIT URL coming from Global Jenkins configuration in case if the stuff is done on none-LF HW.","name":"GIT_BASE","type":"StringParameterDefinition"},{"defaultParameterValue":{"name":"GS_URL","value":"artifacts.opnfv.org/$PROJECT"},"description":"URL to Google Storage.","name":"GS_URL","type":"StringParameterDefinition"},{"defaultParameterValue":{"name":"DEPLOY_SCENARIO","value":"os-onos-nofeature-ha"},"description":"Scenario to deploy with.","name":"DEPLOY_SCENARIO","type":"StringParameterDefinition"},{"defaultParameterValue":{"name":"OPNFV_CLEAN","value":"no"},"description":"Use yes in lower case to invoke clean. Indicates if the deploy environment should be cleaned before deployment","name":"OPNFV_CLEAN","type":"StringParameterDefinition"}]}],"queueItem":null,"concurrentBuild":true,"downstreamProjects":[],"scm":{"browser":null,"type":"hudson.plugins.git.GitSCM","branches":[{"name":"origin/master"}],"mergeOptions":{"fastForwardMode":"--ff","mergeStrategy":"default","mergeTarget":null,"remoteBranchName":null},"userRemoteConfigs":[{"credentialsId":"d42411ac011ad6f3dd2e1fa34eaa5d87f910eb2e","name":"origin","refspec":"","url":"$GIT_BASE"}]},"upstreamProjects":[]}
+{
+  "actions": [
+    {
+      "parameterDefinitions": [
+        {
+          "defaultParameterValue": {
+            "name": "PROJECT",
+            "value": "apex"
+          },
+          "description": "JJB configured PROJECT parameter to identify an opnfv Gerrit project",
+          "name": "PROJECT",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "GS_BASE",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          "description": "URL to Google Storage.",
+          "name": "GS_BASE",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "GS_BASE_PROXY",
+            "value": "build.opnfv.org\/artifacts\/$PROJECT"
+          },
+          "description": "URL to Google Storage proxy",
+          "name": "GS_BASE_PROXY",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "ARTIFACT_NAME",
+            "value": "latest"
+          },
+          "description": "RPM Artifact name that will be appended to GS_URL to deploy a specific artifact",
+          "name": "ARTIFACT_NAME",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "ARTIFACT_VERSION",
+            "value": "daily"
+          },
+          "description": "Artifact version type",
+          "name": "ARTIFACT_VERSION",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "BUILD_DIRECTORY",
+            "value": "$WORKSPACE\/build"
+          },
+          "description": "Directory where the build artifact will be located upon the completion of the build.",
+          "name": "BUILD_DIRECTORY",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "CACHE_DIRECTORY",
+            "value": "$HOME\/opnfv\/cache"
+          },
+          "description": "Directory where the cache to be used during the build is located.",
+          "name": "CACHE_DIRECTORY",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "GIT_BASE",
+            "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+          },
+          "description": "Used for overriding the GIT URL coming from Global Jenkins configuration in case if the stuff is done on none-LF HW.",
+          "name": "GIT_BASE",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "GS_URL",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          "description": "URL to Google Storage.",
+          "name": "GS_URL",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "DEPLOY_SCENARIO",
+            "value": "os-onos-nofeature-ha"
+          },
+          "description": "Scenario to deploy with.",
+          "name": "DEPLOY_SCENARIO",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "OPNFV_CLEAN",
+            "value": "no"
+          },
+          "description": "Use yes in lower case to invoke clean. Indicates if the deploy environment should be cleaned before deployment",
+          "name": "OPNFV_CLEAN",
+          "type": "StringParameterDefinition"
+        }
+      ]
+    }
+  ],
+  "description": "<!-- Managed by Jenkins Job Builder -->",
+  "displayName": "apex-deploy-virtual-os-onos-nofeature-ha-master",
+  "displayNameOrNull": null,
+  "name": "apex-deploy-virtual-os-onos-nofeature-ha-master",
+  "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/",
+  "buildable": true,
+  "builds": [
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 609",
+              "upstreamBuild": 609,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 107,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                "branch": [
+                  {
+                    "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                "branch": [
+                  {
+                    "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+            "branch": [
+              {
+                "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#107",
+      "duration": 3177872,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #107",
+      "id": "107",
+      "keepLog": false,
+      "number": 107,
+      "queueId": 7729,
+      "result": "SUCCESS",
+      "timestamp": 1458874078582,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/107\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+          {
+            "affectedPaths": [
+              "ci\/clean.sh"
+            ],
+            "commitId": "5f38edb9a96df7d5927d9b91039144bf4d5f0912",
+            "timestamp": 1458848756000,
+            "author": {
+              "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/fpan",
+              "fullName": "fpan"
+            },
+            "comment": "Fixes occasional VM stoage deleltion failure\n\nRemoves --remove-all-storage option in ci\/clean.sh\n\nJIRA: APEX-121\n\nChange-Id: Ia8063112333d12d09cfb16dd1a02e14551dae7d7\nSigned-off-by: Feng Pan <fpan@redhat.com>\n",
+            "date": "2016-03-24T19:45:56+0000 -0400",
+            "id": "5f38edb9a96df7d5927d9b91039144bf4d5f0912",
+            "msg": "Fixes occasional VM stoage deleltion failure",
+            "paths": [
+              {
+                "editType": "edit",
+                "file": "ci\/clean.sh"
+              }
+            ]
+          }
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+        {
+          "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/fpan",
+          "description": null,
+          "fullName": "fpan",
+          "id": "fpan",
+          "property": [
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+              "insensitiveSearch": false
+            },
+            {
+              "address": "fpan@redhat.com"
+            },
+            {
+
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 607",
+              "upstreamBuild": 607,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 106,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "e45742b51011e726f13739698bdae94594709ecd",
+                "branch": [
+                  {
+                    "SHA1": "e45742b51011e726f13739698bdae94594709ecd",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "e45742b51011e726f13739698bdae94594709ecd",
+                "branch": [
+                  {
+                    "SHA1": "e45742b51011e726f13739698bdae94594709ecd",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "e45742b51011e726f13739698bdae94594709ecd",
+            "branch": [
+              {
+                "SHA1": "e45742b51011e726f13739698bdae94594709ecd",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#106",
+      "duration": 3418548,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #106",
+      "id": "106",
+      "keepLog": false,
+      "number": 106,
+      "queueId": 7689,
+      "result": "SUCCESS",
+      "timestamp": 1458854340139,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/106\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+          {
+            "affectedPaths": [
+              "build\/opnfv-tripleo-heat-templates.patch"
+            ],
+            "commitId": "89ac4d397e3a40cdfa2a807b89896c2a5e547634",
+            "timestamp": 1458782317000,
+            "author": {
+              "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/fpan",
+              "fullName": "fpan"
+            },
+            "comment": "Adds L3 agent for no-sdn no-ha scenario\n\nJIRA: APEX-110\n\nChange-Id: Ifbca9328f7ee502232b51b8641eb0c5dc90a487b\nSigned-off-by: Feng Pan <fpan@redhat.com>\n",
+            "date": "2016-03-24T01:18:37+0000 +0000",
+            "id": "89ac4d397e3a40cdfa2a807b89896c2a5e547634",
+            "msg": "Adds L3 agent for no-sdn no-ha scenario",
+            "paths": [
+              {
+                "editType": "edit",
+                "file": "build\/opnfv-tripleo-heat-templates.patch"
+              }
+            ]
+          }
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+        {
+          "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/fpan",
+          "description": null,
+          "fullName": "fpan",
+          "id": "fpan",
+          "property": [
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+              "insensitiveSearch": false
+            },
+            {
+              "address": "fpan@redhat.com"
+            },
+            {
+
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 606",
+              "upstreamBuild": 606,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 105,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "673897bcb5a8e1cb7a58941c8b6f7a4c0052c8fe",
+                "branch": [
+                  {
+                    "SHA1": "673897bcb5a8e1cb7a58941c8b6f7a4c0052c8fe",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "673897bcb5a8e1cb7a58941c8b6f7a4c0052c8fe",
+                "branch": [
+                  {
+                    "SHA1": "673897bcb5a8e1cb7a58941c8b6f7a4c0052c8fe",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "673897bcb5a8e1cb7a58941c8b6f7a4c0052c8fe",
+            "branch": [
+              {
+                "SHA1": "673897bcb5a8e1cb7a58941c8b6f7a4c0052c8fe",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#105",
+      "duration": 3263756,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #105",
+      "id": "105",
+      "keepLog": false,
+      "number": 105,
+      "queueId": 7654,
+      "result": "SUCCESS",
+      "timestamp": 1458842674184,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/105\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+          {
+            "affectedPaths": [
+              "build\/overcloud-opendaylight.sh"
+            ],
+            "commitId": "673897bcb5a8e1cb7a58941c8b6f7a4c0052c8fe",
+            "timestamp": 1458827467000,
+            "author": {
+              "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/dradez",
+              "fullName": "dradez"
+            },
+            "comment": "updating to OpenDaylight Beryllium SR1\n\nChange-Id: Idaf267854b6629a38c458b3c4c1c14af37b7d57c\n",
+            "date": "2016-03-24T13:51:07+0000 -0400",
+            "id": "673897bcb5a8e1cb7a58941c8b6f7a4c0052c8fe",
+            "msg": "updating to OpenDaylight Beryllium SR1",
+            "paths": [
+              {
+                "editType": "edit",
+                "file": "build\/overcloud-opendaylight.sh"
+              }
+            ]
+          }
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+        {
+          "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/dradez",
+          "description": null,
+          "fullName": "dradez",
+          "id": "dradez",
+          "property": [
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+              "insensitiveSearch": false
+            },
+            {
+              "address": "dradez@redhat.com"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 605",
+              "upstreamBuild": 605,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 104,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "81e8d7b55fbc27d8f25031817baf92d9b100f322",
+                "branch": [
+                  {
+                    "SHA1": "81e8d7b55fbc27d8f25031817baf92d9b100f322",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "81e8d7b55fbc27d8f25031817baf92d9b100f322",
+                "branch": [
+                  {
+                    "SHA1": "81e8d7b55fbc27d8f25031817baf92d9b100f322",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "81e8d7b55fbc27d8f25031817baf92d9b100f322",
+            "branch": [
+              {
+                "SHA1": "81e8d7b55fbc27d8f25031817baf92d9b100f322",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#104",
+      "duration": 3148854,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #104",
+      "id": "104",
+      "keepLog": false,
+      "number": 104,
+      "queueId": 7624,
+      "result": "SUCCESS",
+      "timestamp": 1458831639674,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/104\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+          {
+            "affectedPaths": [
+              "build\/cache.sh",
+              "build\/Makefile",
+              "ci\/deploy.sh",
+              "build\/opnfv-tripleo-heat-templates.patch",
+              "build\/cache.mk",
+              "build\/opnfv-apex-undercloud.spec",
+              "docs\/installation-instructions\/virtualinstall.rst",
+              "config\/network\/network_settings.yaml",
+              "build\/undercloud.sh",
+              "config\/deploy\/network\/network_settings.yaml",
+              "include\/build.sh.debug",
+              "ci\/clean.sh",
+              "build\/opnfv-apex-onos.spec",
+              "ci\/build.sh",
+              "build\/config.mk",
+              "build\/opnfv-apex-opendaylight-sfc.spec",
+              "build\/overcloud-onos.sh",
+              "lib\/installer\/onos\/onos_gw_mac_update.sh",
+              "build\/overcloud-opendaylight.sh",
+              "build\/opnfv-apex.spec",
+              "build\/opnfv-apex-common.spec",
+              "build\/instack.sh",
+              "build\/variables.sh",
+              "build\/overcloud-opendaylight-sfc.sh",
+              "build\/overcloud-full.sh"
+            ],
+            "commitId": "a90fc16a988cd5eb53de383d0830648f758edaff",
+            "timestamp": 1458736462000,
+            "author": {
+              "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/dradez",
+              "fullName": "dradez"
+            },
+            "comment": "updating vm creation for virt deployment\n\n- replacing brbm with logical names br-netname\n- replacing instack-virt-setup with tripleo scripts\n\nJIRA: APEX-90, APEX-80\n\nChange-Id: I58a15dee8de882e034c8af8a3368ca0647741b13\nSigned-off-by: Dan Radez <dradez@redhat.com>\n",
+            "date": "2016-03-23T12:34:22+0000 -0400",
+            "id": "a90fc16a988cd5eb53de383d0830648f758edaff",
+            "msg": "updating vm creation for virt deployment",
+            "paths": [
+              {
+                "editType": "edit",
+                "file": "ci\/clean.sh"
+              },
+              {
+                "editType": "edit",
+                "file": "docs\/installation-instructions\/virtualinstall.rst"
+              },
+              {
+                "editType": "delete",
+                "file": "build\/instack.sh"
+              },
+              {
+                "editType": "edit",
+                "file": "ci\/build.sh"
+              },
+              {
+                "editType": "add",
+                "file": "config\/network\/network_settings.yaml"
+              },
+              {
+                "editType": "edit",
+                "file": "build\/opnfv-tripleo-heat-templates.patch"
+              },
+              {
+                "editType": "add",
+                "file": "build\/overcloud-full.sh"
+              },
+              {
+                "editType": "add",
+                "file": "build\/opnfv-apex-onos.spec"
+              },
+              {
+                "editType": "delete",
+                "file": "include\/build.sh.debug"
+              },
+              {
+                "editType": "add",
+                "file": "build\/overcloud-opendaylight-sfc.sh"
+              },
+              {
+                "editType": "edit",
+                "file": "ci\/deploy.sh"
+              },
+              {
+                "editType": "add",
+                "file": "build\/undercloud.sh"
+              },
+              {
+                "editType": "add",
+                "file": "build\/variables.sh"
+              },
+              {
+                "editType": "edit",
+                "file": "build\/opnfv-apex.spec"
+              },
+              {
+                "editType": "edit",
+                "file": "lib\/installer\/onos\/onos_gw_mac_update.sh"
+              },
+              {
+                "editType": "edit",
+                "file": "build\/opnfv-apex-opendaylight-sfc.spec"
+              },
+              {
+                "editType": "add",
+                "file": "build\/overcloud-onos.sh"
+              },
+              {
+                "editType": "edit",
+                "file": "build\/Makefile"
+              },
+              {
+                "editType": "edit",
+                "file": "build\/opnfv-apex-undercloud.spec"
+              },
+              {
+                "editType": "edit",
+                "file": "build\/opnfv-apex-common.spec"
+              },
+              {
+                "editType": "delete",
+                "file": "build\/config.mk"
+              },
+              {
+                "editType": "add",
+                "file": "build\/cache.sh"
+              },
+              {
+                "editType": "add",
+                "file": "build\/overcloud-opendaylight.sh"
+              },
+              {
+                "editType": "delete",
+                "file": "config\/deploy\/network\/network_settings.yaml"
+              },
+              {
+                "editType": "delete",
+                "file": "build\/cache.mk"
+              }
+            ]
+          },
+          {
+            "affectedPaths": [
+              "ci\/deploy.sh"
+            ],
+            "commitId": "4b5e79294eecf7e10bfb1459c55f9186312c32bf",
+            "timestamp": 1458758222000,
+            "author": {
+              "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/dradez",
+              "fullName": "dradez"
+            },
+            "comment": "Allow 2+ compute node for none HA installs APEX-117\n\nChanged the number of compute nodes to no longer be\nhard coded to 1 and now calculate to be total_nodes -1\nfor non-HA deployments.\n\nRebased to new build.\n\nChange-Id: I8dc135876a8b436714806b79d4193d225761534d\nSigned-off-by: randyl <r.levensalor@cablelabs.com>\n",
+            "date": "2016-03-23T18:37:02+0000 -0400",
+            "id": "4b5e79294eecf7e10bfb1459c55f9186312c32bf",
+            "msg": "Allow 2+ compute node for none HA installs APEX-117",
+            "paths": [
+              {
+                "editType": "edit",
+                "file": "ci\/deploy.sh"
+              }
+            ]
+          }
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+        {
+          "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/dradez",
+          "description": null,
+          "fullName": "dradez",
+          "id": "dradez",
+          "property": [
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+              "insensitiveSearch": false
+            },
+            {
+              "address": "dradez@redhat.com"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 600",
+              "upstreamBuild": 600,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 103,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "a896444c04552b866a9460bbe70ae3488e4877d9",
+                "branch": [
+                  {
+                    "SHA1": "a896444c04552b866a9460bbe70ae3488e4877d9",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "a896444c04552b866a9460bbe70ae3488e4877d9",
+                "branch": [
+                  {
+                    "SHA1": "a896444c04552b866a9460bbe70ae3488e4877d9",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "a896444c04552b866a9460bbe70ae3488e4877d9",
+            "branch": [
+              {
+                "SHA1": "a896444c04552b866a9460bbe70ae3488e4877d9",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#103",
+      "duration": 3424142,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #103",
+      "id": "103",
+      "keepLog": false,
+      "number": 103,
+      "queueId": 7468,
+      "result": "SUCCESS",
+      "timestamp": 1458764722848,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/103\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 596",
+              "upstreamBuild": 596,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 102,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "a896444c04552b866a9460bbe70ae3488e4877d9",
+                "branch": [
+                  {
+                    "SHA1": "a896444c04552b866a9460bbe70ae3488e4877d9",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "a896444c04552b866a9460bbe70ae3488e4877d9",
+                "branch": [
+                  {
+                    "SHA1": "a896444c04552b866a9460bbe70ae3488e4877d9",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "a896444c04552b866a9460bbe70ae3488e4877d9",
+            "branch": [
+              {
+                "SHA1": "a896444c04552b866a9460bbe70ae3488e4877d9",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#102",
+      "duration": 3433144,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #102",
+      "id": "102",
+      "keepLog": false,
+      "number": 102,
+      "queueId": 7399,
+      "result": "SUCCESS",
+      "timestamp": 1458740779456,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/102\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+          {
+            "affectedPaths": [
+              "docs\/installation-instructions\/baremetal.rst",
+              "LICENSE.rst"
+            ],
+            "commitId": "a896444c04552b866a9460bbe70ae3488e4877d9",
+            "timestamp": 1458669391000,
+            "author": {
+              "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/r.levensalor",
+              "fullName": "r.levensalor"
+            },
+            "comment": "Fixed minor warnings in .rst files\n\nSome of the titles in LICENSE.rst and baremetal.rst\nhad extra underline characters.  These should match\nthe length of the line above.\n\nVery minor and low priorty changes, but we should fix\nany of the warnings that we can.\n\nChange-Id: Idaa7c8272ef034b5000360c7720d99a89357d0b6\nSigned-off-by: randyl <r.levensalor@cablelabs.com>\n",
+            "date": "2016-03-22T17:56:31+0000 -0600",
+            "id": "a896444c04552b866a9460bbe70ae3488e4877d9",
+            "msg": "Fixed minor warnings in .rst files",
+            "paths": [
+              {
+                "editType": "edit",
+                "file": "docs\/installation-instructions\/baremetal.rst"
+              },
+              {
+                "editType": "edit",
+                "file": "LICENSE.rst"
+              }
+            ]
+          }
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+        {
+          "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/r.levensalor",
+          "description": null,
+          "fullName": "r.levensalor",
+          "id": "r.levensalor",
+          "property": [
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+              "insensitiveSearch": false
+            },
+            {
+              "address": "r.levensalor@cablelabs.com"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 594",
+              "upstreamBuild": 594,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 101,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "branch": [
+                  {
+                    "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "branch": [
+                  {
+                    "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+            "branch": [
+              {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#101",
+      "duration": 3007635,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #101",
+      "id": "101",
+      "keepLog": false,
+      "number": 101,
+      "queueId": 7297,
+      "result": "FAILURE",
+      "timestamp": 1458687074485,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/101\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 592",
+              "upstreamBuild": 592,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 100,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "branch": [
+                  {
+                    "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "branch": [
+                  {
+                    "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+            "branch": [
+              {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#100",
+      "duration": 3329249,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #100",
+      "id": "100",
+      "keepLog": false,
+      "number": 100,
+      "queueId": 7248,
+      "result": "SUCCESS",
+      "timestamp": 1458662464685,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/100\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 591",
+              "upstreamBuild": 591,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 99,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "branch": [
+                  {
+                    "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "branch": [
+                  {
+                    "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+            "branch": [
+              {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#99",
+      "duration": 3454904,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #99",
+      "id": "99",
+      "keepLog": false,
+      "number": 99,
+      "queueId": 7116,
+      "result": "SUCCESS",
+      "timestamp": 1458596193695,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/99\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 587",
+              "upstreamBuild": 587,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 98,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "branch": [
+                  {
+                    "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "branch": [
+                  {
+                    "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+            "branch": [
+              {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#98",
+      "duration": 3371998,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #98",
+      "id": "98",
+      "keepLog": false,
+      "number": 98,
+      "queueId": 6733,
+      "result": "SUCCESS",
+      "timestamp": 1458317164057,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/98\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 586",
+              "upstreamBuild": 586,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 97,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "branch": [
+                  {
+                    "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "branch": [
+                  {
+                    "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+            "branch": [
+              {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#97",
+      "duration": 1807226,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #97",
+      "id": "97",
+      "keepLog": false,
+      "number": 97,
+      "queueId": 6689,
+      "result": "FAILURE",
+      "timestamp": 1458303613770,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/97\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 580",
+              "upstreamBuild": 580,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 96,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "branch": [
+                  {
+                    "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "branch": [
+                  {
+                    "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+            "branch": [
+              {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#96",
+      "duration": 3389159,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #96",
+      "id": "96",
+      "keepLog": false,
+      "number": 96,
+      "queueId": 6522,
+      "result": "SUCCESS",
+      "timestamp": 1458233230260,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/96\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 577",
+              "upstreamBuild": 577,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 95,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "branch": [
+                  {
+                    "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "branch": [
+                  {
+                    "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+            "branch": [
+              {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#95",
+      "duration": 6011229,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #95",
+      "id": "95",
+      "keepLog": false,
+      "number": 95,
+      "queueId": 6150,
+      "result": "FAILURE",
+      "timestamp": 1458005126299,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/95\/",
+      "builtOn": "opnfv-jump-1",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 573",
+              "upstreamBuild": 573,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 94,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "branch": [
+                  {
+                    "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "branch": [
+                  {
+                    "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+            "branch": [
+              {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#94",
+      "duration": 4507245,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #94",
+      "id": "94",
+      "keepLog": false,
+      "number": 94,
+      "queueId": 5807,
+      "result": "SUCCESS",
+      "timestamp": 1457715586283,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/94\/",
+      "builtOn": "opnfv-jump-1",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 569",
+              "upstreamBuild": 569,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 93,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "branch": [
+                  {
+                    "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "branch": [
+                  {
+                    "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+            "branch": [
+              {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#93",
+      "duration": 2579393,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #93",
+      "id": "93",
+      "keepLog": false,
+      "number": 93,
+      "queueId": 5567,
+      "result": "SUCCESS",
+      "timestamp": 1457666574839,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/93\/",
+      "builtOn": "opnfv-jump-1",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+        {
+          "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/trozet",
+          "description": null,
+          "fullName": "trozet",
+          "id": "trozet",
+          "property": [
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+              "insensitiveSearch": false
+            },
+            {
+              "address": "trozet@redhat.com"
+            },
+            {
+
+            }
+          ]
+        },
+        {
+          "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/viktor.tikkanen",
+          "description": null,
+          "fullName": "viktor.tikkanen",
+          "id": "viktor.tikkanen",
+          "property": [
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+              "insensitiveSearch": false
+            },
+            {
+              "address": "viktor.tikkanen@nokia.com"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 567",
+              "upstreamBuild": 567,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 92,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "branch": [
+                  {
+                    "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "branch": [
+                  {
+                    "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+            "branch": [
+              {
+                "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#92",
+      "duration": 2601096,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #92",
+      "id": "92",
+      "keepLog": false,
+      "number": 92,
+      "queueId": 5515,
+      "result": "FAILURE",
+      "timestamp": 1457624018970,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/92\/",
+      "builtOn": "opnfv-jump-1",
+      "changeSet": {
+        "items": [
+          {
+            "affectedPaths": [
+              "docs\/installation-instructions\/baremetal.rst"
+            ],
+            "commitId": "c77d98309557308e909c08f6879e566c87b92315",
+            "timestamp": 1457523201000,
+            "author": {
+              "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/viktor.tikkanen",
+              "fullName": "viktor.tikkanen"
+            },
+            "comment": "Corrected a couple of errors in the installation instructions\n\nChange-Id: I52889fd3a29b03e46fcb84c60feb7d3b67fe44c7\nSigned-off-by: Viktor Tikkanen <viktor.tikkanen@nokia.com>\n",
+            "date": "2016-03-09T11:33:21+0000 +0200",
+            "id": "c77d98309557308e909c08f6879e566c87b92315",
+            "msg": "Corrected a couple of errors in the installation instructions",
+            "paths": [
+              {
+                "editType": "edit",
+                "file": "docs\/installation-instructions\/baremetal.rst"
+              }
+            ]
+          }
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+        {
+          "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/trozet",
+          "description": null,
+          "fullName": "trozet",
+          "id": "trozet",
+          "property": [
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+              "insensitiveSearch": false
+            },
+            {
+              "address": "trozet@redhat.com"
+            },
+            {
+
+            }
+          ]
+        },
+        {
+          "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/viktor.tikkanen",
+          "description": null,
+          "fullName": "viktor.tikkanen",
+          "id": "viktor.tikkanen",
+          "property": [
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+              "insensitiveSearch": false
+            },
+            {
+              "address": "viktor.tikkanen@nokia.com"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 564",
+              "upstreamBuild": 564,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 91,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                "branch": [
+                  {
+                    "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                "branch": [
+                  {
+                    "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+            "branch": [
+              {
+                "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#91",
+      "duration": 3130609,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #91",
+      "id": "91",
+      "keepLog": false,
+      "number": 91,
+      "queueId": 5386,
+      "result": "FAILURE",
+      "timestamp": 1457542916260,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/91\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+        {
+          "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/trozet",
+          "description": null,
+          "fullName": "trozet",
+          "id": "trozet",
+          "property": [
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+              "insensitiveSearch": false
+            },
+            {
+              "address": "trozet@redhat.com"
+            },
+            {
+
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            }
+          ]
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by user radez",
+              "userId": "radez",
+              "userName": "radez"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 90,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                "branch": [
+                  {
+                    "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                "branch": [
+                  {
+                    "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+            "branch": [
+              {
+                "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#90",
+      "duration": 3625631,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #90",
+      "id": "90",
+      "keepLog": false,
+      "number": 90,
+      "queueId": 5344,
+      "result": "FAILURE",
+      "timestamp": 1457531557423,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/90\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+        {
+          "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/trozet",
+          "description": null,
+          "fullName": "trozet",
+          "id": "trozet",
+          "property": [
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+              "insensitiveSearch": false
+            },
+            {
+              "address": "trozet@redhat.com"
+            },
+            {
+
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "aprx-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            }
+          ]
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by user radez",
+              "userId": "radez",
+              "userName": "radez"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 89,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                "branch": [
+                  {
+                    "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                "branch": [
+                  {
+                    "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+            "branch": [
+              {
+                "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#89",
+      "duration": 3370,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #89",
+      "id": "89",
+      "keepLog": false,
+      "number": 89,
+      "queueId": 5343,
+      "result": "FAILURE",
+      "timestamp": 1457531512898,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/89\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+        {
+          "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/trozet",
+          "description": null,
+          "fullName": "trozet",
+          "id": "trozet",
+          "property": [
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+              "insensitiveSearch": false
+            },
+            {
+              "address": "trozet@redhat.com"
+            },
+            {
+
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            }
+          ]
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by user radez",
+              "userId": "radez",
+              "userName": "radez"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 88,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                "branch": [
+                  {
+                    "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                "branch": [
+                  {
+                    "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+            "branch": [
+              {
+                "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#88",
+      "duration": 16004,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #88",
+      "id": "88",
+      "keepLog": false,
+      "number": 88,
+      "queueId": 5342,
+      "result": "FAILURE",
+      "timestamp": 1457531436772,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/88\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+        {
+          "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/trozet",
+          "description": null,
+          "fullName": "trozet",
+          "id": "trozet",
+          "property": [
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+              "insensitiveSearch": false
+            },
+            {
+              "address": "trozet@redhat.com"
+            },
+            {
+
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "yes"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 563",
+              "upstreamBuild": 563,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 87,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                "branch": [
+                  {
+                    "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                "branch": [
+                  {
+                    "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+            "branch": [
+              {
+                "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#87",
+      "duration": 4142,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #87",
+      "id": "87",
+      "keepLog": false,
+      "number": 87,
+      "queueId": 5291,
+      "result": "FAILURE",
+      "timestamp": 1457502514335,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/87\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+        {
+          "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/trozet",
+          "description": null,
+          "fullName": "trozet",
+          "id": "trozet",
+          "property": [
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+              "insensitiveSearch": false
+            },
+            {
+              "address": "trozet@redhat.com"
+            },
+            {
+
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "OPNFV_CLEAN",
+              "value": "'yes'"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 561",
+              "upstreamBuild": 561,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 86,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                "branch": [
+                  {
+                    "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                "branch": [
+                  {
+                    "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+            "branch": [
+              {
+                "SHA1": "67566f2f8c700f8c4b78bfac557f70721a243834",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#86",
+      "duration": 3884,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #86",
+      "id": "86",
+      "keepLog": false,
+      "number": 86,
+      "queueId": 5243,
+      "result": "FAILURE",
+      "timestamp": 1457481225612,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/86\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+          {
+            "affectedPaths": [
+              "build\/opendaylight-puppet-neutron.patch",
+              "build\/opnfv-puppet-tripleo.patch",
+              "build\/opnfv-tripleo-heat-templates.patch",
+              "build\/instack.sh",
+              "build\/opendaylight.yaml",
+              "build\/network-environment.yaml"
+            ],
+            "commitId": "67566f2f8c700f8c4b78bfac557f70721a243834",
+            "timestamp": 1457271814000,
+            "author": {
+              "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/trozet",
+              "fullName": "trozet"
+            },
+            "comment": "Adds OpenDaylight HA (OVSDB Clustering)\n\nOVSDB Clustering changes include:\n - Modifications to create an OpenDaylight\n   VIP for communication between Neutron SB <-> ODL NB.\n - OpenDaylight configured in HA mode in THT via puppet-opendaylight\n - OVS instances configured with managers pointing to all 3 ODL\n   instances for HA mode\n - Build now points to latest Beryllium release\n - Modified puppet-neutron in build to pull latest stable\/liberty\n\nJIRA: APEX-107\n\nChange-Id: Iab510db922dfcd2fbd4962b9751cd2f7e5724f44\nSigned-off-by: Tim Rozet <trozet@redhat.com>\n",
+            "date": "2016-03-06T13:43:34+0000 -0500",
+            "id": "67566f2f8c700f8c4b78bfac557f70721a243834",
+            "msg": "Adds OpenDaylight HA (OVSDB Clustering)",
+            "paths": [
+              {
+                "editType": "edit",
+                "file": "build\/network-environment.yaml"
+              },
+              {
+                "editType": "add",
+                "file": "build\/opnfv-puppet-tripleo.patch"
+              },
+              {
+                "editType": "delete",
+                "file": "build\/opendaylight.yaml"
+              },
+              {
+                "editType": "edit",
+                "file": "build\/opnfv-tripleo-heat-templates.patch"
+              },
+              {
+                "editType": "delete",
+                "file": "build\/opendaylight-puppet-neutron.patch"
+              },
+              {
+                "editType": "edit",
+                "file": "build\/instack.sh"
+              }
+            ]
+          }
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+        {
+          "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/trozet",
+          "description": null,
+          "fullName": "trozet",
+          "id": "trozet",
+          "property": [
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+              "insensitiveSearch": false
+            },
+            {
+              "address": "trozet@redhat.com"
+            },
+            {
+
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 545",
+              "upstreamBuild": 545,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 85,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                "branch": [
+                  {
+                    "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                "branch": [
+                  {
+                    "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+            "branch": [
+              {
+                "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#85",
+      "duration": 3225200,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #85",
+      "id": "85",
+      "keepLog": false,
+      "number": 85,
+      "queueId": 4875,
+      "result": "SUCCESS",
+      "timestamp": 1457279067422,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/85\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 544",
+              "upstreamBuild": 544,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 84,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                "branch": [
+                  {
+                    "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                "branch": [
+                  {
+                    "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+            "branch": [
+              {
+                "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#84",
+      "duration": 6223527,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #84",
+      "id": "84",
+      "keepLog": false,
+      "number": 84,
+      "queueId": 4828,
+      "result": "FAILURE",
+      "timestamp": 1457237232789,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/84\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 539",
+              "upstreamBuild": 539,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 83,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                "branch": [
+                  {
+                    "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                "branch": [
+                  {
+                    "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+            "branch": [
+              {
+                "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#83",
+      "duration": 3206030,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #83",
+      "id": "83",
+      "keepLog": false,
+      "number": 83,
+      "queueId": 4646,
+      "result": "SUCCESS",
+      "timestamp": 1457106431319,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/83\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 537",
+              "upstreamBuild": 537,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 82,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                "branch": [
+                  {
+                    "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                "branch": [
+                  {
+                    "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+            "branch": [
+              {
+                "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#82",
+      "duration": 3257519,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #82",
+      "id": "82",
+      "keepLog": false,
+      "number": 82,
+      "queueId": 4559,
+      "result": "SUCCESS",
+      "timestamp": 1457073386167,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/82\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+        {
+          "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/dradez",
+          "description": null,
+          "fullName": "dradez",
+          "id": "dradez",
+          "property": [
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+              "insensitiveSearch": false
+            },
+            {
+              "address": "dradez@redhat.com"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 529",
+              "upstreamBuild": 529,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 81,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                "branch": [
+                  {
+                    "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                "branch": [
+                  {
+                    "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+            "branch": [
+              {
+                "SHA1": "17c3afc75f082e9374eb1344068c792d178c0d35",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#81",
+      "duration": 6216519,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #81",
+      "id": "81",
+      "keepLog": false,
+      "number": 81,
+      "queueId": 4228,
+      "result": "FAILURE",
+      "timestamp": 1456887239044,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/81\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+          {
+            "affectedPaths": [
+              "build\/Makefile"
+            ],
+            "commitId": "7f1312c63dff70df8a2c29bfe4a16b6e159e4c44",
+            "timestamp": 1456757123000,
+            "author": {
+              "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/dradez",
+              "fullName": "dradez"
+            },
+            "comment": "updating the centos dvd version\n\nChange-Id: I2ab43f43858745b5ac5ed695301ad09290b2c320\nSigned-off-by: Dan Radez <dradez@redhat.com>\n",
+            "date": "2016-02-29T14:45:23+0000 -0500",
+            "id": "7f1312c63dff70df8a2c29bfe4a16b6e159e4c44",
+            "msg": "updating the centos dvd version",
+            "paths": [
+              {
+                "editType": "edit",
+                "file": "build\/Makefile"
+              }
+            ]
+          },
+          {
+            "affectedPaths": [
+              "ci\/deploy.sh"
+            ],
+            "commitId": "796cb23d09f15790cf397aa30a892bfe670c648f",
+            "timestamp": 1456777447000,
+            "author": {
+              "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/dradez",
+              "fullName": "dradez"
+            },
+            "comment": "updates to fix the --flat option\n\nJIRA: APEX-84\n\nChange-Id: Ic806118c3c3032abff6cebe5c93ad62a6a0a23c7\nSigned-off-by: Dan Radez <dradez@redhat.com>\n",
+            "date": "2016-02-29T20:24:07+0000 -0500",
+            "id": "796cb23d09f15790cf397aa30a892bfe670c648f",
+            "msg": "updates to fix the --flat option",
+            "paths": [
+              {
+                "editType": "edit",
+                "file": "ci\/deploy.sh"
+              }
+            ]
+          },
+          {
+            "affectedPaths": [
+              "build\/instack.sh"
+            ],
+            "commitId": "17c3afc75f082e9374eb1344068c792d178c0d35",
+            "timestamp": 1456778658000,
+            "author": {
+              "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/dradez",
+              "fullName": "dradez"
+            },
+            "comment": "AMT Power Management fixes\n\n- Teal Box uses AMT power management, this fixes the support for the AMT power Management so the Ironic AMT driver can\nbe used.\n\nChange-Id: If7c3c89cf6063c18a97524ade387e4ae841f6c80\nSigned-off-by: Dan Radez <dradez@redhat.com>\n",
+            "date": "2016-02-29T20:44:18+0000 -0500",
+            "id": "17c3afc75f082e9374eb1344068c792d178c0d35",
+            "msg": "AMT Power Management fixes",
+            "paths": [
+              {
+                "editType": "edit",
+                "file": "build\/instack.sh"
+              }
+            ]
+          }
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+        {
+          "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/dradez",
+          "description": null,
+          "fullName": "dradez",
+          "id": "dradez",
+          "property": [
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+              "insensitiveSearch": false
+            },
+            {
+              "address": "dradez@redhat.com"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 523",
+              "upstreamBuild": 523,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 80,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+                "branch": [
+                  {
+                    "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+                "branch": [
+                  {
+                    "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+            "branch": [
+              {
+                "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#80",
+      "duration": 3267434,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #80",
+      "id": "80",
+      "keepLog": false,
+      "number": 80,
+      "queueId": 4095,
+      "result": "SUCCESS",
+      "timestamp": 1456818216523,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/80\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 522",
+              "upstreamBuild": 522,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 79,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+                "branch": [
+                  {
+                    "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+                "branch": [
+                  {
+                    "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+            "branch": [
+              {
+                "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#79",
+      "duration": 3204325,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #79",
+      "id": "79",
+      "keepLog": false,
+      "number": 79,
+      "queueId": 4078,
+      "result": "SUCCESS",
+      "timestamp": 1456803828790,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/79\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 521",
+              "upstreamBuild": 521,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 78,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+                "branch": [
+                  {
+                    "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+                "branch": [
+                  {
+                    "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+            "branch": [
+              {
+                "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#78",
+      "duration": 5202826,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #78",
+      "id": "78",
+      "keepLog": false,
+      "number": 78,
+      "queueId": 4041,
+      "result": "SUCCESS",
+      "timestamp": 1456787398571,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/78\/",
+      "builtOn": "intel-pod7",
+      "changeSet": {
+        "items": [
+
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 497",
+              "upstreamBuild": 497,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 77,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+                "branch": [
+                  {
+                    "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+                "branch": [
+                  {
+                    "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+            "branch": [
+              {
+                "SHA1": "034166ea6f9330310789407d8a124812042f305d",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#77",
+      "duration": 2606511,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #77",
+      "id": "77",
+      "keepLog": false,
+      "number": 77,
+      "queueId": 3410,
+      "result": "SUCCESS",
+      "timestamp": 1456439122321,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/77\/",
+      "builtOn": "opnfv-jump-1",
+      "changeSet": {
+        "items": [
+          {
+            "affectedPaths": [
+              "ci\/deploy.sh"
+            ],
+            "commitId": "034166ea6f9330310789407d8a124812042f305d",
+            "timestamp": 1456327079000,
+            "author": {
+              "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/trozet",
+              "fullName": "trozet"
+            },
+            "comment": "fix bug in ci\/build.sh\n\nThis patch fixes bug in ci\/build.sh that cause the following error\nmessage:\n\n    \/bin\/opnfv-deploy: line 197: [: too many arguments\n\nChange-Id: I92419473262a51806baee849669af9b84b94045c\nSigned-off-by: Ryota MIBU <r-mibu@cq.jp.nec.com>\n",
+            "date": "2016-02-24T15:17:59+0000 +0000",
+            "id": "034166ea6f9330310789407d8a124812042f305d",
+            "msg": "fix bug in ci\/build.sh",
+            "paths": [
+              {
+                "editType": "edit",
+                "file": "ci\/deploy.sh"
+              }
+            ]
+          }
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+        {
+          "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/trozet",
+          "description": null,
+          "fullName": "trozet",
+          "id": "trozet",
+          "property": [
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+              "insensitiveSearch": false
+            },
+            {
+              "address": "trozet@redhat.com"
+            },
+            {
+
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "actions": [
+        {
+          "parameters": [
+            {
+              "name": "PROJECT",
+              "value": "apex"
+            },
+            {
+              "name": "GS_BASE",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "GS_BASE_PROXY",
+              "value": "build.opnfv.org\/artifacts\/$PROJECT"
+            },
+            {
+              "name": "ARTIFACT_NAME",
+              "value": "latest"
+            },
+            {
+              "name": "ARTIFACT_VERSION",
+              "value": "daily"
+            },
+            {
+              "name": "BUILD_DIRECTORY",
+              "value": "apex-verify-master\/build_output"
+            },
+            {
+              "name": "CACHE_DIRECTORY",
+              "value": "$HOME\/opnfv\/cache"
+            },
+            {
+              "name": "GIT_BASE",
+              "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+            },
+            {
+              "name": "GS_URL",
+              "value": "artifacts.opnfv.org\/$PROJECT"
+            },
+            {
+              "name": "DEPLOY_SCENARIO",
+              "value": "os-onos-nofeature-ha"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "causes": [
+            {
+              "shortDescription": "Started by upstream project \"apex-verify-master\" build number 493",
+              "upstreamBuild": 493,
+              "upstreamProject": "apex-verify-master",
+              "upstreamUrl": "job\/apex-verify-master\/"
+            }
+          ]
+        },
+        {
+
+        },
+        {
+          "buildsByBranchName": {
+            "refs\/remotes\/origin\/master": {
+              "buildNumber": 76,
+              "buildResult": null,
+              "marked": {
+                "SHA1": "5fece9e6f4bca1f7551dfbf50c385300f264f4f4",
+                "branch": [
+                  {
+                    "SHA1": "5fece9e6f4bca1f7551dfbf50c385300f264f4f4",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              },
+              "revision": {
+                "SHA1": "5fece9e6f4bca1f7551dfbf50c385300f264f4f4",
+                "branch": [
+                  {
+                    "SHA1": "5fece9e6f4bca1f7551dfbf50c385300f264f4f4",
+                    "name": "refs\/remotes\/origin\/master"
+                  }
+                ]
+              }
+            }
+          },
+          "lastBuiltRevision": {
+            "SHA1": "5fece9e6f4bca1f7551dfbf50c385300f264f4f4",
+            "branch": [
+              {
+                "SHA1": "5fece9e6f4bca1f7551dfbf50c385300f264f4f4",
+                "name": "refs\/remotes\/origin\/master"
+              }
+            ]
+          },
+          "remoteUrls": [
+            "$GIT_BASE"
+          ],
+          "scmName": ""
+        },
+        {
+          "tags": [
+
+          ]
+        },
+        {
+
+        }
+      ],
+      "artifacts": [
+
+      ],
+      "building": false,
+      "description": null,
+      "displayName": "#76",
+      "duration": 2697138,
+      "estimatedDuration": 3286725,
+      "executor": null,
+      "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #76",
+      "id": "76",
+      "keepLog": false,
+      "number": 76,
+      "queueId": 2914,
+      "result": "SUCCESS",
+      "timestamp": 1456357766112,
+      "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/76\/",
+      "builtOn": "opnfv-jump-1",
+      "changeSet": {
+        "items": [
+          {
+            "affectedPaths": [
+              "ci\/deploy.sh",
+              "config\/deploy\/deploy_settings.yaml",
+              "config\/deploy\/os-nosdn-nofeature-ha.yaml",
+              "build\/opnfv-tripleo-heat-templates.patch",
+              "config\/deploy\/os-odl_l2-sfc-noha.yaml",
+              "config\/deploy\/os-opencontrail-nofeature-ha.yaml",
+              "config\/deploy\/os-odl_l2-nofeature-ha.yaml",
+              "config\/deploy\/os-onos-nofeature-ha.yaml",
+              "config\/deploy\/os-odl_l3-nofeature-ha.yaml",
+              "build\/instack.sh",
+              "config\/deploy\/os-odl_l2-sdnvpn-ha.yaml"
+            ],
+            "commitId": "c86bd1f24647646b7489cd72e0a0bb91f4a505f1",
+            "timestamp": 1456110872000,
+            "author": {
+              "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/woppin",
+              "fullName": "woppin"
+            },
+            "comment": "Adding SDNVPN support\n\nChange-Id: Id2d6d46a53129d4ae2f93fad835536da067e42df\nJIRA: APEX-51\nSigned-off-by: Dan Radez <dradez@redhat.com>\n",
+            "date": "2016-02-22T03:14:32+0000 +1100",
+            "id": "c86bd1f24647646b7489cd72e0a0bb91f4a505f1",
+            "msg": "Adding SDNVPN support",
+            "paths": [
+              {
+                "editType": "edit",
+                "file": "config\/deploy\/os-onos-nofeature-ha.yaml"
+              },
+              {
+                "editType": "edit",
+                "file": "config\/deploy\/os-odl_l3-nofeature-ha.yaml"
+              },
+              {
+                "editType": "edit",
+                "file": "config\/deploy\/os-odl_l2-nofeature-ha.yaml"
+              },
+              {
+                "editType": "edit",
+                "file": "build\/opnfv-tripleo-heat-templates.patch"
+              },
+              {
+                "editType": "edit",
+                "file": "config\/deploy\/os-opencontrail-nofeature-ha.yaml"
+              },
+              {
+                "editType": "add",
+                "file": "config\/deploy\/os-odl_l2-sdnvpn-ha.yaml"
+              },
+              {
+                "editType": "edit",
+                "file": "config\/deploy\/os-nosdn-nofeature-ha.yaml"
+              },
+              {
+                "editType": "edit",
+                "file": "build\/instack.sh"
+              },
+              {
+                "editType": "edit",
+                "file": "config\/deploy\/os-odl_l2-sfc-noha.yaml"
+              },
+              {
+                "editType": "edit",
+                "file": "config\/deploy\/deploy_settings.yaml"
+              },
+              {
+                "editType": "edit",
+                "file": "ci\/deploy.sh"
+              }
+            ]
+          },
+          {
+            "affectedPaths": [
+              "docs\/release-notes\/release-notes.rst"
+            ],
+            "commitId": "eaab4d01e838a13211c812d4c11200b07a6c36d3",
+            "timestamp": 1456260844000,
+            "author": {
+              "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/dradez",
+              "fullName": "dradez"
+            },
+            "comment": "adding know issues to release docs for Brahmaputra\n\nChange-Id: I7be396d98a4a1e42852576e9819510513ebf9a85\nSigned-off-by: Dan Radez <dradez@redhat.com>\n",
+            "date": "2016-02-23T20:54:04+0000 -0500",
+            "id": "eaab4d01e838a13211c812d4c11200b07a6c36d3",
+            "msg": "adding know issues to release docs for Brahmaputra",
+            "paths": [
+              {
+                "editType": "edit",
+                "file": "docs\/release-notes\/release-notes.rst"
+              }
+            ]
+          }
+        ],
+        "kind": "git"
+      },
+      "culprits": [
+        {
+          "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/dradez",
+          "description": null,
+          "fullName": "dradez",
+          "id": "dradez",
+          "property": [
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+              "insensitiveSearch": false
+            },
+            {
+              "address": "dradez@redhat.com"
+            }
+          ]
+        },
+        {
+          "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/woppin",
+          "description": null,
+          "fullName": "woppin",
+          "id": "woppin",
+          "property": [
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+
+            },
+            {
+              "insensitiveSearch": false
+            },
+            {
+              "address": "woppin@gmail.com"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "color": "blue",
+  "firstBuild": {
+    "actions": [
+      {
+        "parameters": [
+          {
+            "name": "PROJECT",
+            "value": "apex"
+          },
+          {
+            "name": "GS_BASE",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "GS_BASE_PROXY",
+            "value": "build.opnfv.org\/artifacts\/$PROJECT"
+          },
+          {
+            "name": "ARTIFACT_NAME",
+            "value": "latest"
+          },
+          {
+            "name": "ARTIFACT_VERSION",
+            "value": "daily"
+          },
+          {
+            "name": "BUILD_DIRECTORY",
+            "value": "apex-verify-master\/build_output"
+          },
+          {
+            "name": "CACHE_DIRECTORY",
+            "value": "$HOME\/opnfv\/cache"
+          },
+          {
+            "name": "GIT_BASE",
+            "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+          },
+          {
+            "name": "GS_URL",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "DEPLOY_SCENARIO",
+            "value": "os-onos-nofeature-ha"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "causes": [
+          {
+            "shortDescription": "Started by upstream project \"apex-verify-master\" build number 493",
+            "upstreamBuild": 493,
+            "upstreamProject": "apex-verify-master",
+            "upstreamUrl": "job\/apex-verify-master\/"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "buildsByBranchName": {
+          "refs\/remotes\/origin\/master": {
+            "buildNumber": 76,
+            "buildResult": null,
+            "marked": {
+              "SHA1": "5fece9e6f4bca1f7551dfbf50c385300f264f4f4",
+              "branch": [
+                {
+                  "SHA1": "5fece9e6f4bca1f7551dfbf50c385300f264f4f4",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            },
+            "revision": {
+              "SHA1": "5fece9e6f4bca1f7551dfbf50c385300f264f4f4",
+              "branch": [
+                {
+                  "SHA1": "5fece9e6f4bca1f7551dfbf50c385300f264f4f4",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            }
+          }
+        },
+        "lastBuiltRevision": {
+          "SHA1": "5fece9e6f4bca1f7551dfbf50c385300f264f4f4",
+          "branch": [
+            {
+              "SHA1": "5fece9e6f4bca1f7551dfbf50c385300f264f4f4",
+              "name": "refs\/remotes\/origin\/master"
+            }
+          ]
+        },
+        "remoteUrls": [
+          "$GIT_BASE"
+        ],
+        "scmName": ""
+      },
+      {
+        "tags": [
+
+        ]
+      },
+      {
+
+      }
+    ],
+    "artifacts": [
+
+    ],
+    "building": false,
+    "description": null,
+    "displayName": "#76",
+    "duration": 2697138,
+    "estimatedDuration": 3286725,
+    "executor": null,
+    "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #76",
+    "id": "76",
+    "keepLog": false,
+    "number": 76,
+    "queueId": 2914,
+    "result": "SUCCESS",
+    "timestamp": 1456357766112,
+    "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/76\/",
+    "builtOn": "opnfv-jump-1",
+    "changeSet": {
+      "items": [
+        {
+          "affectedPaths": [
+            "ci\/deploy.sh",
+            "config\/deploy\/deploy_settings.yaml",
+            "config\/deploy\/os-nosdn-nofeature-ha.yaml",
+            "build\/opnfv-tripleo-heat-templates.patch",
+            "config\/deploy\/os-odl_l2-sfc-noha.yaml",
+            "config\/deploy\/os-opencontrail-nofeature-ha.yaml",
+            "config\/deploy\/os-odl_l2-nofeature-ha.yaml",
+            "config\/deploy\/os-onos-nofeature-ha.yaml",
+            "config\/deploy\/os-odl_l3-nofeature-ha.yaml",
+            "build\/instack.sh",
+            "config\/deploy\/os-odl_l2-sdnvpn-ha.yaml"
+          ],
+          "commitId": "c86bd1f24647646b7489cd72e0a0bb91f4a505f1",
+          "timestamp": 1456110872000,
+          "author": {
+            "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/woppin",
+            "fullName": "woppin"
+          },
+          "comment": "Adding SDNVPN support\n\nChange-Id: Id2d6d46a53129d4ae2f93fad835536da067e42df\nJIRA: APEX-51\nSigned-off-by: Dan Radez <dradez@redhat.com>\n",
+          "date": "2016-02-22T03:14:32+0000 +1100",
+          "id": "c86bd1f24647646b7489cd72e0a0bb91f4a505f1",
+          "msg": "Adding SDNVPN support",
+          "paths": [
+            {
+              "editType": "edit",
+              "file": "config\/deploy\/os-onos-nofeature-ha.yaml"
+            },
+            {
+              "editType": "edit",
+              "file": "config\/deploy\/os-odl_l3-nofeature-ha.yaml"
+            },
+            {
+              "editType": "edit",
+              "file": "config\/deploy\/os-odl_l2-nofeature-ha.yaml"
+            },
+            {
+              "editType": "edit",
+              "file": "build\/opnfv-tripleo-heat-templates.patch"
+            },
+            {
+              "editType": "edit",
+              "file": "config\/deploy\/os-opencontrail-nofeature-ha.yaml"
+            },
+            {
+              "editType": "add",
+              "file": "config\/deploy\/os-odl_l2-sdnvpn-ha.yaml"
+            },
+            {
+              "editType": "edit",
+              "file": "config\/deploy\/os-nosdn-nofeature-ha.yaml"
+            },
+            {
+              "editType": "edit",
+              "file": "build\/instack.sh"
+            },
+            {
+              "editType": "edit",
+              "file": "config\/deploy\/os-odl_l2-sfc-noha.yaml"
+            },
+            {
+              "editType": "edit",
+              "file": "config\/deploy\/deploy_settings.yaml"
+            },
+            {
+              "editType": "edit",
+              "file": "ci\/deploy.sh"
+            }
+          ]
+        },
+        {
+          "affectedPaths": [
+            "docs\/release-notes\/release-notes.rst"
+          ],
+          "commitId": "eaab4d01e838a13211c812d4c11200b07a6c36d3",
+          "timestamp": 1456260844000,
+          "author": {
+            "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/dradez",
+            "fullName": "dradez"
+          },
+          "comment": "adding know issues to release docs for Brahmaputra\n\nChange-Id: I7be396d98a4a1e42852576e9819510513ebf9a85\nSigned-off-by: Dan Radez <dradez@redhat.com>\n",
+          "date": "2016-02-23T20:54:04+0000 -0500",
+          "id": "eaab4d01e838a13211c812d4c11200b07a6c36d3",
+          "msg": "adding know issues to release docs for Brahmaputra",
+          "paths": [
+            {
+              "editType": "edit",
+              "file": "docs\/release-notes\/release-notes.rst"
+            }
+          ]
+        }
+      ],
+      "kind": "git"
+    },
+    "culprits": [
+      {
+        "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/dradez",
+        "description": null,
+        "fullName": "dradez",
+        "id": "dradez",
+        "property": [
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+            "insensitiveSearch": false
+          },
+          {
+            "address": "dradez@redhat.com"
+          }
+        ]
+      },
+      {
+        "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/woppin",
+        "description": null,
+        "fullName": "woppin",
+        "id": "woppin",
+        "property": [
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+            "insensitiveSearch": false
+          },
+          {
+            "address": "woppin@gmail.com"
+          }
+        ]
+      }
+    ]
+  },
+  "healthReport": [
+    {
+      "description": "Build stability: No recent builds failed.",
+      "iconClassName": "icon-health-80plus",
+      "iconUrl": "health-80plus.png",
+      "score": 100
+    }
+  ],
+  "inQueue": false,
+  "keepDependencies": false,
+  "lastBuild": {
+    "actions": [
+      {
+        "parameters": [
+          {
+            "name": "PROJECT",
+            "value": "apex"
+          },
+          {
+            "name": "GS_BASE",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "GS_BASE_PROXY",
+            "value": "build.opnfv.org\/artifacts\/$PROJECT"
+          },
+          {
+            "name": "ARTIFACT_NAME",
+            "value": "latest"
+          },
+          {
+            "name": "ARTIFACT_VERSION",
+            "value": "daily"
+          },
+          {
+            "name": "BUILD_DIRECTORY",
+            "value": "apex-verify-master\/build_output"
+          },
+          {
+            "name": "CACHE_DIRECTORY",
+            "value": "$HOME\/opnfv\/cache"
+          },
+          {
+            "name": "GIT_BASE",
+            "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+          },
+          {
+            "name": "GS_URL",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "DEPLOY_SCENARIO",
+            "value": "os-onos-nofeature-ha"
+          },
+          {
+            "name": "OPNFV_CLEAN",
+            "value": "yes"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "causes": [
+          {
+            "shortDescription": "Started by upstream project \"apex-verify-master\" build number 609",
+            "upstreamBuild": 609,
+            "upstreamProject": "apex-verify-master",
+            "upstreamUrl": "job\/apex-verify-master\/"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "buildsByBranchName": {
+          "refs\/remotes\/origin\/master": {
+            "buildNumber": 107,
+            "buildResult": null,
+            "marked": {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "branch": [
+                {
+                  "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            },
+            "revision": {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "branch": [
+                {
+                  "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            }
+          }
+        },
+        "lastBuiltRevision": {
+          "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+          "branch": [
+            {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "name": "refs\/remotes\/origin\/master"
+            }
+          ]
+        },
+        "remoteUrls": [
+          "$GIT_BASE"
+        ],
+        "scmName": ""
+      },
+      {
+        "tags": [
+
+        ]
+      },
+      {
+
+      }
+    ],
+    "artifacts": [
+
+    ],
+    "building": false,
+    "description": null,
+    "displayName": "#107",
+    "duration": 3177872,
+    "estimatedDuration": 3286725,
+    "executor": null,
+    "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #107",
+    "id": "107",
+    "keepLog": false,
+    "number": 107,
+    "queueId": 7729,
+    "result": "SUCCESS",
+    "timestamp": 1458874078582,
+    "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/107\/",
+    "builtOn": "intel-pod7",
+    "changeSet": {
+      "items": [
+        {
+          "affectedPaths": [
+            "ci\/clean.sh"
+          ],
+          "commitId": "5f38edb9a96df7d5927d9b91039144bf4d5f0912",
+          "timestamp": 1458848756000,
+          "author": {
+            "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/fpan",
+            "fullName": "fpan"
+          },
+          "comment": "Fixes occasional VM stoage deleltion failure\n\nRemoves --remove-all-storage option in ci\/clean.sh\n\nJIRA: APEX-121\n\nChange-Id: Ia8063112333d12d09cfb16dd1a02e14551dae7d7\nSigned-off-by: Feng Pan <fpan@redhat.com>\n",
+          "date": "2016-03-24T19:45:56+0000 -0400",
+          "id": "5f38edb9a96df7d5927d9b91039144bf4d5f0912",
+          "msg": "Fixes occasional VM stoage deleltion failure",
+          "paths": [
+            {
+              "editType": "edit",
+              "file": "ci\/clean.sh"
+            }
+          ]
+        }
+      ],
+      "kind": "git"
+    },
+    "culprits": [
+      {
+        "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/fpan",
+        "description": null,
+        "fullName": "fpan",
+        "id": "fpan",
+        "property": [
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+            "insensitiveSearch": false
+          },
+          {
+            "address": "fpan@redhat.com"
+          },
+          {
+
+          }
+        ]
+      }
+    ]
+  },
+  "lastCompletedBuild": {
+    "actions": [
+      {
+        "parameters": [
+          {
+            "name": "PROJECT",
+            "value": "apex"
+          },
+          {
+            "name": "GS_BASE",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "GS_BASE_PROXY",
+            "value": "build.opnfv.org\/artifacts\/$PROJECT"
+          },
+          {
+            "name": "ARTIFACT_NAME",
+            "value": "latest"
+          },
+          {
+            "name": "ARTIFACT_VERSION",
+            "value": "daily"
+          },
+          {
+            "name": "BUILD_DIRECTORY",
+            "value": "apex-verify-master\/build_output"
+          },
+          {
+            "name": "CACHE_DIRECTORY",
+            "value": "$HOME\/opnfv\/cache"
+          },
+          {
+            "name": "GIT_BASE",
+            "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+          },
+          {
+            "name": "GS_URL",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "DEPLOY_SCENARIO",
+            "value": "os-onos-nofeature-ha"
+          },
+          {
+            "name": "OPNFV_CLEAN",
+            "value": "yes"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "causes": [
+          {
+            "shortDescription": "Started by upstream project \"apex-verify-master\" build number 609",
+            "upstreamBuild": 609,
+            "upstreamProject": "apex-verify-master",
+            "upstreamUrl": "job\/apex-verify-master\/"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "buildsByBranchName": {
+          "refs\/remotes\/origin\/master": {
+            "buildNumber": 107,
+            "buildResult": null,
+            "marked": {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "branch": [
+                {
+                  "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            },
+            "revision": {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "branch": [
+                {
+                  "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            }
+          }
+        },
+        "lastBuiltRevision": {
+          "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+          "branch": [
+            {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "name": "refs\/remotes\/origin\/master"
+            }
+          ]
+        },
+        "remoteUrls": [
+          "$GIT_BASE"
+        ],
+        "scmName": ""
+      },
+      {
+        "tags": [
+
+        ]
+      },
+      {
+
+      }
+    ],
+    "artifacts": [
+
+    ],
+    "building": false,
+    "description": null,
+    "displayName": "#107",
+    "duration": 3177872,
+    "estimatedDuration": 3286725,
+    "executor": null,
+    "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #107",
+    "id": "107",
+    "keepLog": false,
+    "number": 107,
+    "queueId": 7729,
+    "result": "SUCCESS",
+    "timestamp": 1458874078582,
+    "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/107\/",
+    "builtOn": "intel-pod7",
+    "changeSet": {
+      "items": [
+        {
+          "affectedPaths": [
+            "ci\/clean.sh"
+          ],
+          "commitId": "5f38edb9a96df7d5927d9b91039144bf4d5f0912",
+          "timestamp": 1458848756000,
+          "author": {
+            "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/fpan",
+            "fullName": "fpan"
+          },
+          "comment": "Fixes occasional VM stoage deleltion failure\n\nRemoves --remove-all-storage option in ci\/clean.sh\n\nJIRA: APEX-121\n\nChange-Id: Ia8063112333d12d09cfb16dd1a02e14551dae7d7\nSigned-off-by: Feng Pan <fpan@redhat.com>\n",
+          "date": "2016-03-24T19:45:56+0000 -0400",
+          "id": "5f38edb9a96df7d5927d9b91039144bf4d5f0912",
+          "msg": "Fixes occasional VM stoage deleltion failure",
+          "paths": [
+            {
+              "editType": "edit",
+              "file": "ci\/clean.sh"
+            }
+          ]
+        }
+      ],
+      "kind": "git"
+    },
+    "culprits": [
+      {
+        "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/fpan",
+        "description": null,
+        "fullName": "fpan",
+        "id": "fpan",
+        "property": [
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+            "insensitiveSearch": false
+          },
+          {
+            "address": "fpan@redhat.com"
+          },
+          {
+
+          }
+        ]
+      }
+    ]
+  },
+  "lastFailedBuild": {
+    "actions": [
+      {
+        "parameters": [
+          {
+            "name": "PROJECT",
+            "value": "apex"
+          },
+          {
+            "name": "GS_BASE",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "GS_BASE_PROXY",
+            "value": "build.opnfv.org\/artifacts\/$PROJECT"
+          },
+          {
+            "name": "ARTIFACT_NAME",
+            "value": "latest"
+          },
+          {
+            "name": "ARTIFACT_VERSION",
+            "value": "daily"
+          },
+          {
+            "name": "BUILD_DIRECTORY",
+            "value": "apex-verify-master\/build_output"
+          },
+          {
+            "name": "CACHE_DIRECTORY",
+            "value": "$HOME\/opnfv\/cache"
+          },
+          {
+            "name": "GIT_BASE",
+            "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+          },
+          {
+            "name": "GS_URL",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "DEPLOY_SCENARIO",
+            "value": "os-onos-nofeature-ha"
+          },
+          {
+            "name": "OPNFV_CLEAN",
+            "value": "yes"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "causes": [
+          {
+            "shortDescription": "Started by upstream project \"apex-verify-master\" build number 594",
+            "upstreamBuild": 594,
+            "upstreamProject": "apex-verify-master",
+            "upstreamUrl": "job\/apex-verify-master\/"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "buildsByBranchName": {
+          "refs\/remotes\/origin\/master": {
+            "buildNumber": 101,
+            "buildResult": null,
+            "marked": {
+              "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+              "branch": [
+                {
+                  "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            },
+            "revision": {
+              "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+              "branch": [
+                {
+                  "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            }
+          }
+        },
+        "lastBuiltRevision": {
+          "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+          "branch": [
+            {
+              "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+              "name": "refs\/remotes\/origin\/master"
+            }
+          ]
+        },
+        "remoteUrls": [
+          "$GIT_BASE"
+        ],
+        "scmName": ""
+      },
+      {
+        "tags": [
+
+        ]
+      },
+      {
+
+      }
+    ],
+    "artifacts": [
+
+    ],
+    "building": false,
+    "description": null,
+    "displayName": "#101",
+    "duration": 3007635,
+    "estimatedDuration": 3286725,
+    "executor": null,
+    "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #101",
+    "id": "101",
+    "keepLog": false,
+    "number": 101,
+    "queueId": 7297,
+    "result": "FAILURE",
+    "timestamp": 1458687074485,
+    "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/101\/",
+    "builtOn": "intel-pod7",
+    "changeSet": {
+      "items": [
+
+      ],
+      "kind": "git"
+    },
+    "culprits": [
+
+    ]
+  },
+  "lastStableBuild": {
+    "actions": [
+      {
+        "parameters": [
+          {
+            "name": "PROJECT",
+            "value": "apex"
+          },
+          {
+            "name": "GS_BASE",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "GS_BASE_PROXY",
+            "value": "build.opnfv.org\/artifacts\/$PROJECT"
+          },
+          {
+            "name": "ARTIFACT_NAME",
+            "value": "latest"
+          },
+          {
+            "name": "ARTIFACT_VERSION",
+            "value": "daily"
+          },
+          {
+            "name": "BUILD_DIRECTORY",
+            "value": "apex-verify-master\/build_output"
+          },
+          {
+            "name": "CACHE_DIRECTORY",
+            "value": "$HOME\/opnfv\/cache"
+          },
+          {
+            "name": "GIT_BASE",
+            "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+          },
+          {
+            "name": "GS_URL",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "DEPLOY_SCENARIO",
+            "value": "os-onos-nofeature-ha"
+          },
+          {
+            "name": "OPNFV_CLEAN",
+            "value": "yes"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "causes": [
+          {
+            "shortDescription": "Started by upstream project \"apex-verify-master\" build number 609",
+            "upstreamBuild": 609,
+            "upstreamProject": "apex-verify-master",
+            "upstreamUrl": "job\/apex-verify-master\/"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "buildsByBranchName": {
+          "refs\/remotes\/origin\/master": {
+            "buildNumber": 107,
+            "buildResult": null,
+            "marked": {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "branch": [
+                {
+                  "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            },
+            "revision": {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "branch": [
+                {
+                  "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            }
+          }
+        },
+        "lastBuiltRevision": {
+          "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+          "branch": [
+            {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "name": "refs\/remotes\/origin\/master"
+            }
+          ]
+        },
+        "remoteUrls": [
+          "$GIT_BASE"
+        ],
+        "scmName": ""
+      },
+      {
+        "tags": [
+
+        ]
+      },
+      {
+
+      }
+    ],
+    "artifacts": [
+
+    ],
+    "building": false,
+    "description": null,
+    "displayName": "#107",
+    "duration": 3177872,
+    "estimatedDuration": 3286725,
+    "executor": null,
+    "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #107",
+    "id": "107",
+    "keepLog": false,
+    "number": 107,
+    "queueId": 7729,
+    "result": "SUCCESS",
+    "timestamp": 1458874078582,
+    "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/107\/",
+    "builtOn": "intel-pod7",
+    "changeSet": {
+      "items": [
+        {
+          "affectedPaths": [
+            "ci\/clean.sh"
+          ],
+          "commitId": "5f38edb9a96df7d5927d9b91039144bf4d5f0912",
+          "timestamp": 1458848756000,
+          "author": {
+            "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/fpan",
+            "fullName": "fpan"
+          },
+          "comment": "Fixes occasional VM stoage deleltion failure\n\nRemoves --remove-all-storage option in ci\/clean.sh\n\nJIRA: APEX-121\n\nChange-Id: Ia8063112333d12d09cfb16dd1a02e14551dae7d7\nSigned-off-by: Feng Pan <fpan@redhat.com>\n",
+          "date": "2016-03-24T19:45:56+0000 -0400",
+          "id": "5f38edb9a96df7d5927d9b91039144bf4d5f0912",
+          "msg": "Fixes occasional VM stoage deleltion failure",
+          "paths": [
+            {
+              "editType": "edit",
+              "file": "ci\/clean.sh"
+            }
+          ]
+        }
+      ],
+      "kind": "git"
+    },
+    "culprits": [
+      {
+        "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/fpan",
+        "description": null,
+        "fullName": "fpan",
+        "id": "fpan",
+        "property": [
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+            "insensitiveSearch": false
+          },
+          {
+            "address": "fpan@redhat.com"
+          },
+          {
+
+          }
+        ]
+      }
+    ]
+  },
+  "lastSuccessfulBuild": {
+    "actions": [
+      {
+        "parameters": [
+          {
+            "name": "PROJECT",
+            "value": "apex"
+          },
+          {
+            "name": "GS_BASE",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "GS_BASE_PROXY",
+            "value": "build.opnfv.org\/artifacts\/$PROJECT"
+          },
+          {
+            "name": "ARTIFACT_NAME",
+            "value": "latest"
+          },
+          {
+            "name": "ARTIFACT_VERSION",
+            "value": "daily"
+          },
+          {
+            "name": "BUILD_DIRECTORY",
+            "value": "apex-verify-master\/build_output"
+          },
+          {
+            "name": "CACHE_DIRECTORY",
+            "value": "$HOME\/opnfv\/cache"
+          },
+          {
+            "name": "GIT_BASE",
+            "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+          },
+          {
+            "name": "GS_URL",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "DEPLOY_SCENARIO",
+            "value": "os-onos-nofeature-ha"
+          },
+          {
+            "name": "OPNFV_CLEAN",
+            "value": "yes"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "causes": [
+          {
+            "shortDescription": "Started by upstream project \"apex-verify-master\" build number 609",
+            "upstreamBuild": 609,
+            "upstreamProject": "apex-verify-master",
+            "upstreamUrl": "job\/apex-verify-master\/"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "buildsByBranchName": {
+          "refs\/remotes\/origin\/master": {
+            "buildNumber": 107,
+            "buildResult": null,
+            "marked": {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "branch": [
+                {
+                  "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            },
+            "revision": {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "branch": [
+                {
+                  "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            }
+          }
+        },
+        "lastBuiltRevision": {
+          "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+          "branch": [
+            {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "name": "refs\/remotes\/origin\/master"
+            }
+          ]
+        },
+        "remoteUrls": [
+          "$GIT_BASE"
+        ],
+        "scmName": ""
+      },
+      {
+        "tags": [
+
+        ]
+      },
+      {
+
+      }
+    ],
+    "artifacts": [
+
+    ],
+    "building": false,
+    "description": null,
+    "displayName": "#107",
+    "duration": 3177872,
+    "estimatedDuration": 3286725,
+    "executor": null,
+    "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #107",
+    "id": "107",
+    "keepLog": false,
+    "number": 107,
+    "queueId": 7729,
+    "result": "SUCCESS",
+    "timestamp": 1458874078582,
+    "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/107\/",
+    "builtOn": "intel-pod7",
+    "changeSet": {
+      "items": [
+        {
+          "affectedPaths": [
+            "ci\/clean.sh"
+          ],
+          "commitId": "5f38edb9a96df7d5927d9b91039144bf4d5f0912",
+          "timestamp": 1458848756000,
+          "author": {
+            "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/fpan",
+            "fullName": "fpan"
+          },
+          "comment": "Fixes occasional VM stoage deleltion failure\n\nRemoves --remove-all-storage option in ci\/clean.sh\n\nJIRA: APEX-121\n\nChange-Id: Ia8063112333d12d09cfb16dd1a02e14551dae7d7\nSigned-off-by: Feng Pan <fpan@redhat.com>\n",
+          "date": "2016-03-24T19:45:56+0000 -0400",
+          "id": "5f38edb9a96df7d5927d9b91039144bf4d5f0912",
+          "msg": "Fixes occasional VM stoage deleltion failure",
+          "paths": [
+            {
+              "editType": "edit",
+              "file": "ci\/clean.sh"
+            }
+          ]
+        }
+      ],
+      "kind": "git"
+    },
+    "culprits": [
+      {
+        "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/fpan",
+        "description": null,
+        "fullName": "fpan",
+        "id": "fpan",
+        "property": [
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+            "insensitiveSearch": false
+          },
+          {
+            "address": "fpan@redhat.com"
+          },
+          {
+
+          }
+        ]
+      }
+    ]
+  },
+  "lastUnstableBuild": null,
+  "lastUnsuccessfulBuild": {
+    "actions": [
+      {
+        "parameters": [
+          {
+            "name": "PROJECT",
+            "value": "apex"
+          },
+          {
+            "name": "GS_BASE",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "GS_BASE_PROXY",
+            "value": "build.opnfv.org\/artifacts\/$PROJECT"
+          },
+          {
+            "name": "ARTIFACT_NAME",
+            "value": "latest"
+          },
+          {
+            "name": "ARTIFACT_VERSION",
+            "value": "daily"
+          },
+          {
+            "name": "BUILD_DIRECTORY",
+            "value": "apex-verify-master\/build_output"
+          },
+          {
+            "name": "CACHE_DIRECTORY",
+            "value": "$HOME\/opnfv\/cache"
+          },
+          {
+            "name": "GIT_BASE",
+            "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+          },
+          {
+            "name": "GS_URL",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "DEPLOY_SCENARIO",
+            "value": "os-onos-nofeature-ha"
+          },
+          {
+            "name": "OPNFV_CLEAN",
+            "value": "yes"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "causes": [
+          {
+            "shortDescription": "Started by upstream project \"apex-verify-master\" build number 594",
+            "upstreamBuild": 594,
+            "upstreamProject": "apex-verify-master",
+            "upstreamUrl": "job\/apex-verify-master\/"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "buildsByBranchName": {
+          "refs\/remotes\/origin\/master": {
+            "buildNumber": 101,
+            "buildResult": null,
+            "marked": {
+              "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+              "branch": [
+                {
+                  "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            },
+            "revision": {
+              "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+              "branch": [
+                {
+                  "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            }
+          }
+        },
+        "lastBuiltRevision": {
+          "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+          "branch": [
+            {
+              "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+              "name": "refs\/remotes\/origin\/master"
+            }
+          ]
+        },
+        "remoteUrls": [
+          "$GIT_BASE"
+        ],
+        "scmName": ""
+      },
+      {
+        "tags": [
+
+        ]
+      },
+      {
+
+      }
+    ],
+    "artifacts": [
+
+    ],
+    "building": false,
+    "description": null,
+    "displayName": "#101",
+    "duration": 3007635,
+    "estimatedDuration": 3286725,
+    "executor": null,
+    "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #101",
+    "id": "101",
+    "keepLog": false,
+    "number": 101,
+    "queueId": 7297,
+    "result": "FAILURE",
+    "timestamp": 1458687074485,
+    "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/101\/",
+    "builtOn": "intel-pod7",
+    "changeSet": {
+      "items": [
+
+      ],
+      "kind": "git"
+    },
+    "culprits": [
+
+    ]
+  },
+  "nextBuildNumber": 108,
+  "property": [
+    {
+
+    },
+    {
+
+    },
+    {
+      "parameterDefinitions": [
+        {
+          "defaultParameterValue": {
+            "name": "PROJECT",
+            "value": "apex"
+          },
+          "description": "JJB configured PROJECT parameter to identify an opnfv Gerrit project",
+          "name": "PROJECT",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "GS_BASE",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          "description": "URL to Google Storage.",
+          "name": "GS_BASE",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "GS_BASE_PROXY",
+            "value": "build.opnfv.org\/artifacts\/$PROJECT"
+          },
+          "description": "URL to Google Storage proxy",
+          "name": "GS_BASE_PROXY",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "ARTIFACT_NAME",
+            "value": "latest"
+          },
+          "description": "RPM Artifact name that will be appended to GS_URL to deploy a specific artifact",
+          "name": "ARTIFACT_NAME",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "ARTIFACT_VERSION",
+            "value": "daily"
+          },
+          "description": "Artifact version type",
+          "name": "ARTIFACT_VERSION",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "BUILD_DIRECTORY",
+            "value": "$WORKSPACE\/build"
+          },
+          "description": "Directory where the build artifact will be located upon the completion of the build.",
+          "name": "BUILD_DIRECTORY",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "CACHE_DIRECTORY",
+            "value": "$HOME\/opnfv\/cache"
+          },
+          "description": "Directory where the cache to be used during the build is located.",
+          "name": "CACHE_DIRECTORY",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "GIT_BASE",
+            "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+          },
+          "description": "Used for overriding the GIT URL coming from Global Jenkins configuration in case if the stuff is done on none-LF HW.",
+          "name": "GIT_BASE",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "GS_URL",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          "description": "URL to Google Storage.",
+          "name": "GS_URL",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "DEPLOY_SCENARIO",
+            "value": "os-onos-nofeature-ha"
+          },
+          "description": "Scenario to deploy with.",
+          "name": "DEPLOY_SCENARIO",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "OPNFV_CLEAN",
+            "value": "no"
+          },
+          "description": "Use yes in lower case to invoke clean. Indicates if the deploy environment should be cleaned before deployment",
+          "name": "OPNFV_CLEAN",
+          "type": "StringParameterDefinition"
+        }
+      ]
+    }
+  ],
+  "queueItem": null,
+  "concurrentBuild": true,
+  "downstreamProjects": [
+
+  ],
+  "scm": {
+    "browser": null,
+    "type": "hudson.plugins.git.GitSCM",
+    "branches": [
+      {
+        "name": "origin\/master"
+      }
+    ],
+    "mergeOptions": {
+      "fastForwardMode": "--ff",
+      "mergeStrategy": "default",
+      "mergeTarget": null,
+      "remoteBranchName": null
+    },
+    "userRemoteConfigs": [
+      {
+        "credentialsId": "d42411ac011ad6f3dd2e1fa34eaa5d87f910eb2e",
+        "name": "origin",
+        "refspec": "",
+        "url": "$GIT_BASE"
+      }
+    ]
+  },
+  "upstreamProjects": [
+
+  ]
+}

--- a/tests/data/jenkins/jenkins_job_no_builds.json
+++ b/tests/data/jenkins/jenkins_job_no_builds.json
@@ -1,0 +1,1592 @@
+{
+  "actions": [
+    {
+      "parameterDefinitions": [
+        {
+          "defaultParameterValue": {
+            "name": "PROJECT",
+            "value": "apex"
+          },
+          "description": "JJB configured PROJECT parameter to identify an opnfv Gerrit project",
+          "name": "PROJECT",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "GS_BASE",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          "description": "URL to Google Storage.",
+          "name": "GS_BASE",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "GS_BASE_PROXY",
+            "value": "build.opnfv.org\/artifacts\/$PROJECT"
+          },
+          "description": "URL to Google Storage proxy",
+          "name": "GS_BASE_PROXY",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "ARTIFACT_NAME",
+            "value": "latest"
+          },
+          "description": "RPM Artifact name that will be appended to GS_URL to deploy a specific artifact",
+          "name": "ARTIFACT_NAME",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "ARTIFACT_VERSION",
+            "value": "daily"
+          },
+          "description": "Artifact version type",
+          "name": "ARTIFACT_VERSION",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "BUILD_DIRECTORY",
+            "value": "$WORKSPACE\/build"
+          },
+          "description": "Directory where the build artifact will be located upon the completion of the build.",
+          "name": "BUILD_DIRECTORY",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "CACHE_DIRECTORY",
+            "value": "$HOME\/opnfv\/cache"
+          },
+          "description": "Directory where the cache to be used during the build is located.",
+          "name": "CACHE_DIRECTORY",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "GIT_BASE",
+            "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+          },
+          "description": "Used for overriding the GIT URL coming from Global Jenkins configuration in case if the stuff is done on none-LF HW.",
+          "name": "GIT_BASE",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "GS_URL",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          "description": "URL to Google Storage.",
+          "name": "GS_URL",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "DEPLOY_SCENARIO",
+            "value": "os-onos-nofeature-ha"
+          },
+          "description": "Scenario to deploy with.",
+          "name": "DEPLOY_SCENARIO",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "OPNFV_CLEAN",
+            "value": "no"
+          },
+          "description": "Use yes in lower case to invoke clean. Indicates if the deploy environment should be cleaned before deployment",
+          "name": "OPNFV_CLEAN",
+          "type": "StringParameterDefinition"
+        }
+      ]
+    }
+  ],
+  "description": "<!-- Managed by Jenkins Job Builder -->",
+  "displayName": "apex-deploy-virtual-os-onos-nofeature-ha-master",
+  "displayNameOrNull": null,
+  "name": "apex-deploy-virtual-os-onos-nofeature-ha-master",
+  "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/",
+  "buildable": true,
+  "color": "blue",
+  "firstBuild": {
+    "actions": [
+      {
+        "parameters": [
+          {
+            "name": "PROJECT",
+            "value": "apex"
+          },
+          {
+            "name": "GS_BASE",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "GS_BASE_PROXY",
+            "value": "build.opnfv.org\/artifacts\/$PROJECT"
+          },
+          {
+            "name": "ARTIFACT_NAME",
+            "value": "latest"
+          },
+          {
+            "name": "ARTIFACT_VERSION",
+            "value": "daily"
+          },
+          {
+            "name": "BUILD_DIRECTORY",
+            "value": "apex-verify-master\/build_output"
+          },
+          {
+            "name": "CACHE_DIRECTORY",
+            "value": "$HOME\/opnfv\/cache"
+          },
+          {
+            "name": "GIT_BASE",
+            "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+          },
+          {
+            "name": "GS_URL",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "DEPLOY_SCENARIO",
+            "value": "os-onos-nofeature-ha"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "causes": [
+          {
+            "shortDescription": "Started by upstream project \"apex-verify-master\" build number 493",
+            "upstreamBuild": 493,
+            "upstreamProject": "apex-verify-master",
+            "upstreamUrl": "job\/apex-verify-master\/"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "buildsByBranchName": {
+          "refs\/remotes\/origin\/master": {
+            "buildNumber": 76,
+            "buildResult": null,
+            "marked": {
+              "SHA1": "5fece9e6f4bca1f7551dfbf50c385300f264f4f4",
+              "branch": [
+                {
+                  "SHA1": "5fece9e6f4bca1f7551dfbf50c385300f264f4f4",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            },
+            "revision": {
+              "SHA1": "5fece9e6f4bca1f7551dfbf50c385300f264f4f4",
+              "branch": [
+                {
+                  "SHA1": "5fece9e6f4bca1f7551dfbf50c385300f264f4f4",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            }
+          }
+        },
+        "lastBuiltRevision": {
+          "SHA1": "5fece9e6f4bca1f7551dfbf50c385300f264f4f4",
+          "branch": [
+            {
+              "SHA1": "5fece9e6f4bca1f7551dfbf50c385300f264f4f4",
+              "name": "refs\/remotes\/origin\/master"
+            }
+          ]
+        },
+        "remoteUrls": [
+          "$GIT_BASE"
+        ],
+        "scmName": ""
+      },
+      {
+        "tags": [
+
+        ]
+      },
+      {
+
+      }
+    ],
+    "artifacts": [
+
+    ],
+    "building": false,
+    "description": null,
+    "displayName": "#76",
+    "duration": 2697138,
+    "estimatedDuration": 3286725,
+    "executor": null,
+    "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #76",
+    "id": "76",
+    "keepLog": false,
+    "number": 76,
+    "queueId": 2914,
+    "result": "SUCCESS",
+    "timestamp": 1456357766112,
+    "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/76\/",
+    "builtOn": "opnfv-jump-1",
+    "changeSet": {
+      "items": [
+        {
+          "affectedPaths": [
+            "ci\/deploy.sh",
+            "config\/deploy\/deploy_settings.yaml",
+            "config\/deploy\/os-nosdn-nofeature-ha.yaml",
+            "build\/opnfv-tripleo-heat-templates.patch",
+            "config\/deploy\/os-odl_l2-sfc-noha.yaml",
+            "config\/deploy\/os-opencontrail-nofeature-ha.yaml",
+            "config\/deploy\/os-odl_l2-nofeature-ha.yaml",
+            "config\/deploy\/os-onos-nofeature-ha.yaml",
+            "config\/deploy\/os-odl_l3-nofeature-ha.yaml",
+            "build\/instack.sh",
+            "config\/deploy\/os-odl_l2-sdnvpn-ha.yaml"
+          ],
+          "commitId": "c86bd1f24647646b7489cd72e0a0bb91f4a505f1",
+          "timestamp": 1456110872000,
+          "author": {
+            "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/woppin",
+            "fullName": "woppin"
+          },
+          "comment": "Adding SDNVPN support\n\nChange-Id: Id2d6d46a53129d4ae2f93fad835536da067e42df\nJIRA: APEX-51\nSigned-off-by: Dan Radez <dradez@redhat.com>\n",
+          "date": "2016-02-22T03:14:32+0000 +1100",
+          "id": "c86bd1f24647646b7489cd72e0a0bb91f4a505f1",
+          "msg": "Adding SDNVPN support",
+          "paths": [
+            {
+              "editType": "edit",
+              "file": "config\/deploy\/os-onos-nofeature-ha.yaml"
+            },
+            {
+              "editType": "edit",
+              "file": "config\/deploy\/os-odl_l3-nofeature-ha.yaml"
+            },
+            {
+              "editType": "edit",
+              "file": "config\/deploy\/os-odl_l2-nofeature-ha.yaml"
+            },
+            {
+              "editType": "edit",
+              "file": "build\/opnfv-tripleo-heat-templates.patch"
+            },
+            {
+              "editType": "edit",
+              "file": "config\/deploy\/os-opencontrail-nofeature-ha.yaml"
+            },
+            {
+              "editType": "add",
+              "file": "config\/deploy\/os-odl_l2-sdnvpn-ha.yaml"
+            },
+            {
+              "editType": "edit",
+              "file": "config\/deploy\/os-nosdn-nofeature-ha.yaml"
+            },
+            {
+              "editType": "edit",
+              "file": "build\/instack.sh"
+            },
+            {
+              "editType": "edit",
+              "file": "config\/deploy\/os-odl_l2-sfc-noha.yaml"
+            },
+            {
+              "editType": "edit",
+              "file": "config\/deploy\/deploy_settings.yaml"
+            },
+            {
+              "editType": "edit",
+              "file": "ci\/deploy.sh"
+            }
+          ]
+        },
+        {
+          "affectedPaths": [
+            "docs\/release-notes\/release-notes.rst"
+          ],
+          "commitId": "eaab4d01e838a13211c812d4c11200b07a6c36d3",
+          "timestamp": 1456260844000,
+          "author": {
+            "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/dradez",
+            "fullName": "dradez"
+          },
+          "comment": "adding know issues to release docs for Brahmaputra\n\nChange-Id: I7be396d98a4a1e42852576e9819510513ebf9a85\nSigned-off-by: Dan Radez <dradez@redhat.com>\n",
+          "date": "2016-02-23T20:54:04+0000 -0500",
+          "id": "eaab4d01e838a13211c812d4c11200b07a6c36d3",
+          "msg": "adding know issues to release docs for Brahmaputra",
+          "paths": [
+            {
+              "editType": "edit",
+              "file": "docs\/release-notes\/release-notes.rst"
+            }
+          ]
+        }
+      ],
+      "kind": "git"
+    },
+    "culprits": [
+      {
+        "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/dradez",
+        "description": null,
+        "fullName": "dradez",
+        "id": "dradez",
+        "property": [
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+            "insensitiveSearch": false
+          },
+          {
+            "address": "dradez@redhat.com"
+          }
+        ]
+      },
+      {
+        "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/woppin",
+        "description": null,
+        "fullName": "woppin",
+        "id": "woppin",
+        "property": [
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+            "insensitiveSearch": false
+          },
+          {
+            "address": "woppin@gmail.com"
+          }
+        ]
+      }
+    ]
+  },
+  "healthReport": [
+    {
+      "description": "Build stability: No recent builds failed.",
+      "iconClassName": "icon-health-80plus",
+      "iconUrl": "health-80plus.png",
+      "score": 100
+    }
+  ],
+  "inQueue": false,
+  "keepDependencies": false,
+  "lastBuild": {
+    "actions": [
+      {
+        "parameters": [
+          {
+            "name": "PROJECT",
+            "value": "apex"
+          },
+          {
+            "name": "GS_BASE",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "GS_BASE_PROXY",
+            "value": "build.opnfv.org\/artifacts\/$PROJECT"
+          },
+          {
+            "name": "ARTIFACT_NAME",
+            "value": "latest"
+          },
+          {
+            "name": "ARTIFACT_VERSION",
+            "value": "daily"
+          },
+          {
+            "name": "BUILD_DIRECTORY",
+            "value": "apex-verify-master\/build_output"
+          },
+          {
+            "name": "CACHE_DIRECTORY",
+            "value": "$HOME\/opnfv\/cache"
+          },
+          {
+            "name": "GIT_BASE",
+            "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+          },
+          {
+            "name": "GS_URL",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "DEPLOY_SCENARIO",
+            "value": "os-onos-nofeature-ha"
+          },
+          {
+            "name": "OPNFV_CLEAN",
+            "value": "yes"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "causes": [
+          {
+            "shortDescription": "Started by upstream project \"apex-verify-master\" build number 609",
+            "upstreamBuild": 609,
+            "upstreamProject": "apex-verify-master",
+            "upstreamUrl": "job\/apex-verify-master\/"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "buildsByBranchName": {
+          "refs\/remotes\/origin\/master": {
+            "buildNumber": 107,
+            "buildResult": null,
+            "marked": {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "branch": [
+                {
+                  "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            },
+            "revision": {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "branch": [
+                {
+                  "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            }
+          }
+        },
+        "lastBuiltRevision": {
+          "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+          "branch": [
+            {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "name": "refs\/remotes\/origin\/master"
+            }
+          ]
+        },
+        "remoteUrls": [
+          "$GIT_BASE"
+        ],
+        "scmName": ""
+      },
+      {
+        "tags": [
+
+        ]
+      },
+      {
+
+      }
+    ],
+    "artifacts": [
+
+    ],
+    "building": false,
+    "description": null,
+    "displayName": "#107",
+    "duration": 3177872,
+    "estimatedDuration": 3286725,
+    "executor": null,
+    "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #107",
+    "id": "107",
+    "keepLog": false,
+    "number": 107,
+    "queueId": 7729,
+    "result": "SUCCESS",
+    "timestamp": 1458874078582,
+    "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/107\/",
+    "builtOn": "intel-pod7",
+    "changeSet": {
+      "items": [
+        {
+          "affectedPaths": [
+            "ci\/clean.sh"
+          ],
+          "commitId": "5f38edb9a96df7d5927d9b91039144bf4d5f0912",
+          "timestamp": 1458848756000,
+          "author": {
+            "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/fpan",
+            "fullName": "fpan"
+          },
+          "comment": "Fixes occasional VM stoage deleltion failure\n\nRemoves --remove-all-storage option in ci\/clean.sh\n\nJIRA: APEX-121\n\nChange-Id: Ia8063112333d12d09cfb16dd1a02e14551dae7d7\nSigned-off-by: Feng Pan <fpan@redhat.com>\n",
+          "date": "2016-03-24T19:45:56+0000 -0400",
+          "id": "5f38edb9a96df7d5927d9b91039144bf4d5f0912",
+          "msg": "Fixes occasional VM stoage deleltion failure",
+          "paths": [
+            {
+              "editType": "edit",
+              "file": "ci\/clean.sh"
+            }
+          ]
+        }
+      ],
+      "kind": "git"
+    },
+    "culprits": [
+      {
+        "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/fpan",
+        "description": null,
+        "fullName": "fpan",
+        "id": "fpan",
+        "property": [
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+            "insensitiveSearch": false
+          },
+          {
+            "address": "fpan@redhat.com"
+          },
+          {
+
+          }
+        ]
+      }
+    ]
+  },
+  "lastCompletedBuild": {
+    "actions": [
+      {
+        "parameters": [
+          {
+            "name": "PROJECT",
+            "value": "apex"
+          },
+          {
+            "name": "GS_BASE",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "GS_BASE_PROXY",
+            "value": "build.opnfv.org\/artifacts\/$PROJECT"
+          },
+          {
+            "name": "ARTIFACT_NAME",
+            "value": "latest"
+          },
+          {
+            "name": "ARTIFACT_VERSION",
+            "value": "daily"
+          },
+          {
+            "name": "BUILD_DIRECTORY",
+            "value": "apex-verify-master\/build_output"
+          },
+          {
+            "name": "CACHE_DIRECTORY",
+            "value": "$HOME\/opnfv\/cache"
+          },
+          {
+            "name": "GIT_BASE",
+            "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+          },
+          {
+            "name": "GS_URL",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "DEPLOY_SCENARIO",
+            "value": "os-onos-nofeature-ha"
+          },
+          {
+            "name": "OPNFV_CLEAN",
+            "value": "yes"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "causes": [
+          {
+            "shortDescription": "Started by upstream project \"apex-verify-master\" build number 609",
+            "upstreamBuild": 609,
+            "upstreamProject": "apex-verify-master",
+            "upstreamUrl": "job\/apex-verify-master\/"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "buildsByBranchName": {
+          "refs\/remotes\/origin\/master": {
+            "buildNumber": 107,
+            "buildResult": null,
+            "marked": {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "branch": [
+                {
+                  "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            },
+            "revision": {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "branch": [
+                {
+                  "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            }
+          }
+        },
+        "lastBuiltRevision": {
+          "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+          "branch": [
+            {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "name": "refs\/remotes\/origin\/master"
+            }
+          ]
+        },
+        "remoteUrls": [
+          "$GIT_BASE"
+        ],
+        "scmName": ""
+      },
+      {
+        "tags": [
+
+        ]
+      },
+      {
+
+      }
+    ],
+    "artifacts": [
+
+    ],
+    "building": false,
+    "description": null,
+    "displayName": "#107",
+    "duration": 3177872,
+    "estimatedDuration": 3286725,
+    "executor": null,
+    "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #107",
+    "id": "107",
+    "keepLog": false,
+    "number": 107,
+    "queueId": 7729,
+    "result": "SUCCESS",
+    "timestamp": 1458874078582,
+    "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/107\/",
+    "builtOn": "intel-pod7",
+    "changeSet": {
+      "items": [
+        {
+          "affectedPaths": [
+            "ci\/clean.sh"
+          ],
+          "commitId": "5f38edb9a96df7d5927d9b91039144bf4d5f0912",
+          "timestamp": 1458848756000,
+          "author": {
+            "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/fpan",
+            "fullName": "fpan"
+          },
+          "comment": "Fixes occasional VM stoage deleltion failure\n\nRemoves --remove-all-storage option in ci\/clean.sh\n\nJIRA: APEX-121\n\nChange-Id: Ia8063112333d12d09cfb16dd1a02e14551dae7d7\nSigned-off-by: Feng Pan <fpan@redhat.com>\n",
+          "date": "2016-03-24T19:45:56+0000 -0400",
+          "id": "5f38edb9a96df7d5927d9b91039144bf4d5f0912",
+          "msg": "Fixes occasional VM stoage deleltion failure",
+          "paths": [
+            {
+              "editType": "edit",
+              "file": "ci\/clean.sh"
+            }
+          ]
+        }
+      ],
+      "kind": "git"
+    },
+    "culprits": [
+      {
+        "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/fpan",
+        "description": null,
+        "fullName": "fpan",
+        "id": "fpan",
+        "property": [
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+            "insensitiveSearch": false
+          },
+          {
+            "address": "fpan@redhat.com"
+          },
+          {
+
+          }
+        ]
+      }
+    ]
+  },
+  "lastFailedBuild": {
+    "actions": [
+      {
+        "parameters": [
+          {
+            "name": "PROJECT",
+            "value": "apex"
+          },
+          {
+            "name": "GS_BASE",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "GS_BASE_PROXY",
+            "value": "build.opnfv.org\/artifacts\/$PROJECT"
+          },
+          {
+            "name": "ARTIFACT_NAME",
+            "value": "latest"
+          },
+          {
+            "name": "ARTIFACT_VERSION",
+            "value": "daily"
+          },
+          {
+            "name": "BUILD_DIRECTORY",
+            "value": "apex-verify-master\/build_output"
+          },
+          {
+            "name": "CACHE_DIRECTORY",
+            "value": "$HOME\/opnfv\/cache"
+          },
+          {
+            "name": "GIT_BASE",
+            "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+          },
+          {
+            "name": "GS_URL",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "DEPLOY_SCENARIO",
+            "value": "os-onos-nofeature-ha"
+          },
+          {
+            "name": "OPNFV_CLEAN",
+            "value": "yes"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "causes": [
+          {
+            "shortDescription": "Started by upstream project \"apex-verify-master\" build number 594",
+            "upstreamBuild": 594,
+            "upstreamProject": "apex-verify-master",
+            "upstreamUrl": "job\/apex-verify-master\/"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "buildsByBranchName": {
+          "refs\/remotes\/origin\/master": {
+            "buildNumber": 101,
+            "buildResult": null,
+            "marked": {
+              "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+              "branch": [
+                {
+                  "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            },
+            "revision": {
+              "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+              "branch": [
+                {
+                  "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            }
+          }
+        },
+        "lastBuiltRevision": {
+          "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+          "branch": [
+            {
+              "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+              "name": "refs\/remotes\/origin\/master"
+            }
+          ]
+        },
+        "remoteUrls": [
+          "$GIT_BASE"
+        ],
+        "scmName": ""
+      },
+      {
+        "tags": [
+
+        ]
+      },
+      {
+
+      }
+    ],
+    "artifacts": [
+
+    ],
+    "building": false,
+    "description": null,
+    "displayName": "#101",
+    "duration": 3007635,
+    "estimatedDuration": 3286725,
+    "executor": null,
+    "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #101",
+    "id": "101",
+    "keepLog": false,
+    "number": 101,
+    "queueId": 7297,
+    "result": "FAILURE",
+    "timestamp": 1458687074485,
+    "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/101\/",
+    "builtOn": "intel-pod7",
+    "changeSet": {
+      "items": [
+
+      ],
+      "kind": "git"
+    },
+    "culprits": [
+
+    ]
+  },
+  "lastStableBuild": {
+    "actions": [
+      {
+        "parameters": [
+          {
+            "name": "PROJECT",
+            "value": "apex"
+          },
+          {
+            "name": "GS_BASE",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "GS_BASE_PROXY",
+            "value": "build.opnfv.org\/artifacts\/$PROJECT"
+          },
+          {
+            "name": "ARTIFACT_NAME",
+            "value": "latest"
+          },
+          {
+            "name": "ARTIFACT_VERSION",
+            "value": "daily"
+          },
+          {
+            "name": "BUILD_DIRECTORY",
+            "value": "apex-verify-master\/build_output"
+          },
+          {
+            "name": "CACHE_DIRECTORY",
+            "value": "$HOME\/opnfv\/cache"
+          },
+          {
+            "name": "GIT_BASE",
+            "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+          },
+          {
+            "name": "GS_URL",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "DEPLOY_SCENARIO",
+            "value": "os-onos-nofeature-ha"
+          },
+          {
+            "name": "OPNFV_CLEAN",
+            "value": "yes"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "causes": [
+          {
+            "shortDescription": "Started by upstream project \"apex-verify-master\" build number 609",
+            "upstreamBuild": 609,
+            "upstreamProject": "apex-verify-master",
+            "upstreamUrl": "job\/apex-verify-master\/"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "buildsByBranchName": {
+          "refs\/remotes\/origin\/master": {
+            "buildNumber": 107,
+            "buildResult": null,
+            "marked": {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "branch": [
+                {
+                  "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            },
+            "revision": {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "branch": [
+                {
+                  "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            }
+          }
+        },
+        "lastBuiltRevision": {
+          "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+          "branch": [
+            {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "name": "refs\/remotes\/origin\/master"
+            }
+          ]
+        },
+        "remoteUrls": [
+          "$GIT_BASE"
+        ],
+        "scmName": ""
+      },
+      {
+        "tags": [
+
+        ]
+      },
+      {
+
+      }
+    ],
+    "artifacts": [
+
+    ],
+    "building": false,
+    "description": null,
+    "displayName": "#107",
+    "duration": 3177872,
+    "estimatedDuration": 3286725,
+    "executor": null,
+    "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #107",
+    "id": "107",
+    "keepLog": false,
+    "number": 107,
+    "queueId": 7729,
+    "result": "SUCCESS",
+    "timestamp": 1458874078582,
+    "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/107\/",
+    "builtOn": "intel-pod7",
+    "changeSet": {
+      "items": [
+        {
+          "affectedPaths": [
+            "ci\/clean.sh"
+          ],
+          "commitId": "5f38edb9a96df7d5927d9b91039144bf4d5f0912",
+          "timestamp": 1458848756000,
+          "author": {
+            "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/fpan",
+            "fullName": "fpan"
+          },
+          "comment": "Fixes occasional VM stoage deleltion failure\n\nRemoves --remove-all-storage option in ci\/clean.sh\n\nJIRA: APEX-121\n\nChange-Id: Ia8063112333d12d09cfb16dd1a02e14551dae7d7\nSigned-off-by: Feng Pan <fpan@redhat.com>\n",
+          "date": "2016-03-24T19:45:56+0000 -0400",
+          "id": "5f38edb9a96df7d5927d9b91039144bf4d5f0912",
+          "msg": "Fixes occasional VM stoage deleltion failure",
+          "paths": [
+            {
+              "editType": "edit",
+              "file": "ci\/clean.sh"
+            }
+          ]
+        }
+      ],
+      "kind": "git"
+    },
+    "culprits": [
+      {
+        "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/fpan",
+        "description": null,
+        "fullName": "fpan",
+        "id": "fpan",
+        "property": [
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+            "insensitiveSearch": false
+          },
+          {
+            "address": "fpan@redhat.com"
+          },
+          {
+
+          }
+        ]
+      }
+    ]
+  },
+  "lastSuccessfulBuild": {
+    "actions": [
+      {
+        "parameters": [
+          {
+            "name": "PROJECT",
+            "value": "apex"
+          },
+          {
+            "name": "GS_BASE",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "GS_BASE_PROXY",
+            "value": "build.opnfv.org\/artifacts\/$PROJECT"
+          },
+          {
+            "name": "ARTIFACT_NAME",
+            "value": "latest"
+          },
+          {
+            "name": "ARTIFACT_VERSION",
+            "value": "daily"
+          },
+          {
+            "name": "BUILD_DIRECTORY",
+            "value": "apex-verify-master\/build_output"
+          },
+          {
+            "name": "CACHE_DIRECTORY",
+            "value": "$HOME\/opnfv\/cache"
+          },
+          {
+            "name": "GIT_BASE",
+            "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+          },
+          {
+            "name": "GS_URL",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "DEPLOY_SCENARIO",
+            "value": "os-onos-nofeature-ha"
+          },
+          {
+            "name": "OPNFV_CLEAN",
+            "value": "yes"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "causes": [
+          {
+            "shortDescription": "Started by upstream project \"apex-verify-master\" build number 609",
+            "upstreamBuild": 609,
+            "upstreamProject": "apex-verify-master",
+            "upstreamUrl": "job\/apex-verify-master\/"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "buildsByBranchName": {
+          "refs\/remotes\/origin\/master": {
+            "buildNumber": 107,
+            "buildResult": null,
+            "marked": {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "branch": [
+                {
+                  "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            },
+            "revision": {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "branch": [
+                {
+                  "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            }
+          }
+        },
+        "lastBuiltRevision": {
+          "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+          "branch": [
+            {
+              "SHA1": "9d3cab8d46e5823fee43a0b6c2f19d5dccfa4c3a",
+              "name": "refs\/remotes\/origin\/master"
+            }
+          ]
+        },
+        "remoteUrls": [
+          "$GIT_BASE"
+        ],
+        "scmName": ""
+      },
+      {
+        "tags": [
+
+        ]
+      },
+      {
+
+      }
+    ],
+    "artifacts": [
+
+    ],
+    "building": false,
+    "description": null,
+    "displayName": "#107",
+    "duration": 3177872,
+    "estimatedDuration": 3286725,
+    "executor": null,
+    "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #107",
+    "id": "107",
+    "keepLog": false,
+    "number": 107,
+    "queueId": 7729,
+    "result": "SUCCESS",
+    "timestamp": 1458874078582,
+    "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/107\/",
+    "builtOn": "intel-pod7",
+    "changeSet": {
+      "items": [
+        {
+          "affectedPaths": [
+            "ci\/clean.sh"
+          ],
+          "commitId": "5f38edb9a96df7d5927d9b91039144bf4d5f0912",
+          "timestamp": 1458848756000,
+          "author": {
+            "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/fpan",
+            "fullName": "fpan"
+          },
+          "comment": "Fixes occasional VM stoage deleltion failure\n\nRemoves --remove-all-storage option in ci\/clean.sh\n\nJIRA: APEX-121\n\nChange-Id: Ia8063112333d12d09cfb16dd1a02e14551dae7d7\nSigned-off-by: Feng Pan <fpan@redhat.com>\n",
+          "date": "2016-03-24T19:45:56+0000 -0400",
+          "id": "5f38edb9a96df7d5927d9b91039144bf4d5f0912",
+          "msg": "Fixes occasional VM stoage deleltion failure",
+          "paths": [
+            {
+              "editType": "edit",
+              "file": "ci\/clean.sh"
+            }
+          ]
+        }
+      ],
+      "kind": "git"
+    },
+    "culprits": [
+      {
+        "absoluteUrl": "https:\/\/build.opnfv.org\/ci\/user\/fpan",
+        "description": null,
+        "fullName": "fpan",
+        "id": "fpan",
+        "property": [
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+
+          },
+          {
+            "insensitiveSearch": false
+          },
+          {
+            "address": "fpan@redhat.com"
+          },
+          {
+
+          }
+        ]
+      }
+    ]
+  },
+  "lastUnstableBuild": null,
+  "lastUnsuccessfulBuild": {
+    "actions": [
+      {
+        "parameters": [
+          {
+            "name": "PROJECT",
+            "value": "apex"
+          },
+          {
+            "name": "GS_BASE",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "GS_BASE_PROXY",
+            "value": "build.opnfv.org\/artifacts\/$PROJECT"
+          },
+          {
+            "name": "ARTIFACT_NAME",
+            "value": "latest"
+          },
+          {
+            "name": "ARTIFACT_VERSION",
+            "value": "daily"
+          },
+          {
+            "name": "BUILD_DIRECTORY",
+            "value": "apex-verify-master\/build_output"
+          },
+          {
+            "name": "CACHE_DIRECTORY",
+            "value": "$HOME\/opnfv\/cache"
+          },
+          {
+            "name": "GIT_BASE",
+            "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+          },
+          {
+            "name": "GS_URL",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          {
+            "name": "DEPLOY_SCENARIO",
+            "value": "os-onos-nofeature-ha"
+          },
+          {
+            "name": "OPNFV_CLEAN",
+            "value": "yes"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "causes": [
+          {
+            "shortDescription": "Started by upstream project \"apex-verify-master\" build number 594",
+            "upstreamBuild": 594,
+            "upstreamProject": "apex-verify-master",
+            "upstreamUrl": "job\/apex-verify-master\/"
+          }
+        ]
+      },
+      {
+
+      },
+      {
+        "buildsByBranchName": {
+          "refs\/remotes\/origin\/master": {
+            "buildNumber": 101,
+            "buildResult": null,
+            "marked": {
+              "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+              "branch": [
+                {
+                  "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            },
+            "revision": {
+              "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+              "branch": [
+                {
+                  "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+                  "name": "refs\/remotes\/origin\/master"
+                }
+              ]
+            }
+          }
+        },
+        "lastBuiltRevision": {
+          "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+          "branch": [
+            {
+              "SHA1": "c77d98309557308e909c08f6879e566c87b92315",
+              "name": "refs\/remotes\/origin\/master"
+            }
+          ]
+        },
+        "remoteUrls": [
+          "$GIT_BASE"
+        ],
+        "scmName": ""
+      },
+      {
+        "tags": [
+
+        ]
+      },
+      {
+
+      }
+    ],
+    "artifacts": [
+
+    ],
+    "building": false,
+    "description": null,
+    "displayName": "#101",
+    "duration": 3007635,
+    "estimatedDuration": 3286725,
+    "executor": null,
+    "fullDisplayName": "apex-deploy-virtual-os-onos-nofeature-ha-master #101",
+    "id": "101",
+    "keepLog": false,
+    "number": 101,
+    "queueId": 7297,
+    "result": "FAILURE",
+    "timestamp": 1458687074485,
+    "url": "https:\/\/build.opnfv.org\/ci\/job\/apex-deploy-virtual-os-onos-nofeature-ha-master\/101\/",
+    "builtOn": "intel-pod7",
+    "changeSet": {
+      "items": [
+
+      ],
+      "kind": "git"
+    },
+    "culprits": [
+
+    ]
+  },
+  "nextBuildNumber": 108,
+  "property": [
+    {
+
+    },
+    {
+
+    },
+    {
+      "parameterDefinitions": [
+        {
+          "defaultParameterValue": {
+            "name": "PROJECT",
+            "value": "apex"
+          },
+          "description": "JJB configured PROJECT parameter to identify an opnfv Gerrit project",
+          "name": "PROJECT",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "GS_BASE",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          "description": "URL to Google Storage.",
+          "name": "GS_BASE",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "GS_BASE_PROXY",
+            "value": "build.opnfv.org\/artifacts\/$PROJECT"
+          },
+          "description": "URL to Google Storage proxy",
+          "name": "GS_BASE_PROXY",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "ARTIFACT_NAME",
+            "value": "latest"
+          },
+          "description": "RPM Artifact name that will be appended to GS_URL to deploy a specific artifact",
+          "name": "ARTIFACT_NAME",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "ARTIFACT_VERSION",
+            "value": "daily"
+          },
+          "description": "Artifact version type",
+          "name": "ARTIFACT_VERSION",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "BUILD_DIRECTORY",
+            "value": "$WORKSPACE\/build"
+          },
+          "description": "Directory where the build artifact will be located upon the completion of the build.",
+          "name": "BUILD_DIRECTORY",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "CACHE_DIRECTORY",
+            "value": "$HOME\/opnfv\/cache"
+          },
+          "description": "Directory where the cache to be used during the build is located.",
+          "name": "CACHE_DIRECTORY",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "GIT_BASE",
+            "value": "https:\/\/gerrit.opnfv.org\/gerrit\/$PROJECT"
+          },
+          "description": "Used for overriding the GIT URL coming from Global Jenkins configuration in case if the stuff is done on none-LF HW.",
+          "name": "GIT_BASE",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "GS_URL",
+            "value": "artifacts.opnfv.org\/$PROJECT"
+          },
+          "description": "URL to Google Storage.",
+          "name": "GS_URL",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "DEPLOY_SCENARIO",
+            "value": "os-onos-nofeature-ha"
+          },
+          "description": "Scenario to deploy with.",
+          "name": "DEPLOY_SCENARIO",
+          "type": "StringParameterDefinition"
+        },
+        {
+          "defaultParameterValue": {
+            "name": "OPNFV_CLEAN",
+            "value": "no"
+          },
+          "description": "Use yes in lower case to invoke clean. Indicates if the deploy environment should be cleaned before deployment",
+          "name": "OPNFV_CLEAN",
+          "type": "StringParameterDefinition"
+        }
+      ]
+    }
+  ],
+  "queueItem": null,
+  "concurrentBuild": true,
+  "downstreamProjects": [
+
+  ],
+  "scm": {
+    "browser": null,
+    "type": "hudson.plugins.git.GitSCM",
+    "branches": [
+      {
+        "name": "origin\/master"
+      }
+    ],
+    "mergeOptions": {
+      "fastForwardMode": "--ff",
+      "mergeStrategy": "default",
+      "mergeTarget": null,
+      "remoteBranchName": null
+    },
+    "userRemoteConfigs": [
+      {
+        "credentialsId": "d42411ac011ad6f3dd2e1fa34eaa5d87f910eb2e",
+        "name": "origin",
+        "refspec": "",
+        "url": "$GIT_BASE"
+      }
+    ]
+  },
+  "upstreamProjects": [
+
+  ]
+}

--- a/tests/data/jenkins/jenkins_jobs.json
+++ b/tests/data/jenkins/jenkins_jobs.json
@@ -20,6 +20,11 @@
             "name": "invalid-json-job",
             "url": "http://example.com/ci/job/invalid-json-job/",
             "color": "red"
+        },
+        {
+            "_class": "org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject",
+            "name": "zowe-docs-site",
+            "url": "http://example.com/ci/job/zowe-docs-site/"
         }
     ]
 }

--- a/tests/data/jenkins/jenkins_workflow_job_builds.json
+++ b/tests/data/jenkins/jenkins_workflow_job_builds.json
@@ -1,0 +1,2420 @@
+{
+    "_class": "org.jenkinsci.plugins.workflow.job.WorkflowJob",
+    "actions": [
+        {},
+        {},
+        {},
+        {
+            "_class": "hudson.plugins.jobConfigHistory.JobConfigHistoryProjectAction",
+            "jobConfigHistory": [
+                {
+                    "currentName": "",
+                    "date": "2019-11-14_21-57-10",
+                    "hasConfig": true,
+                    "job": "zowe-docs-site/users%2Fjack%2Flf-jenkins",
+                    "oldName": "",
+                    "operation": "Changed",
+                    "user": "SYSTEM",
+                    "userID": "SYSTEM"
+                },
+                {
+                    "currentName": "",
+                    "date": "2019-11-14_21-27-18",
+                    "hasConfig": true,
+                    "job": "zowe-docs-site/users%2Fjack%2Flf-jenkins",
+                    "oldName": "",
+                    "operation": "Changed",
+                    "user": "SYSTEM",
+                    "userID": "SYSTEM"
+                },
+                {
+                    "currentName": "",
+                    "date": "2019-11-13_21-29-20",
+                    "hasConfig": true,
+                    "job": "zowe-docs-site/users%2Fjack%2Flf-jenkins",
+                    "oldName": "",
+                    "operation": "Changed",
+                    "user": "SYSTEM",
+                    "userID": "SYSTEM"
+                },
+                {
+                    "currentName": "",
+                    "date": "2019-11-13_21-27-13",
+                    "hasConfig": true,
+                    "job": "zowe-docs-site/users%2Fjack%2Flf-jenkins",
+                    "oldName": "",
+                    "operation": "Created",
+                    "user": "SYSTEM",
+                    "userID": "SYSTEM"
+                },
+                {
+                    "currentName": "",
+                    "date": "2019-11-13_21-27-12",
+                    "hasConfig": true,
+                    "job": "zowe-docs-site/users%2Fjack%2Flf-jenkins",
+                    "oldName": "",
+                    "operation": "Changed",
+                    "user": "SYSTEM",
+                    "userID": "SYSTEM"
+                },
+                {
+                    "currentName": "",
+                    "date": "2019-11-13_21-27-11",
+                    "hasConfig": true,
+                    "job": "zowe-docs-site/users%2Fjack%2Flf-jenkins",
+                    "oldName": "",
+                    "operation": "Changed",
+                    "user": "SYSTEM",
+                    "userID": "SYSTEM"
+                },
+                {
+                    "currentName": "",
+                    "date": "2019-11-13_21-27-10",
+                    "hasConfig": true,
+                    "job": "zowe-docs-site/users%2Fjack%2Flf-jenkins",
+                    "oldName": "",
+                    "operation": "Changed",
+                    "user": "SYSTEM",
+                    "userID": "SYSTEM"
+                }
+            ]
+        },
+        {},
+        {},
+        {},
+        {},
+        {
+            "_class": "com.cloudbees.plugins.credentials.ViewCredentialsAction",
+            "stores": {}
+        }
+    ],
+    "buildable": true,
+    "builds": [
+        {
+            "_class": "org.jenkinsci.plugins.workflow.job.WorkflowRun",
+            "actions": [
+                {
+                    "_class": "hudson.model.ParametersAction",
+                    "parameters": [
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Check for CI Skip",
+                            "value": false
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Init Generic Pipeline",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Lint",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Audit",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Prepare .deploy",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Build: Source",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Test: Broken Links",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Generate PDF",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Publish: Package",
+                            "value": true
+                        }
+                    ]
+                },
+                {
+                    "_class": "hudson.model.CauseAction",
+                    "causes": [
+                        {
+                            "_class": "hudson.model.Cause$UserIdCause",
+                            "shortDescription": "Started by user Daniel Pono Takamori",
+                            "userId": "takamori",
+                            "userName": "Daniel Pono Takamori"
+                        }
+                    ]
+                },
+                {},
+                {
+                    "_class": "jenkins.scm.api.SCMRevisionAction"
+                },
+                {},
+                {
+                    "_class": "org.jenkinsci.plugins.workflow.cps.EnvActionImpl"
+                },
+                {},
+                {},
+                {
+                    "_class": "hudson.plugins.git.util.BuildData",
+                    "buildsByBranchName": {
+                        "master": {
+                            "_class": "hudson.plugins.git.util.Build",
+                            "buildNumber": 5,
+                            "buildResult": null,
+                            "marked": {
+                                "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                "branch": [
+                                    {
+                                        "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                        "name": "master"
+                                    }
+                                ]
+                            },
+                            "revision": {
+                                "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                "branch": [
+                                    {
+                                        "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                        "name": "master"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "lastBuiltRevision": {
+                        "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                        "branch": [
+                            {
+                                "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                "name": "master"
+                            }
+                        ]
+                    },
+                    "remoteUrls": [
+                        "https://github.com/zowe/jenkins-library.git"
+                    ],
+                    "scmName": ""
+                },
+                {
+                    "_class": "hudson.plugins.git.GitTagAction"
+                },
+                {},
+                {
+                    "_class": "hudson.plugins.git.util.BuildData",
+                    "buildsByBranchName": {
+                        "users/jack/lf-jenkins": {
+                            "_class": "hudson.plugins.git.util.Build",
+                            "buildNumber": 5,
+                            "buildResult": null,
+                            "marked": {
+                                "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                "branch": [
+                                    {
+                                        "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                        "name": "users/jack/lf-jenkins"
+                                    }
+                                ]
+                            },
+                            "revision": {
+                                "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                "branch": [
+                                    {
+                                        "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                        "name": "users/jack/lf-jenkins"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "lastBuiltRevision": {
+                        "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                        "branch": [
+                            {
+                                "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                "name": "users/jack/lf-jenkins"
+                            }
+                        ]
+                    },
+                    "remoteUrls": [
+                        "https://github.com/zowe/docs-site.git"
+                    ],
+                    "scmName": ""
+                },
+                {},
+                {},
+                {},
+                {},
+                {
+                    "_class": "org.jenkinsci.plugins.pipeline.modeldefinition.actions.RestartDeclarativePipelineAction"
+                },
+                {},
+                {
+                    "_class": "org.jenkinsci.plugins.workflow.job.views.FlowGraphAction"
+                },
+                {},
+                {}
+            ],
+            "artifacts": [],
+            "building": false,
+            "changeSets": [],
+            "culprits": [],
+            "description": null,
+            "displayName": "#5",
+            "duration": 177525,
+            "estimatedDuration": 395858,
+            "executor": null,
+            "fullDisplayName": "zowe-docs-site \u00bb users/jack/lf-jenkins #5",
+            "id": "5",
+            "keepLog": false,
+            "nextBuild": null,
+            "number": 5,
+            "previousBuild": {
+                "number": 4,
+                "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/4/"
+            },
+            "queueId": 1588,
+            "result": "SUCCESS",
+            "timestamp": 1573768779979,
+            "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/5/"
+        },
+        {
+            "_class": "org.jenkinsci.plugins.workflow.job.WorkflowRun",
+            "actions": [
+                {
+                    "_class": "hudson.model.ParametersAction",
+                    "parameters": [
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Check for CI Skip",
+                            "value": false
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Init Generic Pipeline",
+                            "value": false
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Lint",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Audit",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Prepare .deploy",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Build: Source",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Test: Broken Links",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Generate PDF",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Publish: Package",
+                            "value": true
+                        }
+                    ]
+                },
+                {
+                    "_class": "hudson.model.CauseAction",
+                    "causes": [
+                        {
+                            "_class": "hudson.model.Cause$UserIdCause",
+                            "shortDescription": "Started by user Daniel Pono Takamori",
+                            "userId": "takamori",
+                            "userName": "Daniel Pono Takamori"
+                        }
+                    ]
+                },
+                {},
+                {
+                    "_class": "jenkins.scm.api.SCMRevisionAction"
+                },
+                {},
+                {
+                    "_class": "org.jenkinsci.plugins.workflow.cps.EnvActionImpl"
+                },
+                {},
+                {},
+                {
+                    "_class": "hudson.plugins.git.util.BuildData",
+                    "buildsByBranchName": {
+                        "master": {
+                            "_class": "hudson.plugins.git.util.Build",
+                            "buildNumber": 4,
+                            "buildResult": null,
+                            "marked": {
+                                "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                "branch": [
+                                    {
+                                        "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                        "name": "master"
+                                    }
+                                ]
+                            },
+                            "revision": {
+                                "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                "branch": [
+                                    {
+                                        "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                        "name": "master"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "lastBuiltRevision": {
+                        "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                        "branch": [
+                            {
+                                "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                "name": "master"
+                            }
+                        ]
+                    },
+                    "remoteUrls": [
+                        "https://github.com/zowe/jenkins-library.git"
+                    ],
+                    "scmName": ""
+                },
+                {
+                    "_class": "hudson.plugins.git.GitTagAction"
+                },
+                {},
+                {
+                    "_class": "hudson.plugins.git.util.BuildData",
+                    "buildsByBranchName": {
+                        "users/jack/lf-jenkins": {
+                            "_class": "hudson.plugins.git.util.Build",
+                            "buildNumber": 4,
+                            "buildResult": null,
+                            "marked": {
+                                "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                "branch": [
+                                    {
+                                        "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                        "name": "users/jack/lf-jenkins"
+                                    }
+                                ]
+                            },
+                            "revision": {
+                                "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                "branch": [
+                                    {
+                                        "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                        "name": "users/jack/lf-jenkins"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "lastBuiltRevision": {
+                        "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                        "branch": [
+                            {
+                                "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                "name": "users/jack/lf-jenkins"
+                            }
+                        ]
+                    },
+                    "remoteUrls": [
+                        "https://github.com/zowe/docs-site.git"
+                    ],
+                    "scmName": ""
+                },
+                {},
+                {},
+                {},
+                {},
+                {},
+                {
+                    "_class": "org.jenkinsci.plugins.pipeline.modeldefinition.actions.RestartDeclarativePipelineAction"
+                },
+                {},
+                {
+                    "_class": "org.jenkinsci.plugins.workflow.job.views.FlowGraphAction"
+                },
+                {},
+                {}
+            ],
+            "artifacts": [],
+            "building": false,
+            "changeSets": [],
+            "culprits": [],
+            "description": null,
+            "displayName": "#4",
+            "duration": 127885,
+            "estimatedDuration": 395858,
+            "executor": null,
+            "fullDisplayName": "zowe-docs-site \u00bb users/jack/lf-jenkins #4",
+            "id": "4",
+            "keepLog": false,
+            "nextBuild": {
+                "number": 5,
+                "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/5/"
+            },
+            "number": 4,
+            "previousBuild": {
+                "number": 3,
+                "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/3/"
+            },
+            "queueId": 1586,
+            "result": "FAILURE",
+            "timestamp": 1573768516016,
+            "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/4/"
+        },
+        {
+            "_class": "org.jenkinsci.plugins.workflow.job.WorkflowRun",
+            "actions": [
+                {
+                    "_class": "hudson.model.ParametersAction",
+                    "parameters": [
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Check for CI Skip",
+                            "value": false
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Init Generic Pipeline",
+                            "value": false
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Lint",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Audit",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Prepare .deploy",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Build: Source",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Test: Broken Links",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Generate PDF",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Publish: Package",
+                            "value": true
+                        }
+                    ]
+                },
+                {
+                    "_class": "hudson.model.CauseAction",
+                    "causes": [
+                        {
+                            "_class": "hudson.model.Cause$UserIdCause",
+                            "shortDescription": "Started by user Daniel Pono Takamori",
+                            "userId": "takamori",
+                            "userName": "Daniel Pono Takamori"
+                        }
+                    ]
+                },
+                {
+                    "_class": "jenkins.scm.api.SCMRevisionAction"
+                },
+                {},
+                {
+                    "_class": "org.jenkinsci.plugins.workflow.cps.EnvActionImpl"
+                },
+                {},
+                {},
+                {
+                    "_class": "hudson.plugins.git.util.BuildData",
+                    "buildsByBranchName": {
+                        "master": {
+                            "_class": "hudson.plugins.git.util.Build",
+                            "buildNumber": 3,
+                            "buildResult": null,
+                            "marked": {
+                                "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                "branch": [
+                                    {
+                                        "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                        "name": "master"
+                                    }
+                                ]
+                            },
+                            "revision": {
+                                "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                "branch": [
+                                    {
+                                        "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                        "name": "master"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "lastBuiltRevision": {
+                        "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                        "branch": [
+                            {
+                                "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                "name": "master"
+                            }
+                        ]
+                    },
+                    "remoteUrls": [
+                        "https://github.com/zowe/jenkins-library.git"
+                    ],
+                    "scmName": ""
+                },
+                {
+                    "_class": "hudson.plugins.git.GitTagAction"
+                },
+                {},
+                {
+                    "_class": "hudson.plugins.git.util.BuildData",
+                    "buildsByBranchName": {
+                        "users/jack/lf-jenkins": {
+                            "_class": "hudson.plugins.git.util.Build",
+                            "buildNumber": 3,
+                            "buildResult": null,
+                            "marked": {
+                                "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                "branch": [
+                                    {
+                                        "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                        "name": "users/jack/lf-jenkins"
+                                    }
+                                ]
+                            },
+                            "revision": {
+                                "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                "branch": [
+                                    {
+                                        "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                        "name": "users/jack/lf-jenkins"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "lastBuiltRevision": {
+                        "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                        "branch": [
+                            {
+                                "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                "name": "users/jack/lf-jenkins"
+                            }
+                        ]
+                    },
+                    "remoteUrls": [
+                        "https://github.com/zowe/docs-site.git"
+                    ],
+                    "scmName": ""
+                },
+                {},
+                {},
+                {},
+                {},
+                {},
+                {
+                    "_class": "org.jenkinsci.plugins.pipeline.modeldefinition.actions.RestartDeclarativePipelineAction"
+                },
+                {},
+                {
+                    "_class": "org.jenkinsci.plugins.workflow.job.views.FlowGraphAction"
+                },
+                {},
+                {}
+            ],
+            "artifacts": [],
+            "building": false,
+            "changeSets": [],
+            "culprits": [],
+            "description": null,
+            "displayName": "#3",
+            "duration": 882163,
+            "estimatedDuration": 395858,
+            "executor": null,
+            "fullDisplayName": "zowe-docs-site \u00bb users/jack/lf-jenkins #3",
+            "id": "3",
+            "keepLog": false,
+            "nextBuild": {
+                "number": 4,
+                "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/4/"
+            },
+            "number": 3,
+            "previousBuild": {
+                "number": 2,
+                "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/2/"
+            },
+            "queueId": 1584,
+            "result": "FAILURE",
+            "timestamp": 1573765972008,
+            "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/3/"
+        },
+        {
+            "_class": "org.jenkinsci.plugins.workflow.job.WorkflowRun",
+            "actions": [
+                {
+                    "_class": "hudson.model.ParametersAction",
+                    "parameters": [
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Check for CI Skip",
+                            "value": false
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Init Generic Pipeline",
+                            "value": false
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Lint",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Audit",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Prepare .deploy",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Build: Source",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Test: Broken Links",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Generate PDF",
+                            "value": true
+                        },
+                        {
+                            "_class": "hudson.model.BooleanParameterValue",
+                            "name": "Skip Stage: Publish: Package",
+                            "value": true
+                        }
+                    ]
+                },
+                {
+                    "_class": "hudson.model.CauseAction",
+                    "causes": [
+                        {
+                            "_class": "hudson.model.Cause$UserIdCause",
+                            "shortDescription": "Started by user Daniel Pono Takamori",
+                            "userId": "takamori",
+                            "userName": "Daniel Pono Takamori"
+                        }
+                    ]
+                },
+                {},
+                {},
+                {},
+                {},
+                {
+                    "_class": "org.jenkinsci.plugins.pipeline.modeldefinition.actions.RestartDeclarativePipelineAction"
+                },
+                {},
+                {
+                    "_class": "org.jenkinsci.plugins.workflow.job.views.FlowGraphAction"
+                },
+                {},
+                {}
+            ],
+            "artifacts": [],
+            "building": false,
+            "changeSets": [],
+            "culprits": [],
+            "description": null,
+            "displayName": "#2",
+            "duration": 463782,
+            "estimatedDuration": 395858,
+            "executor": null,
+            "fullDisplayName": "zowe-docs-site \u00bb users/jack/lf-jenkins #2",
+            "id": "2",
+            "keepLog": false,
+            "nextBuild": {
+                "number": 3,
+                "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/3/"
+            },
+            "number": 2,
+            "previousBuild": {
+                "number": 1,
+                "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/1/"
+            },
+            "queueId": 1583,
+            "result": "FAILURE",
+            "timestamp": 1573765401166,
+            "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/2/"
+        },
+        {
+            "_class": "org.jenkinsci.plugins.workflow.job.WorkflowRun",
+            "actions": [
+                {
+                    "_class": "hudson.model.CauseAction",
+                    "causes": [
+                        {
+                            "_class": "jenkins.branch.BranchEventCause",
+                            "shortDescription": "Push event to branch users/jack/lf-jenkins"
+                        }
+                    ]
+                },
+                {
+                    "_class": "jenkins.scm.api.SCMRevisionAction"
+                },
+                {},
+                {
+                    "_class": "org.jenkinsci.plugins.workflow.cps.EnvActionImpl"
+                },
+                {},
+                {},
+                {
+                    "_class": "hudson.plugins.git.util.BuildData",
+                    "buildsByBranchName": {
+                        "master": {
+                            "_class": "hudson.plugins.git.util.Build",
+                            "buildNumber": 1,
+                            "buildResult": null,
+                            "marked": {
+                                "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                "branch": [
+                                    {
+                                        "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                        "name": "master"
+                                    }
+                                ]
+                            },
+                            "revision": {
+                                "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                "branch": [
+                                    {
+                                        "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                        "name": "master"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "lastBuiltRevision": {
+                        "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                        "branch": [
+                            {
+                                "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                "name": "master"
+                            }
+                        ]
+                    },
+                    "remoteUrls": [
+                        "https://github.com/zowe/jenkins-library.git"
+                    ],
+                    "scmName": ""
+                },
+                {
+                    "_class": "hudson.plugins.git.GitTagAction"
+                },
+                {},
+                {
+                    "_class": "hudson.plugins.git.util.BuildData",
+                    "buildsByBranchName": {
+                        "users/jack/lf-jenkins": {
+                            "_class": "hudson.plugins.git.util.Build",
+                            "buildNumber": 1,
+                            "buildResult": null,
+                            "marked": {
+                                "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                "branch": [
+                                    {
+                                        "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                        "name": "users/jack/lf-jenkins"
+                                    }
+                                ]
+                            },
+                            "revision": {
+                                "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                "branch": [
+                                    {
+                                        "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                        "name": "users/jack/lf-jenkins"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "lastBuiltRevision": {
+                        "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                        "branch": [
+                            {
+                                "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                "name": "users/jack/lf-jenkins"
+                            }
+                        ]
+                    },
+                    "remoteUrls": [
+                        "https://github.com/zowe/docs-site.git"
+                    ],
+                    "scmName": ""
+                },
+                {},
+                {},
+                {},
+                {},
+                {
+                    "_class": "org.jenkinsci.plugins.pipeline.modeldefinition.actions.RestartDeclarativePipelineAction"
+                },
+                {},
+                {
+                    "_class": "org.jenkinsci.plugins.workflow.job.views.FlowGraphAction"
+                },
+                {},
+                {}
+            ],
+            "artifacts": [],
+            "building": false,
+            "changeSets": [],
+            "culprits": [],
+            "description": null,
+            "displayName": "#1",
+            "duration": 141256,
+            "estimatedDuration": 395858,
+            "executor": null,
+            "fullDisplayName": "zowe-docs-site \u00bb users/jack/lf-jenkins #1",
+            "id": "1",
+            "keepLog": false,
+            "nextBuild": {
+                "number": 2,
+                "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/2/"
+            },
+            "number": 1,
+            "previousBuild": null,
+            "queueId": 991,
+            "result": "FAILURE",
+            "timestamp": 1573680433476,
+            "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/1/"
+        }
+    ],
+    "color": "blue",
+    "concurrentBuild": false,
+    "description": null,
+    "displayName": "users/jack/lf-jenkins",
+    "displayNameOrNull": "users/jack/lf-jenkins",
+    "firstBuild": {
+        "_class": "org.jenkinsci.plugins.workflow.job.WorkflowRun",
+        "actions": [
+            {
+                "_class": "hudson.model.CauseAction",
+                "causes": [
+                    {
+                        "_class": "jenkins.branch.BranchEventCause",
+                        "shortDescription": "Push event to branch users/jack/lf-jenkins"
+                    }
+                ]
+            },
+            {
+                "_class": "jenkins.scm.api.SCMRevisionAction"
+            },
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.workflow.cps.EnvActionImpl"
+            },
+            {},
+            {},
+            {
+                "_class": "hudson.plugins.git.util.BuildData",
+                "buildsByBranchName": {
+                    "master": {
+                        "_class": "hudson.plugins.git.util.Build",
+                        "buildNumber": 1,
+                        "buildResult": null,
+                        "marked": {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "branch": [
+                                {
+                                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                    "name": "master"
+                                }
+                            ]
+                        },
+                        "revision": {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "branch": [
+                                {
+                                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                    "name": "master"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "lastBuiltRevision": {
+                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                    "branch": [
+                        {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "name": "master"
+                        }
+                    ]
+                },
+                "remoteUrls": [
+                    "https://github.com/zowe/jenkins-library.git"
+                ],
+                "scmName": ""
+            },
+            {
+                "_class": "hudson.plugins.git.GitTagAction"
+            },
+            {},
+            {
+                "_class": "hudson.plugins.git.util.BuildData",
+                "buildsByBranchName": {
+                    "users/jack/lf-jenkins": {
+                        "_class": "hudson.plugins.git.util.Build",
+                        "buildNumber": 1,
+                        "buildResult": null,
+                        "marked": {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "branch": [
+                                {
+                                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                    "name": "users/jack/lf-jenkins"
+                                }
+                            ]
+                        },
+                        "revision": {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "branch": [
+                                {
+                                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                    "name": "users/jack/lf-jenkins"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "lastBuiltRevision": {
+                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                    "branch": [
+                        {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "name": "users/jack/lf-jenkins"
+                        }
+                    ]
+                },
+                "remoteUrls": [
+                    "https://github.com/zowe/docs-site.git"
+                ],
+                "scmName": ""
+            },
+            {},
+            {},
+            {},
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.pipeline.modeldefinition.actions.RestartDeclarativePipelineAction"
+            },
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.workflow.job.views.FlowGraphAction"
+            },
+            {},
+            {}
+        ],
+        "artifacts": [],
+        "building": false,
+        "changeSets": [],
+        "culprits": [],
+        "description": null,
+        "displayName": "#1",
+        "duration": 141256,
+        "estimatedDuration": 395858,
+        "executor": null,
+        "fullDisplayName": "zowe-docs-site \u00bb users/jack/lf-jenkins #1",
+        "id": "1",
+        "keepLog": false,
+        "nextBuild": {
+            "number": 2,
+            "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/2/"
+        },
+        "number": 1,
+        "previousBuild": null,
+        "queueId": 991,
+        "result": "FAILURE",
+        "timestamp": 1573680433476,
+        "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/1/"
+    },
+    "fullDisplayName": "zowe-docs-site \u00bb users/jack/lf-jenkins",
+    "fullName": "zowe-docs-site/users%2Fjack%2Flf-jenkins",
+    "healthReport": [
+        {
+            "description": "Build stability: 4 out of the last 5 builds failed.",
+            "iconClassName": "icon-health-00to19",
+            "iconUrl": "health-00to19.png",
+            "score": 20
+        }
+    ],
+    "inQueue": false,
+    "keepDependencies": false,
+    "lastBuild": {
+        "_class": "org.jenkinsci.plugins.workflow.job.WorkflowRun",
+        "actions": [
+            {
+                "_class": "hudson.model.ParametersAction",
+                "parameters": [
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Check for CI Skip",
+                        "value": false
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Init Generic Pipeline",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Lint",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Audit",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Prepare .deploy",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Build: Source",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Test: Broken Links",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Generate PDF",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Publish: Package",
+                        "value": true
+                    }
+                ]
+            },
+            {
+                "_class": "hudson.model.CauseAction",
+                "causes": [
+                    {
+                        "_class": "hudson.model.Cause$UserIdCause",
+                        "shortDescription": "Started by user Daniel Pono Takamori",
+                        "userId": "takamori",
+                        "userName": "Daniel Pono Takamori"
+                    }
+                ]
+            },
+            {},
+            {
+                "_class": "jenkins.scm.api.SCMRevisionAction"
+            },
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.workflow.cps.EnvActionImpl"
+            },
+            {},
+            {},
+            {
+                "_class": "hudson.plugins.git.util.BuildData",
+                "buildsByBranchName": {
+                    "master": {
+                        "_class": "hudson.plugins.git.util.Build",
+                        "buildNumber": 5,
+                        "buildResult": null,
+                        "marked": {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "branch": [
+                                {
+                                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                    "name": "master"
+                                }
+                            ]
+                        },
+                        "revision": {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "branch": [
+                                {
+                                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                    "name": "master"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "lastBuiltRevision": {
+                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                    "branch": [
+                        {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "name": "master"
+                        }
+                    ]
+                },
+                "remoteUrls": [
+                    "https://github.com/zowe/jenkins-library.git"
+                ],
+                "scmName": ""
+            },
+            {
+                "_class": "hudson.plugins.git.GitTagAction"
+            },
+            {},
+            {
+                "_class": "hudson.plugins.git.util.BuildData",
+                "buildsByBranchName": {
+                    "users/jack/lf-jenkins": {
+                        "_class": "hudson.plugins.git.util.Build",
+                        "buildNumber": 5,
+                        "buildResult": null,
+                        "marked": {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "branch": [
+                                {
+                                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                    "name": "users/jack/lf-jenkins"
+                                }
+                            ]
+                        },
+                        "revision": {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "branch": [
+                                {
+                                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                    "name": "users/jack/lf-jenkins"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "lastBuiltRevision": {
+                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                    "branch": [
+                        {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "name": "users/jack/lf-jenkins"
+                        }
+                    ]
+                },
+                "remoteUrls": [
+                    "https://github.com/zowe/docs-site.git"
+                ],
+                "scmName": ""
+            },
+            {},
+            {},
+            {},
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.pipeline.modeldefinition.actions.RestartDeclarativePipelineAction"
+            },
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.workflow.job.views.FlowGraphAction"
+            },
+            {},
+            {}
+        ],
+        "artifacts": [],
+        "building": false,
+        "changeSets": [],
+        "culprits": [],
+        "description": null,
+        "displayName": "#5",
+        "duration": 177525,
+        "estimatedDuration": 395858,
+        "executor": null,
+        "fullDisplayName": "zowe-docs-site \u00bb users/jack/lf-jenkins #5",
+        "id": "5",
+        "keepLog": false,
+        "nextBuild": null,
+        "number": 5,
+        "previousBuild": {
+            "number": 4,
+            "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/4/"
+        },
+        "queueId": 1588,
+        "result": "SUCCESS",
+        "timestamp": 1573768779979,
+        "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/5/"
+    },
+    "lastCompletedBuild": {
+        "_class": "org.jenkinsci.plugins.workflow.job.WorkflowRun",
+        "actions": [
+            {
+                "_class": "hudson.model.ParametersAction",
+                "parameters": [
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Check for CI Skip",
+                        "value": false
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Init Generic Pipeline",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Lint",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Audit",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Prepare .deploy",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Build: Source",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Test: Broken Links",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Generate PDF",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Publish: Package",
+                        "value": true
+                    }
+                ]
+            },
+            {
+                "_class": "hudson.model.CauseAction",
+                "causes": [
+                    {
+                        "_class": "hudson.model.Cause$UserIdCause",
+                        "shortDescription": "Started by user Daniel Pono Takamori",
+                        "userId": "takamori",
+                        "userName": "Daniel Pono Takamori"
+                    }
+                ]
+            },
+            {},
+            {
+                "_class": "jenkins.scm.api.SCMRevisionAction"
+            },
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.workflow.cps.EnvActionImpl"
+            },
+            {},
+            {},
+            {
+                "_class": "hudson.plugins.git.util.BuildData",
+                "buildsByBranchName": {
+                    "master": {
+                        "_class": "hudson.plugins.git.util.Build",
+                        "buildNumber": 5,
+                        "buildResult": null,
+                        "marked": {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "branch": [
+                                {
+                                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                    "name": "master"
+                                }
+                            ]
+                        },
+                        "revision": {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "branch": [
+                                {
+                                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                    "name": "master"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "lastBuiltRevision": {
+                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                    "branch": [
+                        {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "name": "master"
+                        }
+                    ]
+                },
+                "remoteUrls": [
+                    "https://github.com/zowe/jenkins-library.git"
+                ],
+                "scmName": ""
+            },
+            {
+                "_class": "hudson.plugins.git.GitTagAction"
+            },
+            {},
+            {
+                "_class": "hudson.plugins.git.util.BuildData",
+                "buildsByBranchName": {
+                    "users/jack/lf-jenkins": {
+                        "_class": "hudson.plugins.git.util.Build",
+                        "buildNumber": 5,
+                        "buildResult": null,
+                        "marked": {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "branch": [
+                                {
+                                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                    "name": "users/jack/lf-jenkins"
+                                }
+                            ]
+                        },
+                        "revision": {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "branch": [
+                                {
+                                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                    "name": "users/jack/lf-jenkins"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "lastBuiltRevision": {
+                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                    "branch": [
+                        {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "name": "users/jack/lf-jenkins"
+                        }
+                    ]
+                },
+                "remoteUrls": [
+                    "https://github.com/zowe/docs-site.git"
+                ],
+                "scmName": ""
+            },
+            {},
+            {},
+            {},
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.pipeline.modeldefinition.actions.RestartDeclarativePipelineAction"
+            },
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.workflow.job.views.FlowGraphAction"
+            },
+            {},
+            {}
+        ],
+        "artifacts": [],
+        "building": false,
+        "changeSets": [],
+        "culprits": [],
+        "description": null,
+        "displayName": "#5",
+        "duration": 177525,
+        "estimatedDuration": 395858,
+        "executor": null,
+        "fullDisplayName": "zowe-docs-site \u00bb users/jack/lf-jenkins #5",
+        "id": "5",
+        "keepLog": false,
+        "nextBuild": null,
+        "number": 5,
+        "previousBuild": {
+            "number": 4,
+            "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/4/"
+        },
+        "queueId": 1588,
+        "result": "SUCCESS",
+        "timestamp": 1573768779979,
+        "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/5/"
+    },
+    "lastFailedBuild": {
+        "_class": "org.jenkinsci.plugins.workflow.job.WorkflowRun",
+        "actions": [
+            {
+                "_class": "hudson.model.ParametersAction",
+                "parameters": [
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Check for CI Skip",
+                        "value": false
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Init Generic Pipeline",
+                        "value": false
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Lint",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Audit",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Prepare .deploy",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Build: Source",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Test: Broken Links",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Generate PDF",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Publish: Package",
+                        "value": true
+                    }
+                ]
+            },
+            {
+                "_class": "hudson.model.CauseAction",
+                "causes": [
+                    {
+                        "_class": "hudson.model.Cause$UserIdCause",
+                        "shortDescription": "Started by user Daniel Pono Takamori",
+                        "userId": "takamori",
+                        "userName": "Daniel Pono Takamori"
+                    }
+                ]
+            },
+            {},
+            {
+                "_class": "jenkins.scm.api.SCMRevisionAction"
+            },
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.workflow.cps.EnvActionImpl"
+            },
+            {},
+            {},
+            {
+                "_class": "hudson.plugins.git.util.BuildData",
+                "buildsByBranchName": {
+                    "master": {
+                        "_class": "hudson.plugins.git.util.Build",
+                        "buildNumber": 4,
+                        "buildResult": null,
+                        "marked": {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "branch": [
+                                {
+                                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                    "name": "master"
+                                }
+                            ]
+                        },
+                        "revision": {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "branch": [
+                                {
+                                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                    "name": "master"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "lastBuiltRevision": {
+                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                    "branch": [
+                        {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "name": "master"
+                        }
+                    ]
+                },
+                "remoteUrls": [
+                    "https://github.com/zowe/jenkins-library.git"
+                ],
+                "scmName": ""
+            },
+            {
+                "_class": "hudson.plugins.git.GitTagAction"
+            },
+            {},
+            {
+                "_class": "hudson.plugins.git.util.BuildData",
+                "buildsByBranchName": {
+                    "users/jack/lf-jenkins": {
+                        "_class": "hudson.plugins.git.util.Build",
+                        "buildNumber": 4,
+                        "buildResult": null,
+                        "marked": {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "branch": [
+                                {
+                                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                    "name": "users/jack/lf-jenkins"
+                                }
+                            ]
+                        },
+                        "revision": {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "branch": [
+                                {
+                                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                    "name": "users/jack/lf-jenkins"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "lastBuiltRevision": {
+                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                    "branch": [
+                        {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "name": "users/jack/lf-jenkins"
+                        }
+                    ]
+                },
+                "remoteUrls": [
+                    "https://github.com/zowe/docs-site.git"
+                ],
+                "scmName": ""
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.pipeline.modeldefinition.actions.RestartDeclarativePipelineAction"
+            },
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.workflow.job.views.FlowGraphAction"
+            },
+            {},
+            {}
+        ],
+        "artifacts": [],
+        "building": false,
+        "changeSets": [],
+        "culprits": [],
+        "description": null,
+        "displayName": "#4",
+        "duration": 127885,
+        "estimatedDuration": 395858,
+        "executor": null,
+        "fullDisplayName": "zowe-docs-site \u00bb users/jack/lf-jenkins #4",
+        "id": "4",
+        "keepLog": false,
+        "nextBuild": {
+            "number": 5,
+            "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/5/"
+        },
+        "number": 4,
+        "previousBuild": {
+            "number": 3,
+            "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/3/"
+        },
+        "queueId": 1586,
+        "result": "FAILURE",
+        "timestamp": 1573768516016,
+        "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/4/"
+    },
+    "lastStableBuild": {
+        "_class": "org.jenkinsci.plugins.workflow.job.WorkflowRun",
+        "actions": [
+            {
+                "_class": "hudson.model.ParametersAction",
+                "parameters": [
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Check for CI Skip",
+                        "value": false
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Init Generic Pipeline",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Lint",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Audit",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Prepare .deploy",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Build: Source",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Test: Broken Links",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Generate PDF",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Publish: Package",
+                        "value": true
+                    }
+                ]
+            },
+            {
+                "_class": "hudson.model.CauseAction",
+                "causes": [
+                    {
+                        "_class": "hudson.model.Cause$UserIdCause",
+                        "shortDescription": "Started by user Daniel Pono Takamori",
+                        "userId": "takamori",
+                        "userName": "Daniel Pono Takamori"
+                    }
+                ]
+            },
+            {},
+            {
+                "_class": "jenkins.scm.api.SCMRevisionAction"
+            },
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.workflow.cps.EnvActionImpl"
+            },
+            {},
+            {},
+            {
+                "_class": "hudson.plugins.git.util.BuildData",
+                "buildsByBranchName": {
+                    "master": {
+                        "_class": "hudson.plugins.git.util.Build",
+                        "buildNumber": 5,
+                        "buildResult": null,
+                        "marked": {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "branch": [
+                                {
+                                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                    "name": "master"
+                                }
+                            ]
+                        },
+                        "revision": {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "branch": [
+                                {
+                                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                    "name": "master"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "lastBuiltRevision": {
+                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                    "branch": [
+                        {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "name": "master"
+                        }
+                    ]
+                },
+                "remoteUrls": [
+                    "https://github.com/zowe/jenkins-library.git"
+                ],
+                "scmName": ""
+            },
+            {
+                "_class": "hudson.plugins.git.GitTagAction"
+            },
+            {},
+            {
+                "_class": "hudson.plugins.git.util.BuildData",
+                "buildsByBranchName": {
+                    "users/jack/lf-jenkins": {
+                        "_class": "hudson.plugins.git.util.Build",
+                        "buildNumber": 5,
+                        "buildResult": null,
+                        "marked": {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "branch": [
+                                {
+                                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                    "name": "users/jack/lf-jenkins"
+                                }
+                            ]
+                        },
+                        "revision": {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "branch": [
+                                {
+                                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                    "name": "users/jack/lf-jenkins"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "lastBuiltRevision": {
+                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                    "branch": [
+                        {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "name": "users/jack/lf-jenkins"
+                        }
+                    ]
+                },
+                "remoteUrls": [
+                    "https://github.com/zowe/docs-site.git"
+                ],
+                "scmName": ""
+            },
+            {},
+            {},
+            {},
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.pipeline.modeldefinition.actions.RestartDeclarativePipelineAction"
+            },
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.workflow.job.views.FlowGraphAction"
+            },
+            {},
+            {}
+        ],
+        "artifacts": [],
+        "building": false,
+        "changeSets": [],
+        "culprits": [],
+        "description": null,
+        "displayName": "#5",
+        "duration": 177525,
+        "estimatedDuration": 395858,
+        "executor": null,
+        "fullDisplayName": "zowe-docs-site \u00bb users/jack/lf-jenkins #5",
+        "id": "5",
+        "keepLog": false,
+        "nextBuild": null,
+        "number": 5,
+        "previousBuild": {
+            "number": 4,
+            "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/4/"
+        },
+        "queueId": 1588,
+        "result": "SUCCESS",
+        "timestamp": 1573768779979,
+        "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/5/"
+    },
+    "lastSuccessfulBuild": {
+        "_class": "org.jenkinsci.plugins.workflow.job.WorkflowRun",
+        "actions": [
+            {
+                "_class": "hudson.model.ParametersAction",
+                "parameters": [
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Check for CI Skip",
+                        "value": false
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Init Generic Pipeline",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Lint",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Audit",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Prepare .deploy",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Build: Source",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Test: Broken Links",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Generate PDF",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Publish: Package",
+                        "value": true
+                    }
+                ]
+            },
+            {
+                "_class": "hudson.model.CauseAction",
+                "causes": [
+                    {
+                        "_class": "hudson.model.Cause$UserIdCause",
+                        "shortDescription": "Started by user Daniel Pono Takamori",
+                        "userId": "takamori",
+                        "userName": "Daniel Pono Takamori"
+                    }
+                ]
+            },
+            {},
+            {
+                "_class": "jenkins.scm.api.SCMRevisionAction"
+            },
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.workflow.cps.EnvActionImpl"
+            },
+            {},
+            {},
+            {
+                "_class": "hudson.plugins.git.util.BuildData",
+                "buildsByBranchName": {
+                    "master": {
+                        "_class": "hudson.plugins.git.util.Build",
+                        "buildNumber": 5,
+                        "buildResult": null,
+                        "marked": {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "branch": [
+                                {
+                                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                    "name": "master"
+                                }
+                            ]
+                        },
+                        "revision": {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "branch": [
+                                {
+                                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                    "name": "master"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "lastBuiltRevision": {
+                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                    "branch": [
+                        {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "name": "master"
+                        }
+                    ]
+                },
+                "remoteUrls": [
+                    "https://github.com/zowe/jenkins-library.git"
+                ],
+                "scmName": ""
+            },
+            {
+                "_class": "hudson.plugins.git.GitTagAction"
+            },
+            {},
+            {
+                "_class": "hudson.plugins.git.util.BuildData",
+                "buildsByBranchName": {
+                    "users/jack/lf-jenkins": {
+                        "_class": "hudson.plugins.git.util.Build",
+                        "buildNumber": 5,
+                        "buildResult": null,
+                        "marked": {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "branch": [
+                                {
+                                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                    "name": "users/jack/lf-jenkins"
+                                }
+                            ]
+                        },
+                        "revision": {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "branch": [
+                                {
+                                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                    "name": "users/jack/lf-jenkins"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "lastBuiltRevision": {
+                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                    "branch": [
+                        {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "name": "users/jack/lf-jenkins"
+                        }
+                    ]
+                },
+                "remoteUrls": [
+                    "https://github.com/zowe/docs-site.git"
+                ],
+                "scmName": ""
+            },
+            {},
+            {},
+            {},
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.pipeline.modeldefinition.actions.RestartDeclarativePipelineAction"
+            },
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.workflow.job.views.FlowGraphAction"
+            },
+            {},
+            {}
+        ],
+        "artifacts": [],
+        "building": false,
+        "changeSets": [],
+        "culprits": [],
+        "description": null,
+        "displayName": "#5",
+        "duration": 177525,
+        "estimatedDuration": 395858,
+        "executor": null,
+        "fullDisplayName": "zowe-docs-site \u00bb users/jack/lf-jenkins #5",
+        "id": "5",
+        "keepLog": false,
+        "nextBuild": null,
+        "number": 5,
+        "previousBuild": {
+            "number": 4,
+            "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/4/"
+        },
+        "queueId": 1588,
+        "result": "SUCCESS",
+        "timestamp": 1573768779979,
+        "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/5/"
+    },
+    "lastUnstableBuild": null,
+    "lastUnsuccessfulBuild": {
+        "_class": "org.jenkinsci.plugins.workflow.job.WorkflowRun",
+        "actions": [
+            {
+                "_class": "hudson.model.ParametersAction",
+                "parameters": [
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Check for CI Skip",
+                        "value": false
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Init Generic Pipeline",
+                        "value": false
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Lint",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Audit",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Prepare .deploy",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Build: Source",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Test: Broken Links",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Generate PDF",
+                        "value": true
+                    },
+                    {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Publish: Package",
+                        "value": true
+                    }
+                ]
+            },
+            {
+                "_class": "hudson.model.CauseAction",
+                "causes": [
+                    {
+                        "_class": "hudson.model.Cause$UserIdCause",
+                        "shortDescription": "Started by user Daniel Pono Takamori",
+                        "userId": "takamori",
+                        "userName": "Daniel Pono Takamori"
+                    }
+                ]
+            },
+            {},
+            {
+                "_class": "jenkins.scm.api.SCMRevisionAction"
+            },
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.workflow.cps.EnvActionImpl"
+            },
+            {},
+            {},
+            {
+                "_class": "hudson.plugins.git.util.BuildData",
+                "buildsByBranchName": {
+                    "master": {
+                        "_class": "hudson.plugins.git.util.Build",
+                        "buildNumber": 4,
+                        "buildResult": null,
+                        "marked": {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "branch": [
+                                {
+                                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                    "name": "master"
+                                }
+                            ]
+                        },
+                        "revision": {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "branch": [
+                                {
+                                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                                    "name": "master"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "lastBuiltRevision": {
+                    "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                    "branch": [
+                        {
+                            "SHA1": "d2040eb52fbb16ae0c59dc478a359df09cf818a5",
+                            "name": "master"
+                        }
+                    ]
+                },
+                "remoteUrls": [
+                    "https://github.com/zowe/jenkins-library.git"
+                ],
+                "scmName": ""
+            },
+            {
+                "_class": "hudson.plugins.git.GitTagAction"
+            },
+            {},
+            {
+                "_class": "hudson.plugins.git.util.BuildData",
+                "buildsByBranchName": {
+                    "users/jack/lf-jenkins": {
+                        "_class": "hudson.plugins.git.util.Build",
+                        "buildNumber": 4,
+                        "buildResult": null,
+                        "marked": {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "branch": [
+                                {
+                                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                    "name": "users/jack/lf-jenkins"
+                                }
+                            ]
+                        },
+                        "revision": {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "branch": [
+                                {
+                                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                                    "name": "users/jack/lf-jenkins"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "lastBuiltRevision": {
+                    "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                    "branch": [
+                        {
+                            "SHA1": "2c6e06a3bf6a52ae3f8f26f11c91d9550794c161",
+                            "name": "users/jack/lf-jenkins"
+                        }
+                    ]
+                },
+                "remoteUrls": [
+                    "https://github.com/zowe/docs-site.git"
+                ],
+                "scmName": ""
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.pipeline.modeldefinition.actions.RestartDeclarativePipelineAction"
+            },
+            {},
+            {
+                "_class": "org.jenkinsci.plugins.workflow.job.views.FlowGraphAction"
+            },
+            {},
+            {}
+        ],
+        "artifacts": [],
+        "building": false,
+        "changeSets": [],
+        "culprits": [],
+        "description": null,
+        "displayName": "#4",
+        "duration": 127885,
+        "estimatedDuration": 395858,
+        "executor": null,
+        "fullDisplayName": "zowe-docs-site \u00bb users/jack/lf-jenkins #4",
+        "id": "4",
+        "keepLog": false,
+        "nextBuild": {
+            "number": 5,
+            "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/5/"
+        },
+        "number": 4,
+        "previousBuild": {
+            "number": 3,
+            "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/3/"
+        },
+        "queueId": 1586,
+        "result": "FAILURE",
+        "timestamp": 1573768516016,
+        "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/4/"
+    },
+    "name": "users%2Fjack%2Flf-jenkins",
+    "nextBuildNumber": 6,
+    "property": [
+        {
+            "_class": "org.jenkinsci.plugins.workflow.multibranch.BranchJobProperty",
+            "branch": {
+                "head": {
+                    "_class": "org.jenkinsci.plugins.github_branch_source.BranchSCMHead"
+                },
+                "scm": {
+                    "_class": "hudson.plugins.git.GitSCM"
+                }
+            }
+        },
+        {
+            "_class": "org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty"
+        },
+        {
+            "_class": "jenkins.model.BuildDiscarderProperty"
+        },
+        {
+            "_class": "hudson.model.ParametersDefinitionProperty",
+            "parameterDefinitions": [
+                {
+                    "_class": "hudson.model.BooleanParameterDefinition",
+                    "defaultParameterValue": {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Check for CI Skip",
+                        "value": false
+                    },
+                    "description": "Setting this to true will skip the stage \"Check for CI Skip\"",
+                    "name": "Skip Stage: Check for CI Skip",
+                    "type": "BooleanParameterDefinition"
+                },
+                {
+                    "_class": "hudson.model.BooleanParameterDefinition",
+                    "defaultParameterValue": {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Init Generic Pipeline",
+                        "value": false
+                    },
+                    "description": "Setting this to true will skip the stage \"Init Generic Pipeline\"",
+                    "name": "Skip Stage: Init Generic Pipeline",
+                    "type": "BooleanParameterDefinition"
+                },
+                {
+                    "_class": "hudson.model.BooleanParameterDefinition",
+                    "defaultParameterValue": {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Lint",
+                        "value": false
+                    },
+                    "description": "Setting this to true will skip the stage \"Lint\"",
+                    "name": "Skip Stage: Lint",
+                    "type": "BooleanParameterDefinition"
+                },
+                {
+                    "_class": "hudson.model.BooleanParameterDefinition",
+                    "defaultParameterValue": {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Audit",
+                        "value": false
+                    },
+                    "description": "Setting this to true will skip the stage \"Audit\"",
+                    "name": "Skip Stage: Audit",
+                    "type": "BooleanParameterDefinition"
+                },
+                {
+                    "_class": "hudson.model.BooleanParameterDefinition",
+                    "defaultParameterValue": {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Prepare .deploy",
+                        "value": false
+                    },
+                    "description": "Setting this to true will skip the stage \"Prepare .deploy\"",
+                    "name": "Skip Stage: Prepare .deploy",
+                    "type": "BooleanParameterDefinition"
+                },
+                {
+                    "_class": "hudson.model.BooleanParameterDefinition",
+                    "defaultParameterValue": {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Build: Source",
+                        "value": false
+                    },
+                    "description": "Setting this to true will skip the stage \"Build: Source\"",
+                    "name": "Skip Stage: Build: Source",
+                    "type": "BooleanParameterDefinition"
+                },
+                {
+                    "_class": "hudson.model.BooleanParameterDefinition",
+                    "defaultParameterValue": {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Test: Broken Links",
+                        "value": false
+                    },
+                    "description": "Setting this to true will skip the stage \"Test: Broken Links\"",
+                    "name": "Skip Stage: Test: Broken Links",
+                    "type": "BooleanParameterDefinition"
+                },
+                {
+                    "_class": "hudson.model.BooleanParameterDefinition",
+                    "defaultParameterValue": {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Generate PDF",
+                        "value": false
+                    },
+                    "description": "Setting this to true will skip the stage \"Generate PDF\"",
+                    "name": "Skip Stage: Generate PDF",
+                    "type": "BooleanParameterDefinition"
+                },
+                {
+                    "_class": "hudson.model.BooleanParameterDefinition",
+                    "defaultParameterValue": {
+                        "_class": "hudson.model.BooleanParameterValue",
+                        "name": "Skip Stage: Publish: Package",
+                        "value": false
+                    },
+                    "description": "Setting this to true will skip the stage \"Publish: Package\"",
+                    "name": "Skip Stage: Publish: Package",
+                    "type": "BooleanParameterDefinition"
+                }
+            ]
+        }
+    ],
+    "queueItem": null,
+    "resumeBlocked": false,
+    "url": "https://jenkins.zowe.org/job/zowe-docs-site/job/users%2Fjack%2Flf-jenkins/"
+}

--- a/tests/data/jenkins/jenkins_workflow_jobs.json
+++ b/tests/data/jenkins/jenkins_workflow_jobs.json
@@ -1,0 +1,59 @@
+{
+    "_class": "org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject",
+    "actions": [
+        {},
+        {
+            "_class": "hudson.plugins.jobConfigHistory.JobConfigHistoryProjectAction"
+        },
+        {},
+        {},
+        {},
+        {},
+        {
+            "_class": "com.cloudbees.plugins.credentials.ViewCredentialsAction"
+        }
+    ],
+    "description": "Build, test and publish Zowe docs website<!-- Managed by Jenkins Job Builder -->",
+    "displayName": "zowe-docs-site",
+    "displayNameOrNull": null,
+    "fullDisplayName": "zowe-docs-site",
+    "fullName": "zowe-docs-site",
+    "healthReport": [
+        {
+            "description": "Worst health: zowe-docs-site \u00bb users/jack/lf-jenkins: Build stability: 4 out of the last 5 builds failed.",
+            "iconClassName": "icon-health-00to19",
+            "iconUrl": "health-00to19.png",
+            "score": 20
+        }
+    ],
+    "jobs": [
+        {
+            "_class": "org.jenkinsci.plugins.workflow.job.WorkflowJob",
+            "color": "blue",
+            "name": "zowe-workflow",
+            "url": "http://example.com/ci/job/zowe-docs-site/job/zowe-workflow/"
+        }
+    ],
+    "name": "zowe-docs-site",
+    "primaryView": {
+        "_class": "jenkins.branch.MultiBranchProjectViewHolder$ViewImpl",
+        "name": "default",
+        "url": "http://example.com/ci/job/zowe-docs-site/"
+    },
+    "sources": [
+        {}
+    ],
+    "url": "http://example.com/ci/job/zowe-docs-site/",
+    "views": [
+        {
+            "_class": "jenkins.branch.MultiBranchProjectViewHolder$ViewImpl",
+            "name": "change-requests",
+            "url": "http://example.com/ci/job/zowe-docs-site/view/change-requests/"
+        },
+        {
+            "_class": "jenkins.branch.MultiBranchProjectViewHolder$ViewImpl",
+            "name": "default",
+            "url": "http://example.com/ci/job/zowe-docs-site/"
+        }
+    ]
+}


### PR DESCRIPTION
This code allows to process workflow multibranches job, which include nested jobs and their corresponding builds.

Since the API doesn't offer an endpoint to retrieve workflow jobs, the backend leverages on the class type of the job to process it accordingly. Thus, if the class type is `WorkflowMultiBranchProject`, the nested jobs are retrieved one by one and their builds obtained. Otherwise the logic to process the job is left as it was.

Tests have been added accordingly.
Backend version is now 0.15.0