### PR TITLE
[groupsio] Format from_date with utc+0 timezone

### DIFF
--- a/perceval/backends/core/groupsio.py
+++ b/perceval/backends/core/groupsio.py
@@ -23,6 +23,7 @@ import logging
 import os
 import requests
 
+from grimoirelab_toolkit.datetime import datetime_to_utc
 from grimoirelab_toolkit.uris import urijoin
 
 from .mbox import MBox, MailingList, CATEGORY_MESSAGE
@@ -65,7 +66,7 @@ class Groupsio(MBox):
     :param archive: archive to store/retrieve items
     :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.4.0'
+    version = '0.4.1'
 
     CATEGORIES = [CATEGORY_MESSAGE]
 
@@ -206,7 +207,7 @@ class GroupsioClient(MailingList):
         }
 
         if from_date:
-            payload['start_time'] = from_date.isoformat()
+            payload['start_time'] = datetime_to_utc(from_date).isoformat()
 
         filepath = os.path.join(self.dirpath, MBOX_FILE)
         success = self._download_archive(url, payload, filepath)

--- a/tests/test_groupsio.py
+++ b/tests/test_groupsio.py
@@ -327,7 +327,7 @@ class TestGroupsioClient(unittest.TestCase):
             },
             {
                 'group_id': ['7769'],
-                'start_time': ['2019-01-01T00:00:00']
+                'start_time': ['2019-01-01T00:00:00 00:00']
             }
         ]
 


### PR DESCRIPTION
This code forces the format of the from_date value to utc+0 timezone. This change is needed since the groupsio API expects to receive a start date with tzinfo.

Backend version is 0.4.1.
Tests have been updated accordingly.