### PR TITLE
[perceval] Update license and copyright information

### DIFF
--- a/bin/perceval
+++ b/bin/perceval
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,7 +17,16 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
+#     Alvaro del Castillo <acs@bitergia.com>
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Luis Cañas Díaz <lcanas@bitergia.com>
+#     Alberto Martín <alberto.martin@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Jesus M. Gonzalez-Barahona <jgb@gsyc.es>
+#     MalloZup <dmaiocchi@suse.com>
+#     Venu Vardhan Reddy Tekula <venuvardhanreddytekula8@gmail.com>
+#     animesh <animuz111@gmail.com>
 #
 
 import argparse

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,6 +19,11 @@
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
 #     Jesus M. Gonzalez-Barahona <jgb@gsyc.es>
+#     Alvaro del Castillo <acs@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     David Pose Fernández <dpose@bitergia.com>
 #
 
 import codecs

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/mocked_package/backend.py
+++ b/tests/mocked_package/backend.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>..
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Valerio Cosentino <valcos@bitergia.com>

--- a/tests/mocked_package/nested_package/nested_backend_b.py
+++ b/tests/mocked_package/nested_package/nested_backend_b.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>..
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Valerio Cosentino <valcos@bitergia.com>

--- a/tests/mocked_package/nested_package/nested_backend_c.py
+++ b/tests/mocked_package/nested_package/nested_backend_c.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>..
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Valerio Cosentino <valcos@bitergia.com>

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +17,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
+#     Valerio Cosentino <valcos@bitergia.com>
 #     Santiago Dueñas <sduenas@bitergia.com>
 #
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,6 +19,8 @@
 # Authors:
 #     Valerio Cosentino <valcos@bitergia.com>
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Jesus M. Gonzalez-Barahona <jgb@gsyc.es>
 #
 
 import os

--- a/tests/test_askbot.py
+++ b/tests/test_askbot.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +18,11 @@
 #
 # Authors:
 #     Alberto Martín <alberto.martin@bitergia.com>
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import datetime

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,10 +14,15 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>..
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
+#     Valerio Cosentino <valcos@bitergia.com>
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Jesus M. Gonzalez-Barahona <jgb@gsyc.es>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
+#     JJMerchante <jj.merchante@gmail.com>
 #
 
 import argparse

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,6 +18,10 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import copy

--- a/tests/test_bugzillarest.py
+++ b/tests/test_bugzillarest.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,6 +18,10 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import copy

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,6 +18,9 @@
 #
 # Authors:
 #     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Jesus M. Gonzalez-Barahona <jgb@gsyc.es>
 #
 
 import os

--- a/tests/test_confluence.py
+++ b/tests/test_confluence.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +18,11 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Maurizio Pillitu <maoo@apache.org>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import datetime

--- a/tests/test_discourse.py
+++ b/tests/test_discourse.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,8 +18,11 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import datetime

--- a/tests/test_dockerhub.py
+++ b/tests/test_dockerhub.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +18,10 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Jesus M. Gonzalez-Barahona <jgb@gsyc.es>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import datetime

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,6 +18,9 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
 #
 
 import unittest

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,6 +18,9 @@
 #
 # Authors:
 #     Valerio Cosentino <valcos@bitergia.com>
+#     Prabhat <prabhatsharma7298@gmail.com>
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import datetime

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,6 +18,13 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Israel Herraiz <israel.herraiz@bbvadata.com>
+#     Jesus M. Gonzalez-Barahona <jgb@gsyc.es>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     anveshc05 <anveshc10047@gmail.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
+#     Victor Morales <victor.morales@intel.com>
 #
 
 import datetime

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,6 +18,17 @@
 #
 # Authors:
 #     Quan Zhou <quan@bitergia.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Jesus M. Gonzalez-Barahona <jgb@gsyc.es>
+#     Lukasz Gryglicki <lukaszgryglicki@o2.pl>
+#     David Pose Fernández <dpose@bitergia.com>
+#     Alvaro del Castillo <acs@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#     Cedric Williams <cewilliams@paypal.com>
+#     JJMerchante <jj.merchante@gmail.com>
 #
 
 import datetime

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,6 +19,11 @@
 # Authors:
 #     Assad Montasser <assad.montasser@ow2.org>
 #     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Jesus M. Gonzalez-Barahona <jgb@gsyc.es>
+#     Harshal Mittal <harshalmittal4@gmail.com>
+#     JJMerchante <jj.merchante@gmail.com>
 #
 
 import copy

--- a/tests/test_googlehits.py
+++ b/tests/test_googlehits.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +18,7 @@
 #
 # Authors:
 #     Valerio Cosentino <valcos@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import datetime

--- a/tests/test_groupsio.py
+++ b/tests/test_groupsio.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +18,8 @@
 #
 # Authors:
 #     Valerio Cosentino <valcos@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
+#     Santiago Dueñas <sduenas@bitergia.com>
 #
 
 import datetime

--- a/tests/test_hyperkitty.py
+++ b/tests/test_hyperkitty.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +18,9 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import datetime

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,7 +18,11 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
 #     Alvaro del Castillo <acs@bitergia.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import json

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,6 +19,12 @@
 # Authors:
 #     Alberto Martín <alberto.martin@bitergia.com>
 #     Quan Zhou <quan@bitergia.com>
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Jesus M. Gonzalez-Barahona <jgb@gsyc.es>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import json

--- a/tests/test_launchpad.py
+++ b/tests/test_launchpad.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,6 +18,9 @@
 #
 # Authors:
 #     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import datetime

--- a/tests/test_mattermost.py
+++ b/tests/test_mattermost.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +18,8 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import datetime

--- a/tests/test_mbox.py
+++ b/tests/test_mbox.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,6 +18,10 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import bz2

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,6 +19,11 @@
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
 #     Alvaro del Castillo <acs@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Jesus M. Gonzalez-Barahona <jgb@gsyc.es>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import datetime

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +18,10 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import copy

--- a/tests/test_nntp.py
+++ b/tests/test_nntp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,6 +18,9 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import collections

--- a/tests/test_phabricator.py
+++ b/tests/test_phabricator.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +18,10 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import copy

--- a/tests/test_pipermail.py
+++ b/tests/test_pipermail.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +18,11 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Quan Zhou <quan@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import datetime

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +18,10 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import copy

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,8 +17,12 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
-#     Santiago Dueñas <sduenas@bitergia.com>
 #     Alvaro del Castillo <acs@bitergia.com>
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import httpretty

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +18,9 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import copy

--- a/tests/test_stackexchange.py
+++ b/tests/test_stackexchange.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,6 +18,11 @@
 #
 # Authors:
 #     Quan Zhou <quan@bitergia.com>
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import copy

--- a/tests/test_supybot.py
+++ b/tests/test_supybot.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +18,10 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import datetime

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +18,10 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import httpretty

--- a/tests/test_twitter.py
+++ b/tests/test_twitter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,6 +18,8 @@
 #
 # Authors:
 #     Valerio Cosentino <valcos@bitergia.com>
+#     Jesus M. Gonzalez-Barahona <jgb@gsyc.es>
+#     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
 import datetime

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,6 +18,9 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Stephan Barth <stephan.barth@gmail.com>
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
 #
 
 import bz2


### PR DESCRIPTION
This PR updates license information for the remaining source code files in Perceval. 
This is an extension of #623.

I tried updating this using the tool, [vchrombie/grimoirelab-scripts](https://github.com/vchrombie/grimoirelab-scripts).