### PR TITLE
[perceva] Allow to disable SSL verification

### DIFF
--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -117,23 +117,25 @@ class Backend:
     :param origin: identifier of the repository
     :param tag: tag items using this label
     :param archive: archive to store/retrieve data
+    :param ssl_verify: enable/disable SSL verification
 
     :raises ValueError: raised when `archive` is not an instance of
         `Archive` class
     """
-    version = '0.11.0'
+    version = '0.12.0'
 
     CATEGORIES = []
     CLASSIFIED_FIELDS = []
     EXTRA_SEARCH_FIELDS = {}
     ORIGIN_UNIQUE_FIELD = None
 
-    def __init__(self, origin, tag=None, archive=None, blacklist_ids=None):
+    def __init__(self, origin, tag=None, archive=None, blacklist_ids=None, ssl_verify=True):
         self._origin = origin
         self.tag = tag if tag else origin
         self.archive = archive or None
         self.blacklist_ids = blacklist_ids or None
         self._summary = None
+        self._ssl_verify = ssl_verify
 
     @property
     def origin(self):
@@ -146,6 +148,10 @@ class Backend:
     @property
     def archive(self):
         return self._archive
+
+    @property
+    def ssl_verify(self):
+        return self._ssl_verify
 
     @archive.setter
     def archive(self, obj):
@@ -410,18 +416,20 @@ class BackendCommandArgumentParser:
     :param token_auth: set token/key authentication arguments
     :param archive: set archiving arguments
     :param aliases: define aliases for parsed arguments
+    :param ssl_verify: set SSL verify argument
 
-    :raises AttributeArror: when both `from_date` and `offset` are set
+    :raises AttributeError: when both `from_date` and `offset` are set
         to `True`
     """
 
     def __init__(self, backend, from_date=False, to_date=False, offset=False,
                  basic_auth=False, token_auth=False, archive=False,
-                 aliases=None, blacklist=False):
+                 aliases=None, blacklist=False, ssl_verify=False):
         self._from_date = from_date
         self._to_date = to_date
         self._archive = archive
         self._backend = backend
+        self._ssl_verify = ssl_verify
 
         self.aliases = aliases or {}
         self.parser = argparse.ArgumentParser()
@@ -467,6 +475,10 @@ class BackendCommandArgumentParser:
 
         if archive:
             self._set_archive_arguments()
+
+        if ssl_verify:
+            group.add_argument('--no-ssl-verify', dest='ssl_verify', action='store_false',
+                               help="disable SSL verification")
 
         self._set_output_arguments()
 

--- a/perceval/backends/core/askbot.py
+++ b/perceval/backends/core/askbot.py
@@ -51,18 +51,19 @@ class Askbot(Backend):
     :param url: Askbot site URL
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
+    :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.7.0'
+    version = '0.8.0'
 
     CATEGORIES = [CATEGORY_QUESTION]
     EXTRA_SEARCH_FIELDS = {
         'tags': ['tags']
     }
 
-    def __init__(self, url, tag=None, archive=None):
+    def __init__(self, url, tag=None, archive=None, ssl_verify=True):
         origin = url
 
-        super().__init__(origin, tag=tag, archive=archive)
+        super().__init__(origin, tag=tag, archive=archive, ssl_verify=ssl_verify)
         self.url = url
         self.client = None
         self.ab_parser = AskbotParser()
@@ -161,7 +162,7 @@ class Askbot(Backend):
     def _init_client(self, from_archive=False):
         """Init client"""
 
-        return AskbotClient(self.url, self.archive, from_archive)
+        return AskbotClient(self.url, self.archive, from_archive, self.ssl_verify)
 
     def __fetch_question(self, question):
         """Fetch an Askbot HTML question body.
@@ -254,6 +255,7 @@ class AskbotClient(HttpClient):
     :param base_url: URL of the Askbot site
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive
+    :param ssl_verify: enable/disable SSL verification
 
     :raises HTTPError: when an error occurs doing the request
     """
@@ -265,8 +267,8 @@ class AskbotClient(HttpClient):
     COMMENTS = 's/post_comments'
     COMMENTS_OLD = 'post_comments'
 
-    def __init__(self, base_url, archive=None, from_archive=False):
-        super().__init__(base_url, archive=archive, from_archive=from_archive)
+    def __init__(self, base_url, archive=None, from_archive=False, ssl_verify=True):
+        super().__init__(base_url, archive=archive, from_archive=from_archive, ssl_verify=ssl_verify)
         self._use_new_urls = True
 
     def get_api_questions(self, path):
@@ -534,7 +536,8 @@ class AskbotCommand(BackendCommand):
 
         parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
-                                              archive=True)
+                                              archive=True,
+                                              ssl_verify=True)
 
         # Required arguments
         parser.parser.add_argument('url',

--- a/perceval/backends/core/bugzilla.py
+++ b/perceval/backends/core/bugzilla.py
@@ -58,8 +58,9 @@ class Bugzilla(Backend):
     :param max_bugs: maximum number of bugs requested on the same query
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
+    :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.11.0'
+    version = '0.12.0'
 
     CATEGORIES = [CATEGORY_BUG]
     EXTRA_SEARCH_FIELDS = {
@@ -69,10 +70,10 @@ class Bugzilla(Backend):
 
     def __init__(self, url, user=None, password=None,
                  max_bugs=MAX_BUGS, max_bugs_csv=MAX_BUGS_CSV,
-                 tag=None, archive=None):
+                 tag=None, archive=None, ssl_verify=True):
         origin = url
 
-        super().__init__(origin, tag=tag, archive=archive)
+        super().__init__(origin, tag=tag, archive=archive, ssl_verify=ssl_verify)
         self.url = url
         self.user = user
         self.password = password
@@ -309,7 +310,7 @@ class Bugzilla(Backend):
 
         return BugzillaClient(self.url, user=self.user, password=self.password,
                               max_bugs_csv=self.max_bugs_csv,
-                              archive=self.archive, from_archive=from_archive)
+                              archive=self.archive, from_archive=from_archive, ssl_verify=self.ssl_verify)
 
     def __fetch_buglist(self, from_date):
         buglist = self.__fetch_and_parse_buglist_page(from_date)
@@ -357,7 +358,8 @@ class BugzillaCommand(BackendCommand):
         parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               basic_auth=True,
-                                              archive=True)
+                                              archive=True,
+                                              ssl_verify=True)
 
         # Bugzilla options
         group = parser.parser.add_argument_group('Bugzilla arguments')
@@ -391,8 +393,9 @@ class BugzillaClient(HttpClient):
     :param max_bugs_cvs: max bugs requested per CSV query
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive
+    :param ssl_verify: enable/disable SSL verification
 
-    :raises BackendError: when an error occurs initilizing the
+    :raises BackendError: when an error occurs initializing the
         client
     """
     URL = "%(base)s/%(cgi)s"
@@ -427,9 +430,9 @@ class BugzillaClient(HttpClient):
     CTYPE_XML = 'xml'
 
     def __init__(self, base_url, user=None, password=None,
-                 max_bugs_csv=MAX_BUGS_CSV, archive=None, from_archive=False):
+                 max_bugs_csv=MAX_BUGS_CSV, archive=None, from_archive=False, ssl_verify=True):
         self.version = None
-        super().__init__(base_url, archive=archive, from_archive=from_archive)
+        super().__init__(base_url, archive=archive, from_archive=from_archive, ssl_verify=ssl_verify)
 
         if user is not None and password is not None:
             self.login(user, password)

--- a/perceval/backends/core/bugzillarest.py
+++ b/perceval/backends/core/bugzillarest.py
@@ -58,8 +58,9 @@ class BugzillaREST(Backend):
     :param max_bugs: maximum number of bugs requested on the same query
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
+    :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.9.0'
+    version = '0.10.0'
 
     CATEGORIES = [CATEGORY_BUG]
     EXTRA_SEARCH_FIELDS = {
@@ -68,10 +69,10 @@ class BugzillaREST(Backend):
     }
 
     def __init__(self, url, user=None, password=None, api_token=None,
-                 max_bugs=MAX_BUGS, tag=None, archive=None):
+                 max_bugs=MAX_BUGS, tag=None, archive=None, ssl_verify=True):
         origin = url
 
-        super().__init__(origin, tag=tag, archive=archive)
+        super().__init__(origin, tag=tag, archive=archive, ssl_verify=ssl_verify)
         self.url = url
         self.user = user
         self.password = password
@@ -171,7 +172,7 @@ class BugzillaREST(Backend):
         """Init client"""
 
         return BugzillaRESTClient(self.url, user=self.user, password=self.password, api_token=self.api_token,
-                                  archive=self.archive, from_archive=from_archive)
+                                  archive=self.archive, from_archive=from_archive, ssl_verify=self.ssl_verify)
 
     def __fetch_and_parse_bugs(self, from_date):
         max_contents = min(MAX_CONTENTS, self.max_bugs)
@@ -266,8 +267,9 @@ class BugzillaRESTClient(HttpClient):
         `user` and `password` parameters will be ignored
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive
+    :param ssl_verify: enable/disable SSL verification
 
-    :raises BackendError: when an error occurs initilizing the
+    :raises BackendError: when an error occurs initializing the
         client
     """
     URL = "%(base)s/rest/%(resource)s"
@@ -297,8 +299,8 @@ class BugzillaRESTClient(HttpClient):
     VEXCLUDE_ATTCH_DATA = 'data'
 
     def __init__(self, base_url, user=None, password=None, api_token=None,
-                 archive=None, from_archive=False):
-        super().__init__(base_url, archive=archive, from_archive=from_archive)
+                 archive=None, from_archive=False, ssl_verify=True):
+        super().__init__(base_url, archive=archive, from_archive=from_archive, ssl_verify=ssl_verify)
 
         self.api_token = api_token if api_token else None
 
@@ -464,7 +466,8 @@ class BugzillaRESTCommand(BackendCommand):
                                               from_date=True,
                                               basic_auth=True,
                                               token_auth=True,
-                                              archive=True)
+                                              archive=True,
+                                              ssl_verify=True)
 
         # BugzillaREST options
         group = parser.parser.add_argument_group('Bugzilla REST arguments')

--- a/perceval/backends/core/confluence.py
+++ b/perceval/backends/core/confluence.py
@@ -56,15 +56,16 @@ class Confluence(Backend):
     :param url: URL of the server
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
+    :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.11.0'
+    version = '0.12.0'
 
     CATEGORIES = [CATEGORY_HISTORICAL_CONTENT]
 
-    def __init__(self, url, tag=None, archive=None):
+    def __init__(self, url, tag=None, archive=None, ssl_verify=True):
         origin = url
 
-        super().__init__(origin, tag=tag, archive=archive)
+        super().__init__(origin, tag=tag, archive=archive, ssl_verify=ssl_verify)
         self.url = url
         self.client = None
 
@@ -256,7 +257,7 @@ class Confluence(Backend):
     def _init_client(self, from_archive=False):
         """Init client"""
 
-        return ConfluenceClient(self.url, archive=self.archive, from_archive=from_archive)
+        return ConfluenceClient(self.url, archive=self.archive, from_archive=from_archive, ssl_verify=self.ssl_verify)
 
     def __fetch_contents_summary(self, from_date):
         logger.debug("Fetching contents summary from %s", str(from_date))
@@ -323,7 +324,8 @@ class ConfluenceCommand(BackendCommand):
 
         parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
-                                              archive=True)
+                                              archive=True,
+                                              ssl_verify=True)
 
         # Required arguments
         parser.parser.add_argument('url',
@@ -341,6 +343,7 @@ class ConfluenceClient(HttpClient):
     :param base_url: URL of the Confluence server
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive
+    :param ssl_verify: enable/disable SSL verification
     """
     URL = "%(base)s/rest/api/%(resource)s"
 
@@ -366,8 +369,8 @@ class ConfluenceClient(HttpClient):
     VEXPAND = ['body.storage', 'history', 'version']
     VHISTORICAL = 'historical'
 
-    def __init__(self, base_url, archive=None, from_archive=False):
-        super().__init__(base_url.rstrip('/'), archive=archive, from_archive=from_archive)
+    def __init__(self, base_url, archive=None, from_archive=False, ssl_verify=True):
+        super().__init__(base_url.rstrip('/'), archive=archive, from_archive=from_archive, ssl_verify=ssl_verify)
 
     def contents(self, from_date=DEFAULT_DATETIME,
                  offset=None, max_contents=MAX_CONTENTS):

--- a/perceval/backends/core/discourse.py
+++ b/perceval/backends/core/discourse.py
@@ -60,8 +60,9 @@ class Discourse(Backend):
         before raising a RetryError exception
     :param sleep_time: time (in seconds) to sleep in case
         of connection problems
+    :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.12.0'
+    version = '0.13.0'
 
     CATEGORIES = [CATEGORY_TOPIC]
     EXTRA_SEARCH_FIELDS = {
@@ -69,13 +70,13 @@ class Discourse(Backend):
     }
 
     def __init__(self, url, api_username=None, api_token=None, tag=None, archive=None,
-                 max_retries=MAX_RETRIES, sleep_time=DEFAULT_SLEEP_TIME):
+                 max_retries=MAX_RETRIES, sleep_time=DEFAULT_SLEEP_TIME, ssl_verify=True):
         origin = url
 
         if (api_username and not api_token) or (api_token and not api_username):
             raise BackendError(cause="Api token and username must be defined together")
 
-        super().__init__(origin, tag=tag, archive=archive)
+        super().__init__(origin, tag=tag, archive=archive, ssl_verify=ssl_verify)
         self.url = url
         self.api_username = api_username
         self.api_token = api_token
@@ -296,6 +297,7 @@ class DiscourseClient(HttpClient):
         before raising a RetryError exception
     :param archive: collect issues already retrieved from an archive
     :param from_archive: it tells whether to write/read the archive
+    :param ssl_verify: enable/disable SSL verification
 
     :raises HTTPError: when an error occurs doing the request
     """
@@ -319,7 +321,7 @@ class DiscourseClient(HttpClient):
 
     def __init__(self, base_url, api_username=None, api_key=None,
                  sleep_time=DEFAULT_SLEEP_TIME, max_retries=MAX_RETRIES,
-                 archive=None, from_archive=False):
+                 archive=None, from_archive=False, ssl_verify=True):
         self.api_username = api_username
         self.api_key = api_key
 
@@ -329,7 +331,7 @@ class DiscourseClient(HttpClient):
         super().__init__(base_url, sleep_time=sleep_time, max_retries=max_retries,
                          extra_headers=self._set_extra_headers(),
                          extra_status_forcelist=self.EXTRA_STATUS_FORCELIST,
-                         archive=archive, from_archive=from_archive)
+                         archive=archive, from_archive=from_archive, ssl_verify=ssl_verify)
 
     def topics_page(self, page=None):
         """Retrieve the #page summaries of the latest topics.
@@ -410,7 +412,8 @@ class DiscourseCommand(BackendCommand):
         parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               token_auth=True,
-                                              archive=True)
+                                              archive=True,
+                                              ssl_verify=True)
 
         # Required arguments
         parser.parser.add_argument('url',

--- a/perceval/backends/core/dockerhub.py
+++ b/perceval/backends/core/dockerhub.py
@@ -56,8 +56,9 @@ class DockerHub(Backend):
     :param repository: DockerHub repository owned by `owner`
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
+    :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.5.0'
+    version = '0.6.0'
 
     CATEGORIES = [CATEGORY_DOCKERHUB_DATA]
     EXTRA_SEARCH_FIELDS = {
@@ -65,13 +66,13 @@ class DockerHub(Backend):
         'namespace': ['namespace']
     }
 
-    def __init__(self, owner, repository, tag=None, archive=None):
+    def __init__(self, owner, repository, tag=None, archive=None, ssl_verify=True):
         if owner == DOCKER_SHORTCUT_OWNER:
             owner = DOCKER_OWNER
 
         origin = urijoin(DOCKERHUB_URL, owner, repository)
 
-        super().__init__(origin, tag=tag, archive=archive)
+        super().__init__(origin, tag=tag, archive=archive, ssl_verify=ssl_verify)
         self.owner = owner
         self.repository = repository
         self.client = None
@@ -174,7 +175,7 @@ class DockerHub(Backend):
     def _init_client(self, from_archive=False):
         """Init client"""
 
-        return DockerHubClient(archive=self.archive, from_archive=from_archive)
+        return DockerHubClient(archive=self.archive, from_archive=from_archive, ssl_verify=self.ssl_verify)
 
 
 class DockerHubClient(HttpClient):
@@ -185,11 +186,12 @@ class DockerHubClient(HttpClient):
 
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive
+    :param ssl_verify: enable/disable SSL verification
     """
     RREPOSITORY = 'repositories'
 
-    def __init__(self, archive=None, from_archive=False):
-        super().__init__(DOCKERHUB_API_URL, archive=archive, from_archive=from_archive)
+    def __init__(self, archive=None, from_archive=False, ssl_verify=True):
+        super().__init__(DOCKERHUB_API_URL, archive=archive, from_archive=from_archive, ssl_verify=ssl_verify)
 
     def repository(self, owner, repository):
         """Fetch information about a repository."""
@@ -213,7 +215,8 @@ class DockerHubCommand(BackendCommand):
         """Returns the DockerHub argument parser."""
 
         parser = BackendCommandArgumentParser(cls.BACKEND,
-                                              archive=True)
+                                              archive=True,
+                                              ssl_verify=True)
 
         # Required arguments
         parser.parser.add_argument('owner',

--- a/perceval/backends/core/googlehits.py
+++ b/perceval/backends/core/googlehits.py
@@ -57,8 +57,9 @@ class GoogleHits(Backend):
         before raising a RetryError exception
     :param sleep_time: time (in seconds) to sleep in case
         of connection problems
+    :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.3.0'
+    version = '0.4.0'
 
     CATEGORIES = [CATEGORY_HITS]
     EXTRA_SEARCH_FIELDS = {
@@ -66,14 +67,14 @@ class GoogleHits(Backend):
     }
 
     def __init__(self, keywords, tag=None, archive=None,
-                 max_retries=MAX_RETRIES, sleep_time=DEFAULT_SLEEP_TIME):
+                 max_retries=MAX_RETRIES, sleep_time=DEFAULT_SLEEP_TIME, ssl_verify=True):
 
         if len(keywords) == 1 and keywords[0].strip() == "":
             cause = "No keywords provided"
             raise BackendError(cause=cause)
 
         self.keywords = keywords
-        super().__init__(GOOGLE_SEARCH_URL, tag=tag, archive=archive)
+        super().__init__(GOOGLE_SEARCH_URL, tag=tag, archive=archive, ssl_verify=ssl_verify)
 
         self.max_retries = max_retries
         self.sleep_time = sleep_time
@@ -161,7 +162,7 @@ class GoogleHits(Backend):
         """Init client"""
 
         return GoogleHitsClient(self.sleep_time, self.max_retries,
-                                archive=self.archive, from_archive=from_archive)
+                                archive=self.archive, from_archive=from_archive, ssl_verify=True)
 
     def __parse_hits(self, hit_raw):
         """Parse the hits returned by the Google Search API"""
@@ -209,14 +210,15 @@ class GoogleHitsClient(HttpClient):
         before raising a RetryError exception
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive
+    :param ssl_verify: enable/disable SSL verification
     """
     EXTRA_STATUS_FORCELIST = [429]
 
     def __init__(self, sleep_time=DEFAULT_SLEEP_TIME, max_retries=MAX_RETRIES,
-                 archive=None, from_archive=False):
+                 archive=None, from_archive=False, ssl_verify=True):
         super().__init__(GOOGLE_SEARCH_URL, extra_status_forcelist=self.EXTRA_STATUS_FORCELIST,
                          sleep_time=sleep_time, max_retries=max_retries,
-                         archive=archive, from_archive=from_archive)
+                         archive=archive, from_archive=from_archive, ssl_verify=ssl_verify)
 
     def hits(self, keywords):
         """Fetch information about a list of keywords."""
@@ -245,7 +247,8 @@ class GoogleHitsCommand(BackendCommand):
         """Returns the GoogleHits argument parser."""
 
         parser = BackendCommandArgumentParser(cls.BACKEND,
-                                              archive=True)
+                                              archive=True,
+                                              ssl_verify=True)
 
         group = parser.parser.add_argument_group('GoogleHits arguments')
         # Generic client options

--- a/perceval/backends/core/hyperkitty.py
+++ b/perceval/backends/core/hyperkitty.py
@@ -52,13 +52,14 @@ class HyperKitty(MBox):
     :param dirpath: directory path where the mboxes are stored
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
+    :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.5.0'
+    version = '0.6.0'
 
     CATEGORIES = [CATEGORY_MESSAGE]
 
-    def __init__(self, url, dirpath, tag=None, archive=None):
-        super().__init__(url, dirpath, tag=tag, archive=archive)
+    def __init__(self, url, dirpath, tag=None, archive=None, ssl_verify=True):
+        super().__init__(url, dirpath, tag=tag, archive=archive, ssl_verify=ssl_verify)
         self.url = url
 
     def fetch(self, category=CATEGORY_MESSAGE, from_date=DEFAULT_DATETIME):
@@ -135,10 +136,11 @@ class HyperKittyList(MailingList):
 
     :param url: URL to the HyperKitty archiver for this list
     :param dirpath: path to the local mboxes archives
+    :param ssl_verify: enable/disable SSL verification
     """
-    def __init__(self, url, dirpath):
+    def __init__(self, url, dirpath, ssl_verify=True):
         super().__init__(url, dirpath)
-        self.client = HttpClient(url)
+        self.client = HttpClient(url, ssl_verify=ssl_verify)
 
     def fetch(self, from_date=DEFAULT_DATETIME):
         """Fetch the mbox files from the remote archiver.
@@ -268,7 +270,8 @@ class HyperKittyCommand(BackendCommand):
         """Returns the HyperKitty argument parser."""
 
         parser = BackendCommandArgumentParser(cls.BACKEND,
-                                              from_date=True)
+                                              from_date=True,
+                                              ssl_verify=True)
 
         # Optional arguments
         group = parser.parser.add_argument_group('HyperKitty arguments')

--- a/perceval/backends/core/launchpad.py
+++ b/perceval/backends/core/launchpad.py
@@ -58,18 +58,19 @@ class Launchpad(Backend):
         of connection problems
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
+    :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.7.0'
+    version = '0.8.0'
 
     CATEGORIES = [CATEGORY_ISSUE]
 
     def __init__(self, distribution, package=None,
                  items_per_page=ITEMS_PER_PAGE, sleep_time=SLEEP_TIME,
-                 tag=None, archive=None):
+                 tag=None, archive=None, ssl_verify=True):
 
         origin = urijoin(LAUNCHPAD_URL, distribution)
 
-        super().__init__(origin, tag=tag, archive=archive)
+        super().__init__(origin, tag=tag, archive=archive, ssl_verify=ssl_verify)
         self.distribution = distribution
         self.package = package
         self.items_per_page = items_per_page
@@ -193,7 +194,7 @@ class Launchpad(Backend):
         """Init client"""
 
         return LaunchpadClient(self.distribution, self.package, self.items_per_page,
-                               self.sleep_time, self.archive, from_archive)
+                               self.sleep_time, self.archive, from_archive, self.ssl_verify)
 
     def __init_extra_issue_fields(self, issue):
         """Add fields to an issue"""
@@ -301,13 +302,14 @@ class LaunchpadClient(HttpClient):
         of connection problems
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive
+    :param ssl_verify: enable/disable SSL verification
     """
 
     _users = {}
 
     def __init__(self, distribution, package=None,
                  items_per_page=ITEMS_PER_PAGE, sleep_time=SLEEP_TIME,
-                 archive=None, from_archive=False):
+                 archive=None, from_archive=False, ssl_verify=True):
 
         self.distribution = distribution
         self.package = package
@@ -315,7 +317,7 @@ class LaunchpadClient(HttpClient):
 
         extra_headers = self.__define_headers()
         super().__init__(LAUNCHPAD_API_URL, sleep_time=sleep_time, extra_headers=extra_headers,
-                         archive=archive, from_archive=from_archive)
+                         archive=archive, from_archive=from_archive, ssl_verify=ssl_verify)
 
     def issues(self, start=None):
         """Get the issues from pagination"""
@@ -478,7 +480,8 @@ class LaunchpadCommand(BackendCommand):
         parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               archive=True,
-                                              token_auth=False)
+                                              token_auth=False,
+                                              ssl_verify=True)
 
         # Optional arguments
         group = parser.parser.add_argument_group('Launchpad arguments')

--- a/perceval/backends/core/mbox.py
+++ b/perceval/backends/core/mbox.py
@@ -60,18 +60,19 @@ class MBox(Backend):
     :param dirpath: directory path where the mboxes are stored
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
+    :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.12.0'
+    version = '0.13.0'
 
     CATEGORIES = [CATEGORY_MESSAGE]
 
     DATE_FIELD = 'Date'
     MESSAGE_ID_FIELD = 'Message-ID'
 
-    def __init__(self, uri, dirpath, tag=None, archive=None):
+    def __init__(self, uri, dirpath, tag=None, archive=None, ssl_verify=True):
         origin = uri
 
-        super().__init__(origin, tag=tag, archive=archive)
+        super().__init__(origin, tag=tag, archive=archive, ssl_verify=ssl_verify)
         self.uri = uri
         self.dirpath = dirpath
 
@@ -332,7 +333,8 @@ class MBoxCommand(BackendCommand):
         """Returns the MBox argument parser."""
 
         parser = BackendCommandArgumentParser(cls.BACKEND,
-                                              from_date=True)
+                                              from_date=True,
+                                              ssl_verify=True)
 
         # Required arguments
         parser.parser.add_argument('uri',

--- a/perceval/backends/core/mediawiki.py
+++ b/perceval/backends/core/mediawiki.py
@@ -69,15 +69,16 @@ class MediaWiki(Backend):
     :param url: MediaWiki url
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
+    :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.10.0'
+    version = '0.11.0'
 
     CATEGORIES = [CATEGORY_PAGE]
 
-    def __init__(self, url, tag=None, archive=None):
+    def __init__(self, url, tag=None, archive=None, ssl_verify=True):
         origin = url
 
-        super().__init__(origin, tag=tag, archive=archive)
+        super().__init__(origin, tag=tag, archive=archive, ssl_verify=ssl_verify)
         self.url = url
         self.client = None
 
@@ -177,7 +178,7 @@ class MediaWiki(Backend):
     def _init_client(self, from_archive=False):
         """Init client"""
 
-        return MediaWikiClient(self.url, self.archive, from_archive)
+        return MediaWikiClient(self.url, self.archive, from_archive, self.ssl_verify)
 
     def __get_max_date(self, reviews):
         """"Get the max date in unixtime format from reviews."""
@@ -392,12 +393,13 @@ class MediaWikiClient(HttpClient):
     :param url: URL of mediawiki site: https://wiki.mozilla.org
     :param archive: an archive to store/retrieved the fetched data
     :param from_archive: define whether the archive is used to store/read data
+    :param ssl_verify: enable/disable SSL verification
 
     :raises HTTPError: when an error occurs doing the request
     """
 
-    def __init__(self, url, archive=None, from_archive=False):
-        super().__init__(urijoin(url, "api.php"), archive=archive, from_archive=from_archive)
+    def __init__(self, url, archive=None, from_archive=False, ssl_verify=True):
+        super().__init__(urijoin(url, "api.php"), archive=archive, from_archive=from_archive, ssl_verify=ssl_verify)
         self.limit = "max"  # Always get the max number of items
 
     def call(self, params):
@@ -537,7 +539,8 @@ class MediaWikiCommand(BackendCommand):
 
         parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
-                                              archive=True)
+                                              archive=True,
+                                              ssl_verify=True)
 
         # MediaWiki options
         group = parser.parser.add_argument_group('MediaWiki arguments')

--- a/perceval/backends/core/meetup.py
+++ b/perceval/backends/core/meetup.py
@@ -67,8 +67,9 @@ class Meetup(Backend):
          it will be reset
     :param sleep_time: time (in seconds) to sleep in case
         of connection problems
+    :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.16.0'
+    version = '0.17.0'
 
     CATEGORIES = [CATEGORY_EVENT]
     CLASSIFIED_FIELDS = [
@@ -85,10 +86,10 @@ class Meetup(Backend):
     def __init__(self, group, api_token,
                  max_items=MAX_ITEMS, tag=None, archive=None,
                  sleep_for_rate=False, min_rate_to_sleep=MIN_RATE_LIMIT,
-                 sleep_time=SLEEP_TIME):
+                 sleep_time=SLEEP_TIME, ssl_verify=True):
         origin = MEETUP_URL
 
-        super().__init__(origin, tag=tag, archive=archive)
+        super().__init__(origin, tag=tag, archive=archive, ssl_verify=ssl_verify)
         self.group = group
         self.max_items = max_items
         self.api_token = api_token
@@ -238,7 +239,7 @@ class Meetup(Backend):
 
         return MeetupClient(self.api_token, self.max_items,
                             self.sleep_for_rate, self.min_rate_to_sleep, self.sleep_time,
-                            self.archive, from_archive)
+                            self.archive, from_archive, self.ssl_verify)
 
     def __fetch_and_parse_comments(self, event_id):
         logger.debug("Fetching and parsing comments from group '%s' event '%s'",
@@ -282,7 +283,8 @@ class MeetupCommand(BackendCommand):
                                               from_date=True,
                                               to_date=True,
                                               token_auth=True,
-                                              archive=True)
+                                              archive=True,
+                                              ssl_verify=True)
 
         # Meetup options
         group = parser.parser.add_argument_group('Meetup arguments')
@@ -321,6 +323,7 @@ class MeetupClient(HttpClient, RateLimitHandler):
         of connection problems
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive
+    :param ssl_verify: enable/disable SSL verification
     """
     EXTRA_STATUS_FORCELIST = [429]
     RCOMMENTS = 'comments'
@@ -346,13 +349,13 @@ class MeetupClient(HttpClient, RateLimitHandler):
 
     def __init__(self, api_token, max_items=MAX_ITEMS,
                  sleep_for_rate=False, min_rate_to_sleep=MIN_RATE_LIMIT, sleep_time=SLEEP_TIME,
-                 archive=None, from_archive=False):
+                 archive=None, from_archive=False, ssl_verify=True):
         self.api_token = api_token
         self.max_items = max_items
 
         super().__init__(MEETUP_API_URL, sleep_time=sleep_time,
                          extra_status_forcelist=self.EXTRA_STATUS_FORCELIST,
-                         archive=archive, from_archive=from_archive)
+                         archive=archive, from_archive=from_archive, ssl_verify=ssl_verify)
         super().setup_rate_limit_handler(sleep_for_rate=sleep_for_rate, min_rate_to_sleep=min_rate_to_sleep)
 
     def calculate_time_to_reset(self):

--- a/perceval/backends/core/rss.py
+++ b/perceval/backends/core/rss.py
@@ -45,15 +45,16 @@ class RSS(Backend):
     :param url: RSS url
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
+    :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.6.0'
+    version = '0.7.0'
 
     CATEGORIES = [CATEGORY_ENTRY]
 
-    def __init__(self, url, tag=None, archive=None):
+    def __init__(self, url, tag=None, archive=None, ssl_verify=True):
         origin = url
 
-        super().__init__(origin, tag=tag, archive=archive)
+        super().__init__(origin, tag=tag, archive=archive, ssl_verify=ssl_verify)
         self.url = url
         self.client = None
 
@@ -144,7 +145,7 @@ class RSS(Backend):
     def _init_client(self, from_archive=False):
         """Init client"""
 
-        return RSSClient(self.url, self.archive, from_archive)
+        return RSSClient(self.url, self.archive, from_archive, self.ssl_verify)
 
 
 class RSSClient(HttpClient):
@@ -156,12 +157,13 @@ class RSSClient(HttpClient):
     :param url: URL of rss node: https://item.opnfv.org/ci
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive
+    :param ssl_verify: enable/disable SSL verification
 
     :raises HTTPError: when an error occurs doing the request
     """
 
-    def __init__(self, url, archive=None, from_archive=False):
-        super().__init__(url, archive=archive, from_archive=from_archive)
+    def __init__(self, url, archive=None, from_archive=False, ssl_verify=True):
+        super().__init__(url, archive=archive, from_archive=from_archive, ssl_verify=ssl_verify)
 
     def get_entries(self):
         """ Retrieve all entries from a RSS feed"""
@@ -180,7 +182,8 @@ class RSSCommand(BackendCommand):
         """Returns the RSS argument parser."""
 
         parser = BackendCommandArgumentParser(cls.BACKEND,
-                                              archive=True)
+                                              archive=True,
+                                              ssl_verify=True)
 
         # Required arguments
         parser.parser.add_argument('url',

--- a/perceval/backends/core/stackexchange.py
+++ b/perceval/backends/core/stackexchange.py
@@ -53,8 +53,9 @@ class StackExchange(Backend):
     :param max_questions: max of questions per page retrieved
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
+    :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.11.0'
+    version = '0.12.0'
 
     CATEGORIES = [CATEGORY_QUESTION]
     EXTRA_SEARCH_FIELDS = {
@@ -62,10 +63,10 @@ class StackExchange(Backend):
     }
 
     def __init__(self, site, tagged=None, api_token=None,
-                 max_questions=MAX_QUESTIONS, tag=None, archive=None):
+                 max_questions=MAX_QUESTIONS, tag=None, archive=None, ssl_verify=True):
         origin = site
 
-        super().__init__(origin, tag=tag, archive=archive)
+        super().__init__(origin, tag=tag, archive=archive, ssl_verify=ssl_verify)
         self.site = site
         self.api_token = api_token
         self.tagged = tagged
@@ -178,7 +179,7 @@ class StackExchange(Backend):
         """Init client"""
 
         return StackExchangeClient(self.site, self.tagged, self.api_token, self.max_questions,
-                                   self.archive, from_archive)
+                                   self.archive, from_archive, self.ssl_verify)
 
 
 class StackExchangeClient(HttpClient):
@@ -193,6 +194,7 @@ class StackExchangeClient(HttpClient):
     :param max_questions: max number of questions per query
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive
+    :param ssl_verify: enable/disable SSL verification
 
     :raises HTTPError: when an error occurs doing the request
     """
@@ -206,8 +208,10 @@ class StackExchangeClient(HttpClient):
     STACKEXCHANGE_API_URL = 'https://api.stackexchange.com'
     VERSION_API = '2.2'
 
-    def __init__(self, site, tagged, token, max_questions=MAX_QUESTIONS, archive=None, from_archive=False):
-        super().__init__(self.STACKEXCHANGE_API_URL, archive=archive, from_archive=from_archive)
+    def __init__(self, site, tagged, token, max_questions=MAX_QUESTIONS,
+                 archive=None, from_archive=False, ssl_verify=True):
+        super().__init__(self.STACKEXCHANGE_API_URL, archive=archive,
+                         from_archive=from_archive, ssl_verify=ssl_verify)
         self.site = site
         self.tagged = tagged
         self.token = token
@@ -310,7 +314,8 @@ class StackExchangeCommand(BackendCommand):
         parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               token_auth=True,
-                                              archive=True)
+                                              archive=True,
+                                              ssl_verify=True)
 
         # StackExchange options
         group = parser.parser.add_argument_group('StackExchange arguments')

--- a/perceval/backends/core/telegram.py
+++ b/perceval/backends/core/telegram.py
@@ -60,8 +60,9 @@ class Telegram(Backend):
     :param bot_token: authentication token used by the bot
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
+    :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.10.0'
+    version = '0.11.0'
 
     CATEGORIES = [CATEGORY_MESSAGE]
     EXTRA_SEARCH_FIELDS = {
@@ -69,10 +70,10 @@ class Telegram(Backend):
         'chat_id': ['message', 'chat', 'id']
     }
 
-    def __init__(self, bot, bot_token, tag=None, archive=None):
+    def __init__(self, bot, bot_token, tag=None, archive=None, ssl_verify=True):
         origin = urijoin(TELEGRAM_URL, bot)
 
-        super().__init__(origin, tag=tag, archive=archive)
+        super().__init__(origin, tag=tag, archive=archive, ssl_verify=ssl_verify)
         self.bot = bot
         self.bot_token = bot_token
 
@@ -235,7 +236,7 @@ class Telegram(Backend):
     def _init_client(self, from_archive=False):
         """Init client"""
 
-        return TelegramBotClient(self.bot_token, self.archive, from_archive)
+        return TelegramBotClient(self.bot_token, self.archive, from_archive, self.ssl_verify)
 
     def _filter_message_by_chats(self, message, chats):
         """Check if a message can be filtered based in a list of chats.
@@ -273,7 +274,8 @@ class TelegramCommand(BackendCommand):
                                               offset=True,
                                               token_auth=True,
                                               archive=True,
-                                              aliases=aliases)
+                                              aliases=aliases,
+                                              ssl_verify=True)
 
         # Backend token is required
         action = parser.parser._option_string_actions['--api-token']
@@ -302,14 +304,15 @@ class TelegramBotClient(HttpClient):
     :param bot_token: token for the bot
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive
+    :param ssl_verify: enable/disable SSL verification
     """
     API_URL = "https://api.telegram.org/bot%(token)s/%(method)s"
 
     UPDATES_METHOD = 'getUpdates'
     OFFSET = 'offset'
 
-    def __init__(self, bot_token, archive=None, from_archive=False):
-        super().__init__(self.API_URL, archive=archive, from_archive=from_archive)
+    def __init__(self, bot_token, archive=None, from_archive=False, ssl_verify=True):
+        super().__init__(self.API_URL, archive=archive, from_archive=from_archive, ssl_verify=ssl_verify)
         self.bot_token = bot_token
 
     def updates(self, offset=None):

--- a/tests/test_askbot.py
+++ b/tests/test_askbot.py
@@ -200,6 +200,12 @@ class TestAskbotClient(unittest.TestCase):
         ab = AskbotClient(ASKBOT_URL)
 
         self.assertEqual(ab.base_url, ASKBOT_URL)
+        self.assertTrue(ab.ssl_verify)
+
+        ab = AskbotClient(ASKBOT_URL, ssl_verify=False)
+
+        self.assertEqual(ab.base_url, ASKBOT_URL)
+        self.assertFalse(ab.ssl_verify)
 
     @httpretty.activate
     def test_get_api_questions(self):
@@ -394,6 +400,7 @@ class TestAskbotBackend(unittest.TestCase):
         self.assertEqual(ab.url, ASKBOT_URL)
         self.assertEqual(ab.tag, 'test')
         self.assertIsNone(ab.client, None)
+        self.assertTrue(ab.ssl_verify)
 
         # When tag is empty or None it will be set to
         # the value in url
@@ -401,9 +408,10 @@ class TestAskbotBackend(unittest.TestCase):
         self.assertEqual(ab.url, ASKBOT_URL)
         self.assertEqual(ab.tag, ASKBOT_URL)
 
-        ab = Askbot(ASKBOT_URL, tag='')
+        ab = Askbot(ASKBOT_URL, tag='', ssl_verify=False)
         self.assertEqual(ab.url, ASKBOT_URL)
         self.assertEqual(ab.tag, ASKBOT_URL)
+        self.assertFalse(ab.ssl_verify)
 
     @httpretty.activate
     def test_too_many_redirects(self):
@@ -714,7 +722,19 @@ class TestAskbotCommand(unittest.TestCase):
         self.assertEqual(parsed_args.url, ASKBOT_URL)
         self.assertEqual(parsed_args.tag, 'test')
         self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
-        self.assertEqual(parsed_args.no_archive, True)
+        self.assertTrue(parsed_args.no_archive)
+        self.assertTrue(parsed_args.ssl_verify)
+
+        args = ['--tag', 'test',
+                '--from-date', '1970-01-01',
+                '--no-ssl-verify',
+                ASKBOT_URL]
+
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.url, ASKBOT_URL)
+        self.assertEqual(parsed_args.tag, 'test')
+        self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
+        self.assertFalse(parsed_args.ssl_verify)
 
 
 if __name__ == "__main__":

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -254,7 +254,8 @@ class MockedBackendCommand(BackendCommand):
                                               from_date=True,
                                               basic_auth=True,
                                               token_auth=True,
-                                              archive=True)
+                                              archive=True,
+                                              ssl_verify=True)
         parser.parser.add_argument('origin')
         parser.parser.add_argument('--subtype', dest='subtype')
 
@@ -321,7 +322,8 @@ class MockedBackendCommandDefaultPrePostInit(BackendCommand):
                                               from_date=True,
                                               basic_auth=True,
                                               token_auth=True,
-                                              archive=True)
+                                              archive=True,
+                                              ssl_verify=True)
         parser.parser.add_argument('origin')
 
         return parser
@@ -378,6 +380,12 @@ class TestBackend(unittest.TestCase):
 
         b = Backend('test')
         self.assertEqual(b.origin, 'test')
+
+    def test_ssl_verify(self):
+        """Test whether the SSL verify value is initialized"""
+
+        b = Backend('test')
+        self.assertTrue(b.ssl_verify)
 
     def test_classified_fields(self):
         """Test whether classified fields property returns a list with fields"""
@@ -998,6 +1006,24 @@ class TestBackendCommandArgumentParser(unittest.TestCase):
         parsed_args = parser.parse(*args)
 
         self.assertEqual(parsed_args.offset, 88)
+
+    def test_parse_ssl_verify_arg(self):
+        """Test if the ssl_verify parameter is parsed"""
+
+        parser = BackendCommandArgumentParser(MockedBackendCommand.BACKEND,
+                                              ssl_verify=True)
+
+        # Check default value
+        args = []
+        parsed_args = parser.parse(*args)
+
+        self.assertTrue(parsed_args.ssl_verify)
+
+        # Check argument
+        args = ['--no-ssl-verify']
+        parsed_args = parser.parse(*args)
+
+        self.assertEqual(parsed_args.ssl_verify, False)
 
     def test_incompatible_date_and_offset(self):
         """Test if date and offset arguments are incompatible"""

--- a/tests/test_confluence.py
+++ b/tests/test_confluence.py
@@ -148,6 +148,7 @@ class TestConfluenceBackend(unittest.TestCase):
         self.assertEqual(confluence.origin, CONFLUENCE_URL)
         self.assertEqual(confluence.tag, 'test')
         self.assertIsNone(confluence.client)
+        self.assertTrue(confluence.ssl_verify)
 
         # When tag is empty or None it will be set to
         # the value in url
@@ -156,10 +157,11 @@ class TestConfluenceBackend(unittest.TestCase):
         self.assertEqual(confluence.origin, CONFLUENCE_URL)
         self.assertEqual(confluence.tag, CONFLUENCE_URL)
 
-        confluence = Confluence(CONFLUENCE_URL, tag='')
+        confluence = Confluence(CONFLUENCE_URL, tag='', ssl_verify=False)
         self.assertEqual(confluence.url, CONFLUENCE_URL)
         self.assertEqual(confluence.origin, CONFLUENCE_URL)
         self.assertEqual(confluence.tag, CONFLUENCE_URL)
+        self.assertFalse(confluence.ssl_verify)
 
     def test_has_archiving(self):
         """Test if it returns True when has_archiving is called"""
@@ -566,7 +568,18 @@ class TestConfluenceCommand(unittest.TestCase):
         parsed_args = parser.parse(*args)
         self.assertEqual(parsed_args.url, 'http://example.com')
         self.assertEqual(parsed_args.tag, 'test')
-        self.assertEqual(parsed_args.no_archive, True)
+        self.assertTrue(parsed_args.no_archive)
+        self.assertTrue(parsed_args.ssl_verify)
+        self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
+
+        args = ['http://example.com',
+                '--tag', 'test', '--no-ssl-verify',
+                '--from-date', '1970-01-01']
+
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.url, 'http://example.com')
+        self.assertEqual(parsed_args.tag, 'test')
+        self.assertFalse(parsed_args.ssl_verify)
         self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
 
 
@@ -581,6 +594,11 @@ class TestConfluenceClient(unittest.TestCase):
 
         client = ConfluenceClient(CONFLUENCE_URL)
         self.assertEqual(client.base_url, CONFLUENCE_URL)
+        self.assertTrue(client.ssl_verify)
+
+        client = ConfluenceClient(CONFLUENCE_URL, ssl_verify=False)
+        self.assertEqual(client.base_url, CONFLUENCE_URL)
+        self.assertFalse(client.ssl_verify)
 
     @httpretty.activate
     def test_contents(self):

--- a/tests/test_discourse.py
+++ b/tests/test_discourse.py
@@ -71,6 +71,7 @@ class TestDiscourseBackend(unittest.TestCase):
         self.assertIsNone(discourse.client)
         self.assertEqual(discourse.sleep_time, DEFAULT_SLEEP_TIME)
         self.assertEqual(discourse.max_retries, MAX_RETRIES)
+        self.assertTrue(discourse.ssl_verify)
 
         # When origin is empty or None it will be set to
         # the value in url
@@ -79,10 +80,11 @@ class TestDiscourseBackend(unittest.TestCase):
         self.assertEqual(discourse.origin, DISCOURSE_SERVER_URL)
         self.assertEqual(discourse.tag, DISCOURSE_SERVER_URL)
 
-        discourse = Discourse(DISCOURSE_SERVER_URL, tag='')
+        discourse = Discourse(DISCOURSE_SERVER_URL, tag='', ssl_verify=False)
         self.assertEqual(discourse.url, DISCOURSE_SERVER_URL)
         self.assertEqual(discourse.origin, DISCOURSE_SERVER_URL)
         self.assertEqual(discourse.tag, DISCOURSE_SERVER_URL)
+        self.assertFalse(discourse.ssl_verify)
 
         discourse = Discourse(DISCOURSE_SERVER_URL, sleep_time=60, max_retries=30)
         self.assertEqual(discourse.url, DISCOURSE_SERVER_URL)
@@ -860,7 +862,7 @@ class TestDiscourseClient(unittest.TestCase):
     """
 
     def test_init(self):
-        """Test whether attributes are initializated"""
+        """Test whether attributes are initialized"""
 
         client = DiscourseClient(DISCOURSE_SERVER_URL)
 
@@ -869,15 +871,17 @@ class TestDiscourseClient(unittest.TestCase):
         self.assertIsNone(client.api_username)
         self.assertEqual(client.sleep_time, DEFAULT_SLEEP_TIME)
         self.assertEqual(client.max_retries, MAX_RETRIES)
+        self.assertTrue(client.ssl_verify)
 
         client = DiscourseClient(DISCOURSE_SERVER_URL,
-                                 api_key='aaaa', api_username='user')
+                                 api_key='aaaa', api_username='user', ssl_verify=False)
 
         self.assertEqual(client.base_url, DISCOURSE_SERVER_URL)
         self.assertEqual(client.api_key, 'aaaa')
         self.assertEqual(client.api_username, 'user')
         self.assertEqual(client.sleep_time, DEFAULT_SLEEP_TIME)
         self.assertEqual(client.max_retries, MAX_RETRIES)
+        self.assertFalse(client.ssl_verify)
 
         client = DiscourseClient(DISCOURSE_SERVER_URL,
                                  api_key='aaaa', api_username='user', sleep_time=60, max_retries=30)
@@ -1014,6 +1018,7 @@ class TestDiscourseCommand(unittest.TestCase):
         self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
         self.assertEqual(parsed_args.sleep_time, DEFAULT_SLEEP_TIME)
         self.assertEqual(parsed_args.max_retries, MAX_RETRIES)
+        self.assertTrue(parsed_args.ssl_verify)
 
         args = ['--tag', 'test', '--no-archive',
                 '--from-date', '1970-01-01',
@@ -1036,6 +1041,7 @@ class TestDiscourseCommand(unittest.TestCase):
                 '--max-retries', '60',
                 '--sleep-time', '30',
                 '--api-token', 'aaaa',
+                '--no-ssl-verify',
                 '--api-username', 'user',
                 DISCOURSE_SERVER_URL]
 
@@ -1048,6 +1054,7 @@ class TestDiscourseCommand(unittest.TestCase):
         self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
         self.assertEqual(parsed_args.sleep_time, 30)
         self.assertEqual(parsed_args.max_retries, 60)
+        self.assertFalse(parsed_args.ssl_verify)
 
 
 if __name__ == "__main__":

--- a/tests/test_dockerhub.py
+++ b/tests/test_dockerhub.py
@@ -75,12 +75,14 @@ class TestDockerHubBackend(unittest.TestCase):
         self.assertEqual(dockerhub.origin, expected_origin)
         self.assertEqual(dockerhub.tag, 'test')
         self.assertIsNone(dockerhub.client)
+        self.assertTrue(dockerhub.ssl_verify)
 
         # When tag is empty or None it will be set to
         # the value in
-        dockerhub = DockerHub('grimoirelab', 'perceval')
+        dockerhub = DockerHub('grimoirelab', 'perceval', ssl_verify=False)
         self.assertEqual(dockerhub.origin, expected_origin)
         self.assertEqual(dockerhub.tag, expected_origin)
+        self.assertFalse(dockerhub.ssl_verify)
 
         dockerhub = DockerHub('grimoirelab', 'perceval', tag='')
         self.assertEqual(dockerhub.origin, expected_origin)
@@ -228,7 +230,15 @@ class TestDockerHubCommand(unittest.TestCase):
         args = ['grimoirelab', 'perceval', '--no-archive']
 
         parsed_args = parser.parse(*args)
-        self.assertEqual(parsed_args.no_archive, True)
+        self.assertTrue(parsed_args.no_archive)
+        self.assertTrue(parsed_args.ssl_verify)
+        self.assertEqual(parsed_args.owner, 'grimoirelab')
+        self.assertEqual(parsed_args.repository, 'perceval')
+
+        args = ['grimoirelab', 'perceval', '--no-ssl-verify']
+
+        parsed_args = parser.parse(*args)
+        self.assertFalse(parsed_args.ssl_verify)
         self.assertEqual(parsed_args.owner, 'grimoirelab')
         self.assertEqual(parsed_args.repository, 'perceval')
 

--- a/tests/test_googlehits.py
+++ b/tests/test_googlehits.py
@@ -90,12 +90,14 @@ class TestGoogleHitsBackend(unittest.TestCase):
         self.assertIsNone(backend.client)
         self.assertEqual(backend.max_retries, MAX_RETRIES)
         self.assertEqual(backend.sleep_time, DEFAULT_SLEEP_TIME)
+        self.assertTrue(backend.ssl_verify)
 
         # When tag is empty or None it will be set to the value in
-        backend = GoogleHits(['bitergia', 'grimoirelab'])
+        backend = GoogleHits(['bitergia', 'grimoirelab'], ssl_verify=False)
         self.assertEqual(backend.keywords, ['bitergia', 'grimoirelab'])
         self.assertEqual(backend.origin, GOOGLE_SEARCH_URL)
         self.assertEqual(backend.tag, GOOGLE_SEARCH_URL)
+        self.assertFalse(backend.ssl_verify)
 
         backend = GoogleHits(['bitergia', 'grimoirelab'], tag='')
         self.assertEqual(backend.keywords, ['bitergia', 'grimoirelab'])
@@ -295,23 +297,25 @@ class TestGoogleHitsCommand(unittest.TestCase):
         args = ['', '--no-archive']
 
         parsed_args = parser.parse(*args)
-        self.assertEqual(parsed_args.no_archive, True)
+        self.assertTrue(parsed_args.no_archive)
         self.assertEqual(parsed_args.keywords, [''])
         self.assertEqual(parsed_args.max_retries, MAX_RETRIES)
         self.assertEqual(parsed_args.sleep_time, DEFAULT_SLEEP_TIME)
+        self.assertTrue(parsed_args.ssl_verify)
 
-        args = ['bitergia', '--no-archive']
+        args = ['bitergia', '--no-archive', '--no-ssl-verify']
 
         parsed_args = parser.parse(*args)
-        self.assertEqual(parsed_args.no_archive, True)
+        self.assertTrue(parsed_args.no_archive)
         self.assertEqual(parsed_args.keywords, ['bitergia'])
         self.assertEqual(parsed_args.max_retries, MAX_RETRIES)
         self.assertEqual(parsed_args.sleep_time, DEFAULT_SLEEP_TIME)
+        self.assertFalse(parsed_args.ssl_verify)
 
         args = ['bitergia', 'grimoirelab', '--no-archive', '--max-retries', '1', '--sleep-time', '100']
 
         parsed_args = parser.parse(*args)
-        self.assertEqual(parsed_args.no_archive, True)
+        self.assertTrue(parsed_args.no_archive)
         self.assertEqual(parsed_args.keywords, ['bitergia', 'grimoirelab'])
         self.assertEqual(parsed_args.max_retries, 1)
         self.assertEqual(parsed_args.sleep_time, 100)

--- a/tests/test_groupsio.py
+++ b/tests/test_groupsio.py
@@ -115,7 +115,7 @@ class TestGroupsioBackend(unittest.TestCase):
         self.assertEqual(backend.dirpath, self.tmp_path)
         self.assertEqual(backend.origin, 'https://groups.io/g/beta+api')
         self.assertEqual(backend.tag, 'test')
-        self.assertTrue(backend.verify)
+        self.assertTrue(backend.ssl_verify)
 
         # When tag is empty or None it will be set to
         # the value in uri
@@ -127,10 +127,10 @@ class TestGroupsioBackend(unittest.TestCase):
         self.assertEqual(backend.origin, 'https://groups.io/g/beta+api')
         self.assertEqual(backend.tag, 'https://groups.io/g/beta+api')
 
-        backend = Groupsio('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', verify=False, tag='')
+        backend = Groupsio('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', ssl_verify=False, tag='')
         self.assertEqual(backend.origin, 'https://groups.io/g/beta+api')
         self.assertEqual(backend.tag, 'https://groups.io/g/beta+api')
-        self.assertFalse(backend.verify)
+        self.assertFalse(backend.ssl_verify)
 
     def test_has_archiving(self):
         """Test if it returns False when has_archiving is called"""
@@ -256,14 +256,14 @@ class TestGroupsioClient(unittest.TestCase):
         self.assertEqual(client.uri, 'https://groups.io/g/beta+api')
         self.assertEqual(client.dirpath, self.tmp_path)
         self.assertEqual(client.group_name, 'beta+api')
-        self.assertTrue(client.verify)
+        self.assertTrue(client.ssl_verify)
 
-        client = GroupsioClient('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', verify=False)
+        client = GroupsioClient('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', ssl_verify=False)
         self.assertIsInstance(client, GroupsioClient)
         self.assertEqual(client.uri, 'https://groups.io/g/beta+api')
         self.assertEqual(client.dirpath, self.tmp_path)
         self.assertEqual(client.group_name, 'beta+api')
-        self.assertFalse(client.verify)
+        self.assertFalse(client.ssl_verify)
 
     @httpretty.activate
     def test_fetch(self):
@@ -271,7 +271,7 @@ class TestGroupsioClient(unittest.TestCase):
 
         setup_http_server(empty_mbox=True)
 
-        client = GroupsioClient('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', verify=False)
+        client = GroupsioClient('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', ssl_verify=False)
         success = client.fetch()
 
         # Check requests
@@ -308,7 +308,7 @@ class TestGroupsioClient(unittest.TestCase):
 
         setup_http_server()
 
-        client = GroupsioClient('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', verify=False)
+        client = GroupsioClient('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', ssl_verify=False)
         from_date = datetime.datetime(2019, 1, 1)
         success = client.fetch(from_date=from_date)
 
@@ -347,7 +347,7 @@ class TestGroupsioClient(unittest.TestCase):
 
         setup_http_server(empty_mbox=True)
 
-        client = GroupsioClient('beta/api', self.tmp_path, 'jsmith@example.com', 'aaaaa', verify=False)
+        client = GroupsioClient('beta/api', self.tmp_path, 'jsmith@example.com', 'aaaaa', ssl_verify=False)
         with self.assertRaises(BackendError):
             client.fetch()
 
@@ -357,7 +357,7 @@ class TestGroupsioClient(unittest.TestCase):
 
         setup_http_server(empty_mbox=True, http_status_download=400)
 
-        client = GroupsioClient('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', verify=False)
+        client = GroupsioClient('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', ssl_verify=False)
         with self.assertRaises(requests.exceptions.HTTPError):
             client.fetch()
 
@@ -367,7 +367,7 @@ class TestGroupsioClient(unittest.TestCase):
 
         setup_http_server(empty_mbox=True)
 
-        client = GroupsioClientMocked('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', verify=False)
+        client = GroupsioClientMocked('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', ssl_verify=False)
         success = client.fetch()
 
         self.assertFalse(success)
@@ -382,7 +382,7 @@ class TestGroupsioClient(unittest.TestCase):
         os.removedirs(self.tmp_path)
 
         self.assertFalse(os.path.exists(self.tmp_path))
-        client = GroupsioClient('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', verify=False)
+        client = GroupsioClient('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', ssl_verify=False)
         _ = client.fetch()
         self.assertTrue(os.path.exists(self.tmp_path))
 
@@ -392,7 +392,7 @@ class TestGroupsioClient(unittest.TestCase):
 
         setup_http_server(empty_mbox=True)
 
-        client = GroupsioClient('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', verify=False)
+        client = GroupsioClient('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', ssl_verify=False)
         success = client.fetch()
 
         self.assertEqual(client.mboxes[0].filepath, os.path.join(self.tmp_path, MBOX_FILE))
@@ -410,7 +410,7 @@ class TestGroupsioClient(unittest.TestCase):
 
         setup_http_server()
 
-        client = GroupsioClient('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', verify=False)
+        client = GroupsioClient('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', ssl_verify=False)
         subs = [subs for subs in client.subscriptions(per_page=1)]
         self.assertEqual(len(subs), 2)
 
@@ -420,7 +420,7 @@ class TestGroupsioClient(unittest.TestCase):
 
         setup_http_server(http_status_subscriptions=400)
 
-        client = GroupsioClient('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', verify=False)
+        client = GroupsioClient('beta+api', self.tmp_path, 'jsmith@example.com', 'aaaaa', ssl_verify=False)
 
         with self.assertRaises(requests.exceptions.HTTPError):
             _ = [subs for subs in client.subscriptions(per_page=1)]
@@ -490,7 +490,6 @@ class TestGroupsioCommand(unittest.TestCase):
                 '--mboxes-path', '/tmp/perceval/',
                 '--tag', 'test',
                 '--from-date', '1970-01-01',
-                '--no-verify',
                 '--email', 'jsmith@example.com',
                 '--password', 'aaaaa']
 
@@ -499,7 +498,24 @@ class TestGroupsioCommand(unittest.TestCase):
         self.assertEqual(parsed_args.mboxes_path, '/tmp/perceval/')
         self.assertEqual(parsed_args.tag, 'test')
         self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
-        self.assertFalse(parsed_args.verify)
+        self.assertTrue(parsed_args.ssl_verify)
+        self.assertEqual(parsed_args.email, 'jsmith@example.com')
+        self.assertEqual(parsed_args.password, 'aaaaa')
+
+        args = ['acme_group',
+                '--mboxes-path', '/tmp/perceval/',
+                '--tag', 'test',
+                '--from-date', '1970-01-01',
+                '--no-ssl-verify',
+                '--email', 'jsmith@example.com',
+                '--password', 'aaaaa']
+
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.group_name, 'acme_group')
+        self.assertEqual(parsed_args.mboxes_path, '/tmp/perceval/')
+        self.assertEqual(parsed_args.tag, 'test')
+        self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
+        self.assertFalse(parsed_args.ssl_verify)
         self.assertEqual(parsed_args.email, 'jsmith@example.com')
         self.assertEqual(parsed_args.password, 'aaaaa')
 

--- a/tests/test_hyperkitty.py
+++ b/tests/test_hyperkitty.py
@@ -164,12 +164,14 @@ class TestHyperKittyBackend(unittest.TestCase):
         self.assertEqual(backend.dirpath, self.tmp_path)
         self.assertEqual(backend.origin, 'http://example.com/')
         self.assertEqual(backend.tag, 'test')
+        self.assertTrue(backend.ssl_verify)
 
         # When tag is empty or None it will be set to
         # the value in uri
-        backend = HyperKitty('http://example.com/', self.tmp_path)
+        backend = HyperKitty('http://example.com/', self.tmp_path, ssl_verify=False)
         self.assertEqual(backend.origin, 'http://example.com/')
         self.assertEqual(backend.tag, 'http://example.com/')
+        self.assertFalse(backend.ssl_verify)
 
         backend = HyperKitty('http://example.com/', self.tmp_path, tag='')
         self.assertEqual(backend.origin, 'http://example.com/')
@@ -347,6 +349,19 @@ class TestHyperKittyCommand(unittest.TestCase):
         self.assertEqual(parsed_args.mboxes_path, '/tmp/perceval/')
         self.assertEqual(parsed_args.tag, 'test')
         self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
+        self.assertTrue(parsed_args.ssl_verify)
+
+        args = ['http://example.com/archives/list/test@example.com/',
+                '--mboxes-path', '/tmp/perceval/',
+                '--tag', 'test', '--no-ssl-verify',
+                '--from-date', '1970-01-01']
+
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.url, 'http://example.com/archives/list/test@example.com/')
+        self.assertEqual(parsed_args.mboxes_path, '/tmp/perceval/')
+        self.assertEqual(parsed_args.tag, 'test')
+        self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
+        self.assertFalse(parsed_args.ssl_verify)
 
 
 if __name__ == "__main__":

--- a/tests/test_mattermost.py
+++ b/tests/test_mattermost.py
@@ -134,16 +134,18 @@ class TestMattermostBackend(unittest.TestCase):
         self.assertEqual(mattermost.api_token, 'aaaa')
         self.assertEqual(mattermost.tag, 'test')
         self.assertEqual(mattermost.max_items, 5)
-        self.assertEqual(mattermost.sleep_for_rate, True)
+        self.assertTrue(mattermost.sleep_for_rate)
+        self.assertTrue(mattermost.ssl_verify)
         self.assertEqual(mattermost.min_rate_to_sleep, 10)
         self.assertEqual(mattermost.sleep_time, 60)
         self.assertIsNone(mattermost.client)
 
         # When tag is empty or None it will be set to
         # the value in URL
-        mattermost = Mattermost('https://mattermost.example.com/', 'abcdefghijkl', 'aaaa',)
+        mattermost = Mattermost('https://mattermost.example.com/', 'abcdefghijkl', 'aaaa', ssl_verify=False)
         self.assertEqual(mattermost.origin, 'https://mattermost.example.com/abcdefghijkl')
         self.assertEqual(mattermost.tag, 'https://mattermost.example.com/abcdefghijkl')
+        self.assertFalse(mattermost.ssl_verify)
 
         mattermost = Mattermost('https://mattermost.example.com/', 'abcdefghijkl', 'aaaa', tag='')
         self.assertEqual(mattermost.origin, 'https://mattermost.example.com/abcdefghijkl')
@@ -423,11 +425,36 @@ class TestMattermostCommand(unittest.TestCase):
         self.assertEqual(parsed_args.api_token, 'aaaa')
         self.assertEqual(parsed_args.max_items, 5)
         self.assertEqual(parsed_args.tag, 'test')
-        self.assertEqual(parsed_args.no_archive, True)
+        self.assertTrue(parsed_args.no_archive)
         self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
-        self.assertEqual(parsed_args.sleep_for_rate, True)
+        self.assertTrue(parsed_args.sleep_for_rate)
         self.assertEqual(parsed_args.min_rate_to_sleep, 10)
         self.assertEqual(parsed_args.sleep_time, 10)
+        self.assertTrue(parsed_args.ssl_verify)
+
+        args = ['https://mattermost.example.com/', 'abcdefghijkl',
+                '--api-token', 'aaaa',
+                '--max-items', '5',
+                '--tag', 'test',
+                '--no-archive',
+                '--from-date', '1970-01-01',
+                '--sleep-for-rate',
+                '--min-rate-to-sleep', '10',
+                '--sleep-time', '10',
+                '--no-ssl-verify']
+
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.url, 'https://mattermost.example.com/')
+        self.assertEqual(parsed_args.channel, 'abcdefghijkl')
+        self.assertEqual(parsed_args.api_token, 'aaaa')
+        self.assertEqual(parsed_args.max_items, 5)
+        self.assertEqual(parsed_args.tag, 'test')
+        self.assertTrue(parsed_args.no_archive)
+        self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
+        self.assertTrue(parsed_args.sleep_for_rate)
+        self.assertEqual(parsed_args.min_rate_to_sleep, 10)
+        self.assertEqual(parsed_args.sleep_time, 10)
+        self.assertFalse(parsed_args.ssl_verify)
 
 
 class TestMattermostClient(unittest.TestCase):
@@ -445,22 +472,24 @@ class TestMattermostClient(unittest.TestCase):
         self.assertEqual(client.base_url, 'https://mattermost.example.com')
         self.assertEqual(client.api_token, 'aaaa')
         self.assertEqual(client.max_items, 60)
-        self.assertEqual(client.sleep_for_rate, False)
+        self.assertFalse(client.sleep_for_rate)
         self.assertEqual(client.min_rate_to_sleep, 10)
         self.assertEqual(client.archive, None)
-        self.assertEqual(client.from_archive, False)
+        self.assertFalse(client.from_archive)
+        self.assertTrue(client.ssl_verify)
 
         client = MattermostClient('https://mattermost.example.com/', 'aaaa',
                                   max_items=5,
                                   sleep_for_rate=True,
                                   min_rate_to_sleep=5,
-                                  sleep_time=3)
+                                  sleep_time=3, ssl_verify=False)
         self.assertEqual(client.base_url, 'https://mattermost.example.com')
         self.assertEqual(client.api_token, 'aaaa')
         self.assertEqual(client.max_items, 5)
-        self.assertEqual(client.sleep_for_rate, True)
+        self.assertTrue(client.sleep_for_rate)
         self.assertEqual(client.min_rate_to_sleep, 5)
         self.assertEqual(client.sleep_time, 3)
+        self.assertFalse(client.ssl_verify)
 
     @httpretty.activate
     def test_channel(self):

--- a/tests/test_mbox.py
+++ b/tests/test_mbox.py
@@ -239,6 +239,7 @@ class TestMBoxBackend(TestBaseMBox):
         self.assertEqual(backend.dirpath, self.tmp_path)
         self.assertEqual(backend.origin, 'http://example.com/')
         self.assertEqual(backend.tag, 'test')
+        self.assertTrue(backend.ssl_verify)
 
         # When origin is empty or None it will be set to
         # the value in uri
@@ -246,9 +247,10 @@ class TestMBoxBackend(TestBaseMBox):
         self.assertEqual(backend.origin, 'http://example.com/')
         self.assertEqual(backend.tag, 'http://example.com/')
 
-        backend = MBox('http://example.com/', self.tmp_path, tag='')
+        backend = MBox('http://example.com/', self.tmp_path, tag='', ssl_verify=False)
         self.assertEqual(backend.origin, 'http://example.com/')
         self.assertEqual(backend.tag, 'http://example.com/')
+        self.assertFalse(backend.ssl_verify)
 
     def test_has_archiving(self):
         """Test if it returns False when has_archiving is called"""
@@ -575,6 +577,19 @@ class TestMBoxCommand(unittest.TestCase):
         self.assertEqual(parsed_args.dirpath, '/tmp/perceval/')
         self.assertEqual(parsed_args.tag, 'test')
         self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
+        self.assertTrue(parsed_args.ssl_verify)
+
+        args = ['http://example.com/', '/tmp/perceval/',
+                '--tag', 'test',
+                '--from-date', '1970-01-01',
+                '--no-ssl-verify']
+
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.uri, 'http://example.com/')
+        self.assertEqual(parsed_args.dirpath, '/tmp/perceval/')
+        self.assertEqual(parsed_args.tag, 'test')
+        self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
+        self.assertFalse(parsed_args.ssl_verify)
 
 
 if __name__ == "__main__":

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -158,13 +158,15 @@ class TestMediaWikiBackend(unittest.TestCase):
         self.assertEqual(mediawiki.origin, MEDIAWIKI_SERVER_URL)
         self.assertEqual(mediawiki.tag, 'test')
         self.assertIsNone(mediawiki.client)
+        self.assertTrue(mediawiki.ssl_verify)
 
         # When tag is empty or None it will be set to
         # the value in url
-        mediawiki = MediaWiki(MEDIAWIKI_SERVER_URL)
+        mediawiki = MediaWiki(MEDIAWIKI_SERVER_URL, ssl_verify=False)
         self.assertEqual(mediawiki.url, MEDIAWIKI_SERVER_URL)
         self.assertEqual(mediawiki.origin, MEDIAWIKI_SERVER_URL)
         self.assertEqual(mediawiki.tag, MEDIAWIKI_SERVER_URL)
+        self.assertFalse(mediawiki.ssl_verify)
 
         mediawiki = MediaWiki(MEDIAWIKI_SERVER_URL, tag='')
         self.assertEqual(mediawiki.url, MEDIAWIKI_SERVER_URL)
@@ -698,7 +700,19 @@ class TestMediaWikiCommand(unittest.TestCase):
         parsed_args = parser.parse(*args)
         self.assertEqual(parsed_args.url, MEDIAWIKI_SERVER_URL)
         self.assertEqual(parsed_args.tag, 'test')
-        self.assertEqual(parsed_args.no_archive, True)
+        self.assertTrue(parsed_args.no_archive)
+        self.assertTrue(parsed_args.ssl_verify)
+        self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
+
+        args = ['--tag', 'test', '--no-ssl-verify',
+                '--no-archive', '--from-date', '1970-01-01',
+                MEDIAWIKI_SERVER_URL]
+
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.url, MEDIAWIKI_SERVER_URL)
+        self.assertEqual(parsed_args.tag, 'test')
+        self.assertTrue(parsed_args.no_archive)
+        self.assertFalse(parsed_args.ssl_verify)
         self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
 
 

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -189,12 +189,14 @@ class TestMeetupBackend(unittest.TestCase):
         self.assertEqual(meetup.group, 'mygroup')
         self.assertEqual(meetup.max_items, 5)
         self.assertIsNone(meetup.client)
+        self.assertTrue(meetup.ssl_verify)
 
         # When tag is empty or None it will be set to
         # the value in URL
-        meetup = Meetup('mygroup', 'aaaa')
+        meetup = Meetup('mygroup', 'aaaa', ssl_verify=False)
         self.assertEqual(meetup.origin, 'https://meetup.com/')
         self.assertEqual(meetup.tag, 'https://meetup.com/')
+        self.assertFalse(meetup.ssl_verify)
 
         meetup = Meetup('mygroup', 'aaaa', tag='')
         self.assertEqual(meetup.origin, 'https://meetup.com/')
@@ -717,6 +719,20 @@ class TestMeetupCommand(unittest.TestCase):
         self.assertEqual(parsed_args.min_rate_to_sleep, 10)
         self.assertEqual(parsed_args.sleep_time, 10)
         self.assertTrue(parsed_args.filter_classified)
+        self.assertTrue(parsed_args.ssl_verify)
+
+        args = ['sqlpass-es',
+                '--api-token', 'aaaa',
+                '--max-items', '5',
+                '--tag', 'test',
+                '--no-ssl-verify']
+
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.group, 'sqlpass-es')
+        self.assertEqual(parsed_args.api_token, 'aaaa')
+        self.assertEqual(parsed_args.max_items, 5)
+        self.assertEqual(parsed_args.tag, 'test')
+        self.assertFalse(parsed_args.ssl_verify)
 
 
 class TestMeetupClient(unittest.TestCase):
@@ -735,14 +751,17 @@ class TestMeetupClient(unittest.TestCase):
         self.assertEqual(client.max_items, 10)
         self.assertFalse(client.sleep_for_rate)
         self.assertEqual(client.min_rate_to_sleep, MIN_RATE_LIMIT)
+        self.assertTrue(client.ssl_verify)
 
         client = MeetupClient('aaaa', max_items=10,
                               sleep_for_rate=True,
-                              min_rate_to_sleep=4)
+                              min_rate_to_sleep=4,
+                              ssl_verify=False)
         self.assertEqual(client.api_token, 'aaaa')
         self.assertEqual(client.max_items, 10)
         self.assertTrue(client.sleep_for_rate)
         self.assertEqual(client.min_rate_to_sleep, 4)
+        self.assertFalse(client.ssl_verify)
 
         # Max rate limit is never overtaken
         client = MeetupClient('aaaa', max_items=10,

--- a/tests/test_phabricator.py
+++ b/tests/test_phabricator.py
@@ -169,6 +169,7 @@ class TestPhabricatorBackend(unittest.TestCase):
         self.assertEqual(phab.origin, PHABRICATOR_URL)
         self.assertEqual(phab.tag, 'test')
         self.assertIsNone(phab.client)
+        self.assertTrue(phab.ssl_verify)
 
         # When tag is empty or None it will be set to
         # the value in url
@@ -177,12 +178,13 @@ class TestPhabricatorBackend(unittest.TestCase):
         self.assertEqual(phab.origin, PHABRICATOR_URL)
         self.assertEqual(phab.tag, PHABRICATOR_URL)
 
-        phab = Phabricator(PHABRICATOR_URL, 'AAAA', tag='')
+        phab = Phabricator(PHABRICATOR_URL, 'AAAA', tag='', ssl_verify=False)
         self.assertEqual(phab.url, PHABRICATOR_URL)
         self.assertEqual(phab.origin, PHABRICATOR_URL)
         self.assertEqual(phab.tag, PHABRICATOR_URL)
         self.assertEqual(phab.max_retries, MAX_RETRIES)
         self.assertEqual(phab.sleep_time, DEFAULT_SLEEP_TIME)
+        self.assertFalse(phab.ssl_verify)
 
         phab = Phabricator(PHABRICATOR_URL, 'AAAA', None, None, 3, 25)
         self.assertEqual(phab.url, PHABRICATOR_URL)
@@ -688,12 +690,14 @@ class TestConduitClient(unittest.TestCase):
         self.assertEqual(client.api_token, 'aaaa')
         self.assertEqual(client.max_retries, MAX_RETRIES)
         self.assertEqual(client.sleep_time, DEFAULT_SLEEP_TIME)
+        self.assertTrue(client.ssl_verify)
 
-        client = ConduitClient(PHABRICATOR_URL, 'aaaa', 2, 100)
+        client = ConduitClient(PHABRICATOR_URL, 'aaaa', 2, 100, ssl_verify=False)
         self.assertEqual(client.base_url, PHABRICATOR_URL)
         self.assertEqual(client.api_token, 'aaaa')
         self.assertEqual(client.max_retries, 2)
         self.assertEqual(client.sleep_time, 100)
+        self.assertFalse(client.ssl_verify)
 
         client = ConduitClient(PHABRICATOR_URL, 'aaaa', max_retries=2, sleep_time=100)
         self.assertEqual(client.base_url, PHABRICATOR_URL)
@@ -968,7 +972,8 @@ class TestPhabricatorCommand(unittest.TestCase):
         self.assertEqual(parsed_args.url, 'http://example.com')
         self.assertEqual(parsed_args.api_token, '12345678')
         self.assertEqual(parsed_args.tag, 'test')
-        self.assertEqual(parsed_args.no_archive, True)
+        self.assertTrue(parsed_args.no_archive)
+        self.assertTrue(parsed_args.ssl_verify)
         self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
         self.assertEqual(parsed_args.max_retries, MAX_RETRIES)
         self.assertEqual(parsed_args.sleep_time, DEFAULT_SLEEP_TIME)
@@ -979,7 +984,8 @@ class TestPhabricatorCommand(unittest.TestCase):
                 '--no-archive',
                 '--from-date', '1970-01-01',
                 '--max-retries', '7',
-                '--sleep-time', '43']
+                '--sleep-time', '43',
+                '--no-ssl-verify']
 
         parsed_args = parser.parse(*args)
         self.assertEqual(parsed_args.url, 'http://example.com')
@@ -989,6 +995,7 @@ class TestPhabricatorCommand(unittest.TestCase):
         self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
         self.assertEqual(parsed_args.max_retries, 7)
         self.assertEqual(parsed_args.sleep_time, 43)
+        self.assertFalse(parsed_args.ssl_verify)
 
 
 if __name__ == "__main__":

--- a/tests/test_pipermail.py
+++ b/tests/test_pipermail.py
@@ -73,15 +73,15 @@ class TestPipermailList(unittest.TestCase):
         self.assertEqual(pmls.uri, PIPERMAIL_URL)
         self.assertEqual(pmls.dirpath, self.tmp_path)
         self.assertEqual(pmls.url, PIPERMAIL_URL)
-        self.assertTrue(pmls.verify)
+        self.assertTrue(pmls.ssl_verify)
 
-        pmls = PipermailList(PIPERMAIL_URL, self.tmp_path, verify=False)
+        pmls = PipermailList(PIPERMAIL_URL, self.tmp_path, ssl_verify=False)
 
         self.assertIsInstance(pmls, MailingList)
         self.assertEqual(pmls.uri, PIPERMAIL_URL)
         self.assertEqual(pmls.dirpath, self.tmp_path)
         self.assertEqual(pmls.url, PIPERMAIL_URL)
-        self.assertFalse(pmls.verify)
+        self.assertFalse(pmls.ssl_verify)
 
     @httpretty.activate
     def test_fetch(self):
@@ -314,7 +314,7 @@ class TestPipermailBackend(unittest.TestCase):
         self.assertEqual(backend.dirpath, self.tmp_path)
         self.assertEqual(backend.origin, 'http://example.com/')
         self.assertEqual(backend.tag, 'test')
-        self.assertTrue(backend.verify)
+        self.assertTrue(backend.ssl_verify)
 
         # When tag is empty or None it will be set to
         # the value in uri
@@ -326,10 +326,10 @@ class TestPipermailBackend(unittest.TestCase):
         self.assertEqual(backend.origin, 'http://example.com/')
         self.assertEqual(backend.tag, 'http://example.com/')
 
-        backend = Pipermail('http://example.com/', self.tmp_path, verify=True, tag='')
+        backend = Pipermail('http://example.com/', self.tmp_path, ssl_verify=True, tag='')
         self.assertEqual(backend.origin, 'http://example.com/')
         self.assertEqual(backend.tag, 'http://example.com/')
-        self.assertTrue(backend.verify)
+        self.assertTrue(backend.ssl_verify)
 
     def test_has_archiving(self):
         """Test if it returns False when has_archiving is called"""
@@ -578,15 +578,27 @@ class TestPipermailCommand(unittest.TestCase):
         args = ['http://example.com/',
                 '--mboxes-path', '/tmp/perceval/',
                 '--tag', 'test',
-                '--from-date', '1970-01-01',
-                '--no-verify']
+                '--from-date', '1970-01-01']
 
         parsed_args = parser.parse(*args)
         self.assertEqual(parsed_args.url, 'http://example.com/')
         self.assertEqual(parsed_args.mboxes_path, '/tmp/perceval/')
         self.assertEqual(parsed_args.tag, 'test')
         self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
-        self.assertFalse(parsed_args.verify)
+        self.assertTrue(parsed_args.ssl_verify)
+
+        args = ['http://example.com/',
+                '--mboxes-path', '/tmp/perceval/',
+                '--tag', 'test',
+                '--from-date', '1970-01-01',
+                '--no-ssl-verify']
+
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.url, 'http://example.com/')
+        self.assertEqual(parsed_args.mboxes_path, '/tmp/perceval/')
+        self.assertEqual(parsed_args.tag, 'test')
+        self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
+        self.assertFalse(parsed_args.ssl_verify)
 
 
 if __name__ == "__main__":

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -85,13 +85,15 @@ class TestRSSBackend(unittest.TestCase):
         self.assertEqual(rss.origin, RSS_FEED_URL)
         self.assertEqual(rss.tag, 'test')
         self.assertIsNone(rss.client)
+        self.assertTrue(rss.ssl_verify)
 
         # When tag is empty or None it will be set to
         # the value in url
-        rss = RSS(RSS_FEED_URL)
+        rss = RSS(RSS_FEED_URL, ssl_verify=False)
         self.assertEqual(rss.url, RSS_FEED_URL)
         self.assertEqual(rss.origin, RSS_FEED_URL)
         self.assertEqual(rss.tag, RSS_FEED_URL)
+        self.assertFalse(rss.ssl_verify)
 
         rss = RSS(RSS_FEED_URL, tag='')
         self.assertEqual(rss.url, RSS_FEED_URL)
@@ -247,7 +249,19 @@ class TestRSSCommand(unittest.TestCase):
         parsed_args = parser.parse(*args)
         self.assertEqual(parsed_args.url, RSS_FEED_URL)
         self.assertEqual(parsed_args.tag, 'test')
-        self.assertEqual(parsed_args.no_archive, True)
+        self.assertTrue(parsed_args.no_archive)
+        self.assertTrue(parsed_args.ssl_verify)
+
+        args = ['--tag', 'test',
+                '--no-archive',
+                '--no-ssl-verify',
+                RSS_FEED_URL]
+
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.url, RSS_FEED_URL)
+        self.assertEqual(parsed_args.tag, 'test')
+        self.assertTrue(parsed_args.no_archive)
+        self.assertFalse(parsed_args.ssl_verify)
 
 
 class TestRSSClient(unittest.TestCase):

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -165,12 +165,14 @@ class TestSlackBackend(unittest.TestCase):
         self.assertEqual(slack.channel, 'C011DUKE8')
         self.assertEqual(slack.max_items, 5)
         self.assertIsNone(slack.client)
+        self.assertTrue(slack.ssl_verify)
 
         # When tag is empty or None it will be set to
         # the value in URL
-        slack = Slack('C011DUKE8', 'aaaa')
+        slack = Slack('C011DUKE8', 'aaaa', ssl_verify=False)
         self.assertEqual(slack.origin, 'https://slack.com/C011DUKE8')
         self.assertEqual(slack.tag, 'https://slack.com/C011DUKE8')
+        self.assertFalse(slack.ssl_verify)
 
         slack = Slack('C011DUKE8', 'aaaa', tag='')
         self.assertEqual(slack.origin, 'https://slack.com/C011DUKE8')
@@ -666,6 +668,12 @@ class TestSlackClient(unittest.TestCase):
         client = SlackClient('aaaa', max_items=5)
         self.assertEqual(client.api_token, 'aaaa')
         self.assertEqual(client.max_items, 5)
+        self.assertTrue(client.ssl_verify)
+
+        client = SlackClient('aaaa', max_items=5, ssl_verify=False)
+        self.assertEqual(client.api_token, 'aaaa')
+        self.assertEqual(client.max_items, 5)
+        self.assertFalse(client.ssl_verify)
 
     @httpretty.activate
     def test_conversation_members(self):
@@ -851,7 +859,22 @@ class TestSlackCommand(unittest.TestCase):
         self.assertEqual(parsed_args.channel, 'C001')
         self.assertEqual(parsed_args.tag, 'test')
         self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
-        self.assertEqual(parsed_args.no_archive, True)
+        self.assertTrue(parsed_args.no_archive)
+        self.assertTrue(parsed_args.ssl_verify)
+        self.assertEqual(parsed_args.api_token, 'abcdefgh')
+        self.assertEqual(parsed_args.max_items, 10)
+
+        args = ['--tag', 'test', '--no-ssl-verify',
+                '--api-token', 'abcdefgh',
+                '--from-date', '1970-01-01',
+                '--max-items', '10',
+                'C001']
+
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.channel, 'C001')
+        self.assertEqual(parsed_args.tag, 'test')
+        self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
+        self.assertFalse(parsed_args.ssl_verify)
         self.assertEqual(parsed_args.api_token, 'abcdefgh')
         self.assertEqual(parsed_args.max_items, 10)
 

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -91,13 +91,15 @@ class TestTelegramBackend(unittest.TestCase):
         self.assertEqual(tlg.origin, origin)
         self.assertEqual(tlg.tag, 'test')
         self.assertIsNone(tlg.client)
+        self.assertTrue(tlg.ssl_verify)
 
         # When tag is empty or None it will be set to
         # the value in url
-        tlg = Telegram(TELEGRAM_BOT, TELEGRAM_TOKEN)
+        tlg = Telegram(TELEGRAM_BOT, TELEGRAM_TOKEN, ssl_verify=False)
         self.assertEqual(tlg.bot, TELEGRAM_BOT)
         self.assertEqual(tlg.origin, origin)
         self.assertEqual(tlg.tag, origin)
+        self.assertFalse(tlg.ssl_verify)
 
         tlg = Telegram(TELEGRAM_BOT, TELEGRAM_TOKEN, tag='')
         self.assertEqual(tlg.bot, TELEGRAM_BOT)
@@ -365,7 +367,23 @@ class TestTelegramCommand(unittest.TestCase):
         self.assertEqual(parsed_args.offset, 10)
         self.assertEqual(parsed_args.chats, [-10000])
         self.assertEqual(parsed_args.tag, 'test')
-        self.assertEqual(parsed_args.no_archive, True)
+        self.assertTrue(parsed_args.no_archive)
+        self.assertTrue(parsed_args.ssl_verify)
+
+        args = ['mybot',
+                '--api-token', '12345678',
+                '--offset', '10',
+                '--chats', '-10000',
+                '--tag', 'test',
+                '--no-ssl-verify']
+
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.bot, 'mybot')
+        self.assertEqual(parsed_args.bot_token, '12345678')
+        self.assertEqual(parsed_args.offset, 10)
+        self.assertEqual(parsed_args.chats, [-10000])
+        self.assertEqual(parsed_args.tag, 'test')
+        self.assertFalse(parsed_args.ssl_verify)
 
 
 class TestTelegramBotClient(unittest.TestCase):
@@ -379,6 +397,11 @@ class TestTelegramBotClient(unittest.TestCase):
 
         client = TelegramBotClient(TELEGRAM_TOKEN)
         self.assertEqual(client.bot_token, TELEGRAM_TOKEN)
+        self.assertTrue(client.ssl_verify)
+
+        client = TelegramBotClient(TELEGRAM_TOKEN, ssl_verify=False)
+        self.assertEqual(client.bot_token, TELEGRAM_TOKEN)
+        self.assertFalse(client.ssl_verify)
 
     @httpretty.activate
     def test_updates(self):


### PR DESCRIPTION
This PR addresses https://github.com/chaoss/grimoirelab-perceval/issues/610, thus it proposes to include the parameter `verify` in the generic Perceval backend to disable SSL verification.

The BackendCommandArgumentParser has been modified accordingly to support this feature. Thus, the user can disable the SSL verification by typing `--no-verify` in the command line together with the other Perceval parameters.

The HttpClient has been updated. Some backends have been updated to showcase this feature and simplifying the review process. In the next days, the other backends will be extended.
