### PR TITLE
[github] Fetch issue/pull request events

### DIFF
--- a/tests/data/github/github_events
+++ b/tests/data/github/github_events
@@ -1,0 +1,52 @@
+{
+    "data": {
+        "repository": {
+            "issue": {
+                "timelineItems": {
+                    "nodes": [
+                        {
+                            "actor": {
+                                "login": "valeriocos"
+                            },
+                            "createdAt": "2020-04-07T13:22:48Z",
+                            "eventType": "MovedColumnsInProjectEvent",
+                            "id": "MDI2Ok1vdmVkQ29sdW1uc0luUHJvamVjdEV2ZW50MzIwOTgzMzI1NA==",
+                            "previousProjectColumnName": "analysis",
+                            "project": {
+                                "closedAt": null,
+                                "createdAt": "2020-04-07T11:41:41Z",
+                                "name": "my fantastic board",
+                                "state": "OPEN",
+                                "updatedAt": "2020-04-07T13:23:03Z",
+                                "url": "https://github.com/valeriocos/test-issues-update/projects/1"
+                            },
+                            "projectColumnName": "doing"
+                        },
+                        {
+                            "actor": {
+                                "login": "valeriocos"
+                            },
+                            "createdAt": "2020-04-07T13:23:03Z",
+                            "eventType": "CrossReferencedEvent",
+                            "id": "MDI2Ok1vdmVkQ29sdW1uc0luUHJvamVjdEV2ZW50MzIwOTgzNDMzMQ==",
+                            "isCrossRepository": false,
+                            "source": {
+                                "createdAt": "2020-04-07T10:31:07Z",
+                                "number": 2,
+                                "type": "Issue",
+                                "updatedAt": "2020-04-07T10:34:26Z",
+                                "url": "https://github.com/valeriocos/test-issues-update/issues/2"
+                            },
+                            "url": "https://github.com/valeriocos/test-issues-update/issues/1#ref-issue-595767496",
+                            "willCloseTarget": false
+                        }
+                    ],
+                    "pageInfo": {
+                        "endCursor": "Y3Vyc29yOnYyOpPPAAABcVTO-tgBqjMyMDk4MzQzMzE=",
+                        "hasNextPage": false
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/data/github/github_events_error
+++ b/tests/data/github/github_events_error
@@ -1,0 +1,13 @@
+{
+    "errors": [
+        {
+            "locations": [
+                {
+                    "column": 80,
+                    "line": 7
+                }
+            ],
+            "message": "Parse error on \"=\" (EQUALS) at [7, 80]"
+        }
+    ]
+}


### PR DESCRIPTION
This code adds a new category to fetch the following event types from issues and pull
requests:
- ADDED_TO_PROJECT_EVENT
- MOVED_COLUMNS_IN_PROJECT_EVENT
- REMOVED_FROM_PROJECT_EVENT
- CROSS_REFERENCED_EVENT
- LABELED_EVENT
- UNLABELED_EVENT
- CLOSED_EVENT

Due to the limitation of not fetching events after a given date from the endpoint `timeline`
of GitHub v3, the events are fetched via the GitHub v4 (based on GraphQL).

The events are fetched in the following way. The issues of a given tracker are retrieved in
ascending order based on the last time they were updated. For each issue, its events (optionally
from/to a given date) are collected using a GraphQL call. Each event is returned by Perceval together with the corresponding issue (available in `data.issue`).

No user information beyond the `login` is included in data returned by Perceval for this category. Thus, the filter classified support has no effect when fetching events.

The backend can be executed in the following way:
```
perceval github chaoss grimoirelab-toolkit
--category event -t xxx
--sleep-for-rate
--no-archive
--from-date 2019-01-01
```

Tests have been added accordingly.
Backend version is now 0.26.0