### PR TITLE
[telegram] Handle edited messages

### DIFF
--- a/perceval/backends/core/telegram.py
+++ b/perceval/backends/core/telegram.py
@@ -62,7 +62,7 @@ class Telegram(Backend):
     :param archive: archive to store/retrieve items
     :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.11.0'
+    version = '0.11.1'
 
     CATEGORIES = [CATEGORY_MESSAGE]
     EXTRA_SEARCH_FIELDS = {
@@ -231,6 +231,15 @@ class Telegram(Backend):
 
         messages = result['result']
         for msg in messages:
+
+            if 'edited_message' in msg:
+                edit_message = msg.pop('edited_message')
+                edit_date = edit_message.pop('edit_date')
+                msg['message'] = edit_message
+                msg['message']['date'] = edit_date
+                msg['message']['edited'] = True
+                logger.debug("Message %s is edited", msg['message']['message_id'])
+
             yield msg
 
     def _init_client(self, from_archive=False):
@@ -352,7 +361,7 @@ class TelegramBotClient(HttpClient):
     def _call(self, method, params):
         """Retrive the given resource.
 
-        :param resource: resource to retrieve
+        :param method: resource to retrieve
         :param params: dict with the HTTP parameters needed to retrieve
             the given resource
         """

--- a/tests/data/telegram/telegram_messages_next.json
+++ b/tests/data/telegram/telegram_messages_next.json
@@ -19,6 +19,41 @@
                 "text": "Hi Bot!!!"
             },
             "update_id": 319280321
+        },
+        {
+            "message": {
+                "chat": {
+                    "id": -2,
+                    "title": "A new group",
+                    "type": "group"
+                },
+                "date": 1467370373,
+                "from": {
+                    "first_name": "Valerio",
+                    "id": 9
+                },
+                "message_id": 35,
+                "text": "Hola Hola"
+            },
+            "update_id": 319280322
+        },
+        {
+            "edited_message": {
+                "chat": {
+                    "id": -2,
+                    "title": "A new group",
+                    "type": "group"
+                },
+                "date": 1467370373,
+                "edit_date": 1467370374,
+                "from": {
+                    "first_name": "Valerio",
+                    "id": 9
+                },
+                "message_id": 35,
+                "text": "Holaaa"
+            },
+            "update_id": 319280323
         }
     ]
 }

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -58,14 +58,14 @@ def setup_http_server():
 
         if 'offset' in params and params['offset'] == ['319280321']:
             body = body_msgs_next
-        elif 'offset' in params and params['offset'] == ['319280322']:
+        elif 'offset' in params and params['offset'] == ['319280324']:
             body = body_msgs_empty
         else:
             body = body_msgs
 
         http_requests.append(httpretty.last_request())
 
-        return (200, headers, body)
+        return 200, headers, body
 
     httpretty.register_uri(httpretty.GET,
                            TELEGRAM_UPDATES_URL,
@@ -125,10 +125,14 @@ class TestTelegramBackend(unittest.TestCase):
         tlg = Telegram(TELEGRAM_BOT, TELEGRAM_TOKEN)
         messages = [msg for msg in tlg.fetch(offset=None)]
 
-        expected = [(31, '5a5457aec04237ac3fab30031e84c745a3bdd157', 1467289325.0, 319280318),
-                    (32, '16a59e93e919174fcd4e70e5b3289201c1016c72', 1467289329.0, 319280319),
-                    (33, '9d03eeea7e3186ca8e5c150b4cbf18c8283cca9d', 1467289371.0, 319280320),
-                    (34, '2e61e72b64c9084f3c5a36671c3119641c3ae42f', 1467370372.0, 319280321)]
+        expected = [
+            (31, '5a5457aec04237ac3fab30031e84c745a3bdd157', 1467289325.0, 319280318),
+            (32, '16a59e93e919174fcd4e70e5b3289201c1016c72', 1467289329.0, 319280319),
+            (33, '9d03eeea7e3186ca8e5c150b4cbf18c8283cca9d', 1467289371.0, 319280320),
+            (34, '2e61e72b64c9084f3c5a36671c3119641c3ae42f', 1467370372.0, 319280321),
+            (35, '563e8e9d3f477cbfd04eef0af3a72af51ab6d72b', 1467370373.0, 319280322),
+            (35, '563e8e9d3f477cbfd04eef0af3a72af51ab6d72b', 1467370374.0, 319280323)
+        ]
 
         self.assertEqual(len(messages), len(expected))
 
@@ -142,11 +146,30 @@ class TestTelegramBackend(unittest.TestCase):
             self.assertEqual(message['category'], 'message')
             self.assertEqual(message['tag'], 'https://telegram.org/' + TELEGRAM_BOT)
 
+        # check that the only the message is marked as edited
+        message = messages[0]
+        self.assertNotIn('edited', message['data']['message'])
+
+        message = messages[1]
+        self.assertNotIn('edited', message['data']['message'])
+
+        message = messages[2]
+        self.assertNotIn('edited', message['data']['message'])
+
+        message = messages[3]
+        self.assertNotIn('edited', message['data']['message'])
+
+        message = messages[4]
+        self.assertNotIn('edited', message['data']['message'])
+
+        message = messages[5]
+        self.assertTrue(message['data']['message']['edited'])
+
         # Check requests
         expected = [
             {'offset': ['1']},
             {'offset': ['319280321']},
-            {'offset': ['319280322']}
+            {'offset': ['319280324']}
         ]
 
         self.assertEqual(len(http_requests), len(expected))
@@ -199,21 +222,28 @@ class TestTelegramBackend(unittest.TestCase):
         tlg = Telegram(TELEGRAM_BOT, TELEGRAM_TOKEN)
         messages = [msg for msg in tlg.fetch(offset=319280321)]
 
-        self.assertEqual(len(messages), 1)
+        expected = [
+            (34, '2e61e72b64c9084f3c5a36671c3119641c3ae42f', 1467370372.0, 319280321),
+            (35, '563e8e9d3f477cbfd04eef0af3a72af51ab6d72b', 1467370373.0, 319280322),
+            (35, '563e8e9d3f477cbfd04eef0af3a72af51ab6d72b', 1467370374.0, 319280323)
+        ]
 
-        msg = messages[0]
-        self.assertEqual(msg['data']['message']['message_id'], 34)
-        self.assertEqual(msg['origin'], 'https://telegram.org/' + TELEGRAM_BOT)
-        self.assertEqual(msg['uuid'], '2e61e72b64c9084f3c5a36671c3119641c3ae42f')
-        self.assertEqual(msg['updated_on'], 1467370372.0)
-        self.assertEqual(msg['offset'], 319280321)
-        self.assertEqual(msg['category'], 'message')
-        self.assertEqual(msg['tag'], 'https://telegram.org/' + TELEGRAM_BOT)
+        self.assertEqual(len(messages), len(expected))
+
+        for x in range(len(messages)):
+            message = messages[x]
+            self.assertEqual(message['data']['message']['message_id'], expected[x][0])
+            self.assertEqual(message['origin'], 'https://telegram.org/' + TELEGRAM_BOT)
+            self.assertEqual(message['uuid'], expected[x][1])
+            self.assertEqual(message['updated_on'], expected[x][2])
+            self.assertEqual(message['offset'], expected[x][3])
+            self.assertEqual(message['category'], 'message')
+            self.assertEqual(message['tag'], 'https://telegram.org/' + TELEGRAM_BOT)
 
         # Check requests
         expected = [
             {'offset': ['319280321']},
-            {'offset': ['319280322']}
+            {'offset': ['319280324']}
         ]
 
         self.assertEqual(len(http_requests), len(expected))
@@ -261,7 +291,7 @@ class TestTelegramBackend(unittest.TestCase):
         http_requests = setup_http_server()
 
         tlg = Telegram(TELEGRAM_BOT, TELEGRAM_TOKEN)
-        messages = [msg for msg in tlg.fetch(offset=319280322)]
+        messages = [msg for msg in tlg.fetch(offset=319280324)]
 
         self.assertEqual(len(messages), 0)
 
@@ -269,7 +299,7 @@ class TestTelegramBackend(unittest.TestCase):
         self.assertEqual(len(http_requests), 1)
 
         self.assertDictEqual(http_requests[0].querystring,
-                             {'offset': ['319280322']})
+                             {'offset': ['319280324']})
 
     def test_parse_messages(self):
         """Test whether the method parses a raw file"""


### PR DESCRIPTION
This issue address #614, thus it handles the edited messages in Telegram. In a nutshell, the edited information is included in a message and the latter is marked as edited (using the boolean attribute `edited` within the message).

Tests have been added accordingly.

Backend version is now 0.11.1