### PR TITLE
[doc] Fix broken link in README

### DIFF
--- a/docker/images/README.md
+++ b/docker/images/README.md
@@ -29,7 +29,7 @@ docker run --rm -it --name perceval -v ~/.perceval:/root/.perceval grimoirelab/p
 
 ### Documentation
 
-All the information regarding the image generation is hosted publicly in [Github](https://github.com/grimoirelab/perceval/tree/master/images/perceval).
+All the information regarding the image generation is hosted publicly in [Github](https://github.com/chaoss/grimoirelab-perceval/tree/master/docker/images).
 
 ### Issues
 


### PR DESCRIPTION
This commit fixes broken link in
README.md of docker/images

Signed-off-by: animesh <animuz111@gmail.com>