### PR TITLE
[backend] Add missing sanitize for archive

### DIFF
--- a/perceval/backends/core/discourse.py
+++ b/perceval/backends/core/discourse.py
@@ -65,7 +65,7 @@ class Discourse(Backend):
         of connection problems
     :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.13.0'
+    version = '0.13.1'
 
     CATEGORIES = [CATEGORY_TOPIC]
     EXTRA_SEARCH_FIELDS = {
@@ -401,6 +401,26 @@ class DiscourseClient(HttpClient):
 
         r = self.fetch(url, payload=params)
         return r.text
+
+    @staticmethod
+    def sanitize_for_archive(url, headers, payload):
+        """Sanitize payload of a HTTP request by removing the user
+        and key information before storing/retrieving archived items
+
+        :param: url: HTTP url request
+        :param: headers: HTTP headers request
+        :param: payload: HTTP payload request
+
+        :returns url, headers and the sanitized payload
+        """
+        if not headers:
+            return url, headers, payload
+
+        if DiscourseClient.HUSER and DiscourseClient.HKEY in headers:
+            headers.pop(DiscourseClient.HUSER, None)
+            headers.pop(DiscourseClient.HKEY, None)
+
+        return url, headers, payload
 
 
 class DiscourseCommand(BackendCommand):

--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -103,7 +103,7 @@ class GitHub(Backend):
         of connection problems
     :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.25.1'
+    version = '0.25.2'
 
     CATEGORIES = [CATEGORY_ISSUE, CATEGORY_PULL_REQUEST, CATEGORY_REPO]
 
@@ -1004,6 +1004,25 @@ class GitHubClient(HttpClient, RateLimitHandler):
         headers = {}
         headers.update({self.HACCEPT: self.VACCEPT})
         return headers
+
+    @staticmethod
+    def sanitize_for_archive(url, headers, payload):
+        """Sanitize payload of a HTTP request by removing the
+        token information before storing/retrieving archived items
+
+        :param: url: HTTP url request
+        :param: headers: HTTP headers request
+        :param: payload: HTTP payload request
+
+        :returns url, headers and the sanitized payload
+        """
+        if not headers:
+            return url, headers, payload
+
+        if GitHubClient.HAUTHORIZATION in headers:
+            headers.pop(GitHubClient.HAUTHORIZATION, None)
+
+        return url, headers, payload
 
 
 class GitHubCommand(BackendCommand):

--- a/perceval/backends/core/mattermost.py
+++ b/perceval/backends/core/mattermost.py
@@ -73,7 +73,7 @@ class Mattermost(Backend):
         of connection problems
     :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.4.0'
+    version = '0.4.1'
 
     CATEGORIES = [CATEGORY_POST]
     EXTRA_SEARCH_FIELDS = {
@@ -409,6 +409,25 @@ class MattermostClient(HttpClient, RateLimitHandler):
             self.HAUTHORIZATION: 'Bearer ' + self.api_token
         }
         return headers
+
+    @staticmethod
+    def sanitize_for_archive(url, headers, payload):
+        """Sanitize payload of a HTTP request by removing the
+        token information before storing/retrieving archived items.
+
+        :param: url: HTTP url request
+        :param: headers: HTTP headers request
+        :param: payload: HTTP payload request
+
+        :returns url, headers and the sanitized payload
+        """
+        if not headers:
+            return url, headers, payload
+
+        if MattermostClient.HAUTHORIZATION in headers:
+            headers.pop(MattermostClient.HAUTHORIZATION, None)
+
+        return url, headers, payload
 
 
 class MattermostCommand(BackendCommand):

--- a/perceval/backends/core/pagure.py
+++ b/perceval/backends/core/pagure.py
@@ -67,7 +67,7 @@ class Pagure(Backend):
         of connection problems
     :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.1.1'
+    version = '0.1.2'
 
     CATEGORIES = [CATEGORY_ISSUE]
 
@@ -386,6 +386,25 @@ class PagureClient(HttpClient):
         """Build URL for a repository"""
 
         return urijoin(self.base_url, self.repository)
+
+    @staticmethod
+    def sanitize_for_archive(url, headers, payload):
+        """Sanitize payload of a HTTP request by removing the
+        token information before storing/retrieving archived items
+
+        :param: url: HTTP url request
+        :param: headers: HTTP headers request
+        :param: payload: HTTP payload request
+
+        :returns url, headers and the sanitized payload
+        """
+        if not headers:
+            return url, headers, payload
+
+        if PagureClient.HAUTHORIZATION in headers:
+            headers.pop(PagureClient.HAUTHORIZATION, None)
+
+        return url, headers, payload
 
 
 class PagureCommand(BackendCommand):

--- a/tests/test_discourse.py
+++ b/tests/test_discourse.py
@@ -29,6 +29,7 @@ import datetime
 import os
 import shutil
 import unittest
+import copy
 
 import httpretty
 import pkg_resources
@@ -991,6 +992,25 @@ class TestDiscourseClient(unittest.TestCase):
         self.assertDictEqual(req.querystring, {})
         self.assertEqual(req.headers[DiscourseClient.HKEY], 'aaaa')
         self.assertEqual(req.headers[DiscourseClient.HUSER], 'user')
+
+    def test_sanitize_for_archive(self):
+        """Test whether the sanitize method works properly"""
+
+        url = "http://example.com"
+        headers = {
+            DiscourseClient.HUSER: 'user',
+            DiscourseClient.HKEY: 'aaaa'
+        }
+        c_headers = copy.deepcopy(headers)
+        payload = {}
+
+        san_u, san_h, san_p = DiscourseClient.sanitize_for_archive(url, c_headers, payload)
+        headers.pop(DiscourseClient.HUSER)
+        headers.pop(DiscourseClient.HKEY)
+
+        self.assertEqual(url, san_u)
+        self.assertEqual(headers, san_h)
+        self.assertEqual(payload, san_p)
 
 
 class TestDiscourseCommand(unittest.TestCase):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -37,6 +37,7 @@ import os
 import time
 import unittest
 import unittest.mock
+import copy
 
 import httpretty
 import pkg_resources
@@ -4104,6 +4105,21 @@ class TestGitHubClient(unittest.TestCase):
 
         self.assertDictEqual(httpretty.last_request().querystring, expected)
         self.assertEqual(httpretty.last_request().headers["Authorization"], "token aaa")
+
+    def test_sanitize_for_archive(self):
+        """Test whether the sanitize method works properly"""
+
+        url = "http://example.com"
+        headers = {GitHubClient.HAUTHORIZATION: "token aaa"}
+        c_headers = copy.deepcopy(headers)
+        payload = {}
+
+        san_u, san_h, san_p = GitHubClient.sanitize_for_archive(url, c_headers, payload)
+        headers.pop(GitHubClient.HAUTHORIZATION)
+
+        self.assertEqual(url, san_u)
+        self.assertEqual(headers, san_h)
+        self.assertEqual(payload, san_p)
 
 
 class TestGitHubCommand(unittest.TestCase):

--- a/tests/test_mattermost.py
+++ b/tests/test_mattermost.py
@@ -25,6 +25,7 @@
 import datetime
 import os
 import unittest
+import copy
 
 import httpretty
 import pkg_resources
@@ -620,6 +621,21 @@ class TestMattermostClient(unittest.TestCase):
         time_to_reset = client.calculate_time_to_reset()
 
         self.assertEqual(time_to_reset, 0)
+
+    def test_sanitize_for_archive(self):
+        """Test whether the sanitize method works properly"""
+
+        url = "http://example.com"
+        headers = {MattermostClient.HAUTHORIZATION: 'Bearer aaaa'}
+        c_headers = copy.deepcopy(headers)
+        payload = {}
+
+        san_u, san_h, san_p = MattermostClient.sanitize_for_archive(url, c_headers, payload)
+        headers.pop(MattermostClient.HAUTHORIZATION)
+
+        self.assertEqual(url, san_u)
+        self.assertEqual(headers, san_h)
+        self.assertEqual(payload, san_p)
 
 
 if __name__ == "__main__":

--- a/tests/test_pagure.py
+++ b/tests/test_pagure.py
@@ -27,6 +27,7 @@ import httpretty
 import pkg_resources
 import requests
 import dateutil.tz
+import copy
 
 pkg_resources.declare_namespace('perceval.backends')
 
@@ -625,6 +626,21 @@ class TestPagureClient(unittest.TestCase):
 
         self.assertDictEqual(httpretty.last_request().querystring, expected)
         self.assertEqual(httpretty.last_request().headers["Authorization"], "token aaa")
+
+    def test_sanitize_for_archive(self):
+        """Test whether the sanitize method works properly"""
+
+        url = "http://example.com"
+        headers = {PagureClient.HAUTHORIZATION: "token aaa"}
+        c_headers = copy.deepcopy(headers)
+        payload = {}
+
+        san_u, san_h, san_p = PagureClient.sanitize_for_archive(url, c_headers, payload)
+        headers.pop(PagureClient.HAUTHORIZATION)
+
+        self.assertEqual(url, san_u)
+        self.assertEqual(headers, san_h)
+        self.assertEqual(payload, san_p)
 
 
 class TestPagureCommand(unittest.TestCase):


### PR DESCRIPTION
Fixes: #638 
This commit adds missing method to sanitize the payload
of a HTTP request before storing/retrieving archived items
to some of the backends that required it.

Signed-off-by: Animesh Kumar <animuz111@gmail.com>