### PR TITLE
[jenkins] Log debug message when builds are not found

### DIFF
--- a/perceval/backends/core/jenkins.py
+++ b/perceval/backends/core/jenkins.py
@@ -59,7 +59,7 @@ class Jenkins(Backend):
     :param archive: collect builds already retrieved from an archive
     :param blacklist_ids: exclude the jobs ID of this list while fetching
     """
-    version = '0.15.0'
+    version = '0.15.1'
 
     CATEGORIES = [CATEGORY_BUILD]
     EXTRA_SEARCH_FIELDS = {
@@ -226,7 +226,7 @@ class Jenkins(Backend):
         builds = builds.get('builds', [])
         if not builds:
             self.summary.skipped += 1
-            logger.warning("No builds for job %s", job['url'])
+            logger.debug("No builds for job %s", job['url'])
 
         return builds
 

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -344,10 +344,10 @@ class TestJenkinsBackend(unittest.TestCase):
         # Test fetch builds from jobs list
         jenkins = Jenkins(SERVER_URL)
 
-        with self.assertLogs(logger, level='WARNING') as cm:
+        with self.assertLogs(logger, level='DEBUG') as cm:
             builds = [build for build in jenkins.fetch()]
-            self.assertRegex(cm.output[0], 'WARNING:perceval.backends.core.jenkins:No builds for job.*')
-            self.assertRegex(cm.output[1], 'WARNING:perceval.backends.core.jenkins:No builds for job.*')
+            self.assertRegex(cm.output[1], 'DEBUG:perceval.backends.core.jenkins:No builds for job.*')
+            self.assertRegex(cm.output[2], 'DEBUG:perceval.backends.core.jenkins:No builds for job.*')
 
         self.assertEqual(builds, [])
 


### PR DESCRIPTION
This code changes the level of the message logged when no builds are found for a job to `debug`. This
change is needed to reduce the size of logs produced when running grimoirelab.

Tests have been modified accordingly.