### PR TITLE
[groupsio] Fetch messages after a given date

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,14 +238,10 @@ $ perceval googlehits "bitergia grimoirelab"
 
 ### Groups.io
 ```
-$ perceval groupsio 'updates' -t 'abcdefghijk' --from-date '2016-01-01'
+$ perceval groupsio 'updates' -e '<me@example.com>' -p 'my-password' --from-date '2016-01-01'
 ```
-In order to get an `api_token`, you should first subscribe to a group via the Groups.io website and then execute the following command:
-```
-$ curl "https://api.groups.io/v1/login" -u 123456: -d "email=<your email address>&password=<your password>"
-```
-
-In case you want to know the group names where your token is subscribed, you can use the following script: https://gist.github.com/valeriocos/676d90c58c56e2b17b882f2603283d39
+In order to fetch the data from a group, you should first subscribe to it via the Groups.io website.
+In case you want to know the group names where you are subscribed, you can use the following script: https://gist.github.com/valeriocos/ad33a0b9b2d13a8336230c8c59df3c55
 
 
 ### HyperKitty

--- a/perceval/backends/core/groupsio.py
+++ b/perceval/backends/core/groupsio.py
@@ -65,7 +65,7 @@ class Groupsio(MBox):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.3.1'
+    version = '0.3.2'
 
     CATEGORIES = [CATEGORY_MESSAGE]
 
@@ -125,7 +125,7 @@ class Groupsio(MBox):
 
         mailing_list = GroupsioClient(self.group_name, self.dirpath,
                                       self.email, self.password, self.verify)
-        mailing_list.fetch()
+        mailing_list.fetch(from_date)
 
         messages = self._fetch_and_parse_messages(mailing_list, from_date)
 
@@ -178,7 +178,7 @@ class GroupsioClient(MailingList):
         self.verify = verify
         self.__login(email, password)
 
-    def fetch(self):
+    def fetch(self, from_date=None):
         """Fetch the mbox files from the remote archiver.
 
         Stores the archives in the path given during the initialization
@@ -187,6 +187,8 @@ class GroupsioClient(MailingList):
 
         Groups.io archives are returned as a .zip file, which contains
         one file in mbox format.
+
+        :param from_date: fetch messages after a given date (included) expressed in ISO format
 
         :returns: a list of tuples, storing the links and paths of the
             fetched archives
@@ -200,7 +202,13 @@ class GroupsioClient(MailingList):
         group_id = self.__find_group_id()
 
         url = urijoin(GROUPSIO_API_URL, self.DOWNLOAD_ARCHIVES)
-        payload = {'group_id': group_id}
+        payload = {
+            'group_id': group_id
+        }
+
+        if from_date:
+            payload['start_time'] = from_date.isoformat()
+
         filepath = os.path.join(self.dirpath, MBOX_FILE)
         success = self._download_archive(url, payload, filepath)
 

--- a/tests/test_groupsio.py
+++ b/tests/test_groupsio.py
@@ -303,6 +303,45 @@ class TestGroupsioClient(unittest.TestCase):
         self.assertTrue(success)
 
     @httpretty.activate
+    def test_fetch_from_date(self):
+        """Test whether archives are fetched after a given date"""
+
+        setup_http_server()
+
+        client = GroupsioClient('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', verify=False)
+        from_date = datetime.datetime(2019, 1, 1)
+        success = client.fetch(from_date=from_date)
+
+        # Check requests
+        expected = [
+            {
+                'email': ['jsmith@example.com'],
+                'password': ['aaaaa']
+            },
+            {
+                'limit': ['100'],
+            },
+            {
+                'limit': ['100'],
+                'page_token': ['1']
+            },
+            {
+                'group_id': ['7769'],
+                'start_time': ['2019-01-01T00:00:00']
+            }
+        ]
+
+        http_requests = httpretty.httpretty.latest_requests
+
+        self.assertEqual(len(http_requests), len(expected))
+
+        for i in range(len(expected)):
+            self.assertDictEqual(http_requests[i].querystring, expected[i])
+
+        self.assertEqual(client.mboxes[0].filepath, os.path.join(self.tmp_path, MBOX_FILE))
+        self.assertTrue(success)
+
+    @httpretty.activate
     def test_fetch_group_id_not_found(self):
         """Test whether an error is thrown when the group id is not found"""
 


### PR DESCRIPTION
This PR addresses #607. It allows to collect a list of messages sent after a given date (included) from the groupsio API. The backend `from_date` parameter is propagated to the client, which sends it to the API endpoint to download archives. This change is made possible after a recent change in the upstream API, and allows to improve the performance of the fetching operation.

Tests have been added accordingly.

Backend version is now 0.3.2.