### PR TITLE
[perceval] Add githubql backend

### DIFF
--- a/perceval/backends/core/githubql.py
+++ b/perceval/backends/core/githubql.py
@@ -1,0 +1,460 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Valerio Cosentino <valcos@bitergia.com>
+#
+
+import json
+import logging
+
+from grimoirelab_toolkit.datetime import (datetime_to_utc,
+                                          str_to_datetime)
+from grimoirelab_toolkit.uris import urijoin
+
+from perceval.backends.core.github import (GitHub,
+                                           GitHubClient,
+                                           GitHubCommand,
+                                           DEFAULT_SLEEP_TIME,
+                                           MIN_RATE_LIMIT,
+                                           MAX_RETRIES,
+                                           MAX_CATEGORY_ITEMS_PER_PAGE)
+from ...client import HttpClient
+from ...utils import DEFAULT_DATETIME, DEFAULT_LAST_DATETIME
+
+CATEGORY_EVENT = "event"
+
+GITHUB_API_URL = "https://api.github.com"
+
+EVENT_TYPES = [
+    'ADDED_TO_PROJECT_EVENT',
+    'MOVED_COLUMNS_IN_PROJECT_EVENT',
+    'REMOVED_FROM_PROJECT_EVENT',
+    'CROSS_REFERENCED_EVENT',
+    'LABELED_EVENT',
+    'UNLABELED_EVENT',
+    'CLOSED_EVENT'
+]
+
+QUERY_TEMPLATE = """
+    {
+      repository (owner: "%s"
+                  name: "%s") {
+        %s (number: %s) {
+          timelineItems (first: %s
+                         after: %s
+                         itemTypes: %s
+                         since: "%s") {
+              nodes {
+                eventType: __typename
+                ... on CrossReferencedEvent {
+                  actor {
+                    login
+                  }
+                  id
+                  createdAt
+                  isCrossRepository
+                  willCloseTarget
+                  url
+                  source {
+                    type:__typename
+                    ... on Issue {
+                      number
+                      url
+                      createdAt
+                      updatedAt
+                      closed
+                      closedAt
+                    },
+                    ... on PullRequest {
+                      number
+                      url
+                      createdAt
+                      updatedAt
+                      closed
+                      closedAt
+                      merged
+                      mergedAt
+                    }
+                  }
+                }
+                ... on ClosedEvent {
+                  actor {
+                    login
+                  }
+                  id
+                  createdAt
+                  url
+                  closer {
+                    type:__typename
+                    ... on PullRequest {
+                      number
+                      url
+                      createdAt
+                      updatedAt
+                      closed
+                      closedAt
+                      merged
+                      mergedAt
+                    }
+                  }
+                }
+                ... on LabeledEvent {
+                  actor {
+                    login
+                  }
+                  id
+                  createdAt
+                  label {
+                    name
+                    description
+                    createdAt
+                    isDefault
+                    updatedAt
+                  }
+                }
+                ... on UnlabeledEvent {
+                  actor {
+                    login
+                  }
+                  id
+                  createdAt
+                  label {
+                    name
+                    description
+                    createdAt
+                    isDefault
+                    updatedAt
+                  }
+                }
+                ... on AddedToProjectEvent {
+                  actor {
+                    login
+                  }
+                  id
+                  createdAt
+                  projectColumnName,
+                  project {
+                    name
+                    url
+                    createdAt
+                    updatedAt
+                    closedAt
+                    state
+                  }
+                }
+                ... on MovedColumnsInProjectEvent {
+                  actor {
+                    login
+                  },
+                  id
+                  createdAt
+                  previousProjectColumnName
+                  projectColumnName
+                  project {
+                    name
+                    url
+                    createdAt
+                    updatedAt
+                    closedAt
+                    state
+                  }
+                }
+                ... on RemovedFromProjectEvent {
+                  actor {
+                    login
+                  },
+                  id
+                  createdAt
+                  projectColumnName
+                  project {
+                    name
+                    url
+                    createdAt
+                    updatedAt
+                    closedAt
+                    state
+                  }
+                }
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+          }
+        }
+      }
+    }
+    """
+
+logger = logging.getLogger(__name__)
+
+
+class GitHubQL(GitHub):
+    """GitHubQL backend for Perceval using the GitHub API v4.
+    Most of the methods are inherited from the GitHub backend.
+
+    This class allows the fetch the issue events of a GitHub
+    repository. Note that the events retrieved included also the
+    ones of pull requests, since in GitHub, every pull request
+    is an issue, but an issue may not be a pull request. Pull
+    requests can be identified by the attribute `pull_request`
+    included in `data.issue`.
+
+    Due to the limitation of not fetching issue events after a
+    given date from GitHub v3, the events are fetched via the
+    GitHub v4 (based on GraphQL).
+
+    All issues of a given tracker are retrieved in ascending order
+    based on the last time they were updated. For each issue, its
+    events (optionally from/until a given date) are collected using
+    a GraphQL call. Each event is returned by Perceval together
+    with the corresponding issue (available in data.issue).
+
+    Since the events are collected issue by issue, the incremental
+    fetching is not supported. This limitation is due to the fact
+    that events that occur on an issue may not update the issue
+    attributes. Since there is no way to identify new events from
+    the attributes of an issue, all issues must be fetched for
+    every execution.
+
+    No user information beyond the login is included in data
+    returned by this backend. Thus, the backend doesn't require
+    filter classified support.
+
+    :param owner: GitHub owner
+    :param repository: GitHub repository from the owner
+    :param api_token: list of GitHub auth tokens to access the API
+    :param base_url: GitHub URL in enterprise edition case;
+        when no value is set the backend will be fetch the data
+        from the GitHub public site.
+    :param tag: label used to mark the data
+    :param archive: archive to store/retrieve items
+    :param sleep_for_rate: sleep until rate limit is reset
+    :param min_rate_to_sleep: minimum rate needed to sleep until
+         it will be reset
+    :param max_retries: number of max retries to a data source
+        before raising a RetryError exception
+    :param max_items: max number of category items per query
+    :param sleep_time: time to sleep in case
+        of connection problems
+    :param ssl_verify: enable/disable SSL verification
+    """
+    version = '0.1.0'
+
+    CATEGORIES = [CATEGORY_EVENT]
+
+    def __init__(self, owner=None, repository=None,
+                 api_token=None, base_url=None,
+                 tag=None, archive=None,
+                 sleep_for_rate=False, min_rate_to_sleep=MIN_RATE_LIMIT,
+                 max_retries=MAX_RETRIES, sleep_time=DEFAULT_SLEEP_TIME,
+                 max_items=MAX_CATEGORY_ITEMS_PER_PAGE, ssl_verify=True):
+        super().__init__(owner, repository, api_token, base_url, tag, archive,
+                         sleep_for_rate, min_rate_to_sleep, max_retries,
+                         sleep_time, max_items, ssl_verify)
+
+    def fetch(self, category=CATEGORY_EVENT, from_date=DEFAULT_DATETIME, to_date=DEFAULT_LAST_DATETIME):
+        """Fetch the issue events from the repository.
+
+        The method retrieves, from a GitHub repository, the issue events
+        since/until a given date.
+
+        :param category: the category of items to fetch
+        :param from_date: obtain issue events since this date
+        :param to_date: obtain issue events until this date (included)
+
+        :returns: a generator of events
+        """
+        if not from_date:
+            from_date = DEFAULT_DATETIME
+        if not to_date:
+            to_date = DEFAULT_LAST_DATETIME
+
+        from_date = datetime_to_utc(from_date)
+        to_date = datetime_to_utc(to_date)
+
+        kwargs = {
+            'from_date': from_date,
+            'to_date': to_date
+        }
+        items = super().fetch(category, **kwargs)
+
+        return items
+
+    def fetch_items(self, category, **kwargs):
+        """Fetch the items
+
+        :param category: the category of items to fetch
+        :param kwargs: backend arguments
+
+        :returns: a generator of items
+        """
+        from_date = kwargs['from_date']
+        to_date = kwargs['to_date']
+
+        items = self.__fetch_events(from_date, to_date)
+
+        return items
+
+    @classmethod
+    def has_resuming(cls):
+        """Returns whether it supports to resume the fetch process.
+
+        :returns: this backend doesn't support items resuming
+        """
+        return False
+
+    @staticmethod
+    def metadata_id(item):
+        """Extracts the identifier from a GitHub item."""
+
+        return str(item['id'])
+
+    @staticmethod
+    def metadata_updated_on(item):
+        """Extracts the update time from a GitHub item.
+
+        The timestamp used is extracted from 'createdAt' field.
+        This date is converted to UNIX timestamp format. As GitHub
+        dates are in UTC the conversion is straightforward.
+
+        :param item: item generated by the backend
+
+        :returns: a UNIX timestamp
+        """
+        ts = item['createdAt']
+        ts = str_to_datetime(ts)
+
+        return ts.timestamp()
+
+    @staticmethod
+    def metadata_category(item):
+        """Extracts the category from a GitHub item.
+
+        This backend generates one type item which is
+        'event'.
+        """
+        return CATEGORY_EVENT
+
+    def _init_client(self, from_archive=False):
+        """Init client"""
+
+        return GitHubQLClient(self.owner, self.repository, self.api_token, self.base_url,
+                              self.sleep_for_rate, self.min_rate_to_sleep,
+                              self.sleep_time, self.max_retries, self.max_items,
+                              self.archive, from_archive, self.ssl_verify)
+
+    def __fetch_events(self, from_date, to_date):
+        """Fetch the events declared at EVENT_TYPES for issues (including pull requests)"""
+
+        issues_groups = self.client.issues()
+
+        for raw_issues in issues_groups:
+            issues = json.loads(raw_issues)
+            for issue in issues:
+                issue_number = issue['number']
+
+                is_pull = 'pull_request' in issue
+                events_groups = self.client.events(issue_number, is_pull, from_date)
+                for events in events_groups:
+                    for event in events:
+
+                        if str_to_datetime(event['createdAt']) > to_date:
+                            return
+
+                        event['issue'] = issue
+                        yield event
+
+
+class GitHubQLClient(GitHubClient):
+    """Client for retrieving information from GitHub API
+
+    :param owner: GitHub owner
+    :param repository: GitHub repository from the owner
+    :param tokens: list of GitHub auth tokens to access the API
+    :param base_url: GitHub URL in enterprise edition case;
+        when no value is set the backend will be fetch the data
+        from the GitHub public site.
+    :param sleep_for_rate: sleep until rate limit is reset
+    :param min_rate_to_sleep: minimum rate needed to sleep until
+         it will be reset
+    :param sleep_time: time to sleep in case
+        of connection problems
+    :param max_retries: number of max retries to a data source
+        before raising a RetryError exception
+    :param max_items: max number of category items (e.g., issues,
+        pull requests) per query
+    :param archive: collect events already retrieved from an archive
+    :param from_archive: it tells whether to write/read the archive
+    :param ssl_verify: enable/disable SSL verification
+    """
+    VACCEPT = 'application/vnd.github.squirrel-girl-preview,application/vnd.github.starfox-preview+json'
+
+    def __init__(self, owner, repository, tokens,
+                 base_url=None, sleep_for_rate=False, min_rate_to_sleep=MIN_RATE_LIMIT,
+                 sleep_time=DEFAULT_SLEEP_TIME, max_retries=MAX_RETRIES,
+                 max_items=MAX_CATEGORY_ITEMS_PER_PAGE, archive=None, from_archive=False, ssl_verify=True):
+        super().__init__(owner, repository, tokens, base_url, sleep_for_rate, min_rate_to_sleep,
+                         sleep_time, max_retries, max_items, archive, from_archive, ssl_verify)
+
+        if base_url:
+            graphql_url = urijoin(base_url, 'api', 'graphql')
+        else:
+            graphql_url = urijoin(GITHUB_API_URL, 'graphql')
+
+        self.graphql_url = graphql_url
+
+    def events(self, issue_number, is_pull, from_date):
+        """Get the issue events of the types declared at EVENT_TYPES from the GraphQL API
+
+        :param issue_number: number of the issue
+        :param is_pull: boolean value to identify a pull request
+        :param from_date: fetch events after a given date
+        """
+        node_type = 'pullRequest' if is_pull else 'issue'
+        event_types = '[{}]'.format(','.join(EVENT_TYPES))
+
+        query = QUERY_TEMPLATE % (self.owner, self.repository, node_type, issue_number,
+                                  self.VPER_PAGE, "null", event_types, from_date.isoformat())
+
+        has_next = True
+        while has_next:
+            response = self.fetch(self.graphql_url, payload=json.dumps({'query': query}), method=HttpClient.POST)
+
+            items = response.json()
+            if 'errors' in items:
+                logger.error("Events not collected for issue %s in %s/%s due to: %s" %
+                             (issue_number, self.owner, self.repository, items['errors'][0]['message']))
+                return []
+
+            timelines = items['data']['repository'][node_type]['timelineItems']
+            nodes = timelines['nodes']
+            yield nodes
+
+            page = timelines['pageInfo']
+            has_next = page['hasNextPage']
+            next_cursor = page['endCursor']
+
+            query = QUERY_TEMPLATE % (self.owner, self.repository, node_type, issue_number, self.VPER_PAGE,
+                                      '"{}"'.format(next_cursor), event_types, from_date.isoformat())
+
+
+class GitHubQLCommand(GitHubCommand):
+    """Class to run GitHubQL backend from the command line."""
+
+    BACKEND = GitHubQL

--- a/tests/data/github/github_events_error
+++ b/tests/data/github/github_events_error
@@ -1,0 +1,13 @@
+{
+    "errors": [
+        {
+            "locations": [
+                {
+                    "column": 80,
+                    "line": 7
+                }
+            ],
+            "message": "Parse error on \"=\" (EQUALS) at [7, 80]"
+        }
+    ]
+}

--- a/tests/data/github/github_events_page_1
+++ b/tests/data/github/github_events_page_1
@@ -1,0 +1,46 @@
+{
+    "data": {
+        "repository": {
+            "issue": {
+                "timelineItems": {
+                    "nodes": [
+                        {
+                            "actor": {
+                                "login": "valeriocos"
+                            },
+                            "createdAt": "2020-04-07T11:21:12Z",
+                            "eventType": "LabeledEvent",
+                            "id": "MDEyOkxhYmVsZWRFdmVudDMyMDkzOTI3NzU=",
+                            "label": {
+                                "createdAt": "2020-04-07T10:30:46Z",
+                                "description": "Something isn't working",
+                                "isDefault": true,
+                                "name": "bug",
+                                "updatedAt": "2020-04-07T10:30:46Z"
+                            }
+                        },
+                        {
+                            "actor": {
+                                "login": "valeriocos"
+                            },
+                            "createdAt": "2020-04-07T11:21:19Z",
+                            "eventType": "LabeledEvent",
+                            "id": "MDEyOkxhYmVsZWRFdmVudDMyMDkzOTMxMzI=",
+                            "label": {
+                                "createdAt": "2020-04-07T10:30:46Z",
+                                "description": "This issue or pull request already exists",
+                                "isDefault": true,
+                                "name": "duplicate",
+                                "updatedAt": "2020-04-07T10:30:46Z"
+                            }
+                        }
+                    ],
+                    "pageInfo": {
+                        "endCursor": "Y3Vyc29yOnYyOpPPAAABcVRfh5gBqjMyMDkzOTMxMzI=",
+                        "hasNextPage": true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/data/github/github_events_page_2
+++ b/tests/data/github/github_events_page_2
@@ -1,0 +1,52 @@
+{
+    "data": {
+        "repository": {
+            "issue": {
+                "timelineItems": {
+                    "nodes": [
+                        {
+                            "actor": {
+                                "login": "valeriocos"
+                            },
+                            "createdAt": "2020-04-07T13:22:48Z",
+                            "eventType": "MovedColumnsInProjectEvent",
+                            "id": "MDI2Ok1vdmVkQ29sdW1uc0luUHJvamVjdEV2ZW50MzIwOTgzMzI1NA==",
+                            "previousProjectColumnName": "analysis",
+                            "project": {
+                                "closedAt": null,
+                                "createdAt": "2020-04-07T11:41:41Z",
+                                "name": "my fantastic board",
+                                "state": "OPEN",
+                                "updatedAt": "2020-04-07T13:23:03Z",
+                                "url": "https://github.com/valeriocos/test-issues-update/projects/1"
+                            },
+                            "projectColumnName": "doing"
+                        },
+                        {
+                            "actor": {
+                                "login": "valeriocos"
+                            },
+                            "createdAt": "2020-04-07T13:23:03Z",
+                            "eventType": "CrossReferencedEvent",
+                            "id": "MDI2Ok1vdmVkQ29sdW1uc0luUHJvamVjdEV2ZW50MzIwOTgzNDMzMQ==",
+                            "isCrossRepository": false,
+                            "source": {
+                                "createdAt": "2020-04-07T10:31:07Z",
+                                "number": 2,
+                                "type": "Issue",
+                                "updatedAt": "2020-04-07T10:34:26Z",
+                                "url": "https://github.com/valeriocos/test-issues-update/issues/2"
+                            },
+                            "url": "https://github.com/valeriocos/test-issues-update/issues/1#ref-issue-595767496",
+                            "willCloseTarget": false
+                        }
+                    ],
+                    "pageInfo": {
+                        "endCursor": "Y3Vyc29yOnYyOpPPAAABcVTO-tgBqjMyMDk4MzQzMzE=",
+                        "hasNextPage": false
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/test_githubql.py
+++ b/tests/test_githubql.py
@@ -1,0 +1,664 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Valerio Cosentino <valcos@bitergia.com>
+#
+
+import datetime
+import os
+import unittest.mock
+
+import httpretty
+import pkg_resources
+
+pkg_resources.declare_namespace('perceval.backends')
+
+from perceval.client import RateLimitHandler
+from perceval.utils import DEFAULT_DATETIME
+from perceval.backends.core.githubql import (logger,
+                                             GitHubQL,
+                                             GitHubQLCommand,
+                                             GitHubQLClient,
+                                             CATEGORY_EVENT,
+                                             MAX_CATEGORY_ITEMS_PER_PAGE)
+from base import TestCaseBackendArchive
+
+
+GITHUB_API_URL = "https://api.github.com"
+GITHUB_API_GRAPHQL_URL = GITHUB_API_URL + "/graphql"
+GITHUB_RATE_LIMIT = GITHUB_API_URL + "/rate_limit"
+GITHUB_REPO_URL = GITHUB_API_URL + "/repos/zhquan_example/repo"
+GITHUB_ISSUES_URL = GITHUB_REPO_URL + "/issues"
+GITHUB_ENTERPRISE_URL = "https://example.com"
+GITHUB_ENTERPRISE_API_URL = "https://example.com/api/v3"
+GITHUB_ENTERPRISE_API_GRAPHQL_URL = GITHUB_ENTERPRISE_URL + "/api/graphql"
+GITHUB_ENTREPRISE_RATE_LIMIT = GITHUB_ENTERPRISE_API_URL + "/rate_limit"
+GITHUB_ENTREPRISE_REPO_URL = GITHUB_ENTERPRISE_API_URL + "/repos/zhquan_example/repo"
+GITHUB_ENTERPRISE_ISSUES_URL = GITHUB_ENTREPRISE_REPO_URL + "/issues"
+
+
+def read_file(filename, mode='r'):
+    with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), filename), mode) as f:
+        content = f.read()
+    return content
+
+
+class TestGitHubQLBackend(unittest.TestCase):
+    """ GitHubQL backend tests """
+
+    @httpretty.activate
+    def test_initialization(self):
+        """Test whether attributes are initialized"""
+
+        rate_limit = read_file('data/github/rate_limit')
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        github = GitHubQL('zhquan_example', 'repo', ['aaa'], tag='test')
+
+        self.assertEqual(github.owner, 'zhquan_example')
+        self.assertEqual(github.repository, 'repo')
+        self.assertEqual(github.origin, 'https://github.com/zhquan_example/repo')
+        self.assertEqual(github.tag, 'test')
+        self.assertEqual(github.max_items, MAX_CATEGORY_ITEMS_PER_PAGE)
+        self.assertFalse(github.exclude_user_data)
+        self.assertEqual(github.categories, [CATEGORY_EVENT])
+        self.assertTrue(github.ssl_verify)
+
+        # When tag is empty or None it will be set to the value in origin
+        github = GitHubQL('zhquan_example', 'repo', ['aaa'], ssl_verify=False)
+        self.assertEqual(github.owner, 'zhquan_example')
+        self.assertEqual(github.repository, 'repo')
+        self.assertEqual(github.origin, 'https://github.com/zhquan_example/repo')
+        self.assertEqual(github.tag, 'https://github.com/zhquan_example/repo')
+        self.assertFalse(github.ssl_verify)
+
+        github = GitHubQL('zhquan_example', 'repo', ['aaa'], tag='')
+        self.assertEqual(github.owner, 'zhquan_example')
+        self.assertEqual(github.repository, 'repo')
+        self.assertEqual(github.origin, 'https://github.com/zhquan_example/repo')
+        self.assertEqual(github.tag, 'https://github.com/zhquan_example/repo')
+
+    def test_has_resuming(self):
+        """Test if it returns False when has_resuming is called"""
+
+        self.assertEqual(GitHubQL.has_resuming(), False)
+
+    def test_has_archiving(self):
+        """Test if it returns True when has_archiving is called"""
+
+        self.assertEqual(GitHubQL.has_archiving(), True)
+
+    @httpretty.activate
+    def test_fetch_events(self):
+        """Test whether a list of events is returned"""
+
+        events = read_file('data/github/github_events_page_2')
+        issue = read_file('data/github/github_issue_2')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUES_URL,
+                               body=issue,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.POST,
+                               GITHUB_API_GRAPHQL_URL,
+                               body=events,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        github = GitHubQL("zhquan_example", "repo", ["aaa"])
+        events = [events for events in github.fetch(from_date=None, to_date=None, category=CATEGORY_EVENT)]
+
+        self.assertEqual(len(events), 2)
+
+        event = events[0]
+        self.assertEqual(event['origin'], 'https://github.com/zhquan_example/repo')
+        self.assertEqual(event['uuid'], 'b46499fd01d2958d836241770063adff953b280e')
+        self.assertEqual(event['updated_on'], 1586265768.0)
+        self.assertEqual(event['category'], CATEGORY_EVENT)
+        self.assertEqual(event['tag'], 'https://github.com/zhquan_example/repo')
+        self.assertEqual(event['data']['actor']['login'], 'valeriocos')
+        self.assertEqual(event['data']['createdAt'], '2020-04-07T13:22:48Z')
+        self.assertEqual(event['data']['eventType'], 'MovedColumnsInProjectEvent')
+        self.assertIn('issue', event['data'])
+
+        event = events[1]
+        self.assertEqual(event['origin'], 'https://github.com/zhquan_example/repo')
+        self.assertEqual(event['uuid'], 'd05238b1254cf69deac49248ad8cc855482a6737')
+        self.assertEqual(event['updated_on'], 1586265783.0)
+        self.assertEqual(event['category'], CATEGORY_EVENT)
+        self.assertEqual(event['tag'], 'https://github.com/zhquan_example/repo')
+        self.assertEqual(event['data']['actor']['login'], 'valeriocos')
+        self.assertEqual(event['data']['createdAt'], '2020-04-07T13:23:03Z')
+        self.assertEqual(event['data']['eventType'], 'CrossReferencedEvent')
+        self.assertIn('issue', event['data'])
+
+    @httpretty.activate
+    def test_fetch_events_pagination(self):
+        """Test whether a list of paginated events is returned"""
+
+        requests = []
+
+        events_page_1 = read_file('data/github/github_events_page_1')
+        events_page_2 = read_file('data/github/github_events_page_2')
+        bodies_json = [events_page_1, events_page_2]
+
+        def request_callback(method, uri, headers):
+            body = bodies_json.pop(0)
+            requests.append(httpretty.last_request())
+            return 200, headers, body
+
+        issue = read_file('data/github/github_issue_2')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUES_URL,
+                               body=issue,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.POST,
+                               GITHUB_API_GRAPHQL_URL,
+                               responses=[httpretty.Response(body=request_callback)
+                                          for _ in range(2)],
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        github = GitHubQL("zhquan_example", "repo", ["aaa"])
+        events = [events for events in github.fetch(from_date=None, to_date=None, category=CATEGORY_EVENT)]
+
+        self.assertEqual(len(events), 4)
+
+        event = events[0]
+        self.assertEqual(event['origin'], 'https://github.com/zhquan_example/repo')
+        self.assertEqual(event['uuid'], '116d709c3225b31f094218148d3fcceaf6737b37')
+        self.assertEqual(event['updated_on'], 1586258472.0)
+        self.assertEqual(event['category'], CATEGORY_EVENT)
+        self.assertEqual(event['tag'], 'https://github.com/zhquan_example/repo')
+        self.assertEqual(event['data']['actor']['login'], 'valeriocos')
+        self.assertEqual(event['data']['createdAt'], '2020-04-07T11:21:12Z')
+        self.assertEqual(event['data']['eventType'], 'LabeledEvent')
+        self.assertIn('issue', event['data'])
+
+        event = events[1]
+        self.assertEqual(event['origin'], 'https://github.com/zhquan_example/repo')
+        self.assertEqual(event['uuid'], 'a5e67dcb8ec7b722cc088c2e5f8bad0b3e285329')
+        self.assertEqual(event['updated_on'], 1586258479.0)
+        self.assertEqual(event['category'], CATEGORY_EVENT)
+        self.assertEqual(event['tag'], 'https://github.com/zhquan_example/repo')
+        self.assertEqual(event['data']['actor']['login'], 'valeriocos')
+        self.assertEqual(event['data']['createdAt'], '2020-04-07T11:21:19Z')
+        self.assertEqual(event['data']['eventType'], 'LabeledEvent')
+        self.assertIn('issue', event['data'])
+
+        event = events[2]
+        self.assertEqual(event['origin'], 'https://github.com/zhquan_example/repo')
+        self.assertEqual(event['uuid'], 'b46499fd01d2958d836241770063adff953b280e')
+        self.assertEqual(event['updated_on'], 1586265768.0)
+        self.assertEqual(event['category'], CATEGORY_EVENT)
+        self.assertEqual(event['tag'], 'https://github.com/zhquan_example/repo')
+        self.assertEqual(event['data']['actor']['login'], 'valeriocos')
+        self.assertEqual(event['data']['createdAt'], '2020-04-07T13:22:48Z')
+        self.assertEqual(event['data']['eventType'], 'MovedColumnsInProjectEvent')
+        self.assertIn('issue', event['data'])
+
+        event = events[3]
+        self.assertEqual(event['origin'], 'https://github.com/zhquan_example/repo')
+        self.assertEqual(event['uuid'], 'd05238b1254cf69deac49248ad8cc855482a6737')
+        self.assertEqual(event['updated_on'], 1586265783.0)
+        self.assertEqual(event['category'], CATEGORY_EVENT)
+        self.assertEqual(event['tag'], 'https://github.com/zhquan_example/repo')
+        self.assertEqual(event['data']['actor']['login'], 'valeriocos')
+        self.assertEqual(event['data']['createdAt'], '2020-04-07T13:23:03Z')
+        self.assertEqual(event['data']['eventType'], 'CrossReferencedEvent')
+        self.assertIn('issue', event['data'])
+
+    @httpretty.activate
+    def test_fetch_events_until_date(self):
+        """Test whether only the events after a given date are returned"""
+
+        events = read_file('data/github/github_events_page_2')
+        issue = read_file('data/github/github_issue_2')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUES_URL,
+                               body=issue,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.POST,
+                               GITHUB_API_GRAPHQL_URL,
+                               body=events,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        github = GitHubQL("zhquan_example", "repo", ["aaa"])
+        to_date = datetime.datetime(2020, 4, 7, 13, 23, 00)
+        events = [events for events in github.fetch(from_date=None, to_date=to_date, category=CATEGORY_EVENT)]
+
+        self.assertEqual(len(events), 1)
+
+        event = events[0]
+        self.assertEqual(event['origin'], 'https://github.com/zhquan_example/repo')
+        self.assertEqual(event['uuid'], 'b46499fd01d2958d836241770063adff953b280e')
+        self.assertEqual(event['updated_on'], 1586265768.0)
+        self.assertEqual(event['category'], CATEGORY_EVENT)
+        self.assertEqual(event['tag'], 'https://github.com/zhquan_example/repo')
+        self.assertEqual(event['data']['actor']['login'], 'valeriocos')
+        self.assertEqual(event['data']['createdAt'], '2020-04-07T13:22:48Z')
+        self.assertEqual(event['data']['eventType'], 'MovedColumnsInProjectEvent')
+        self.assertIn('issue', event['data'])
+
+    @httpretty.activate
+    def test_search_fields_event(self):
+        """Test whether the search_fields is properly set"""
+
+        events = read_file('data/github/github_events_page_2')
+        issue = read_file('data/github/github_issue_2')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUES_URL,
+                               body=issue,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.POST,
+                               GITHUB_API_GRAPHQL_URL,
+                               body=events,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        github = GitHubQL("zhquan_example", "repo", ["aaa"])
+        events = [events for events in github.fetch(from_date=None, to_date=None, category=CATEGORY_EVENT)]
+
+        self.assertEqual(len(events), 2)
+
+        event = events[0]
+        self.assertEqual(github.metadata_id(event['data']), event['search_fields']['item_id'])
+        self.assertEqual(event['search_fields']['owner'], 'zhquan_example')
+        self.assertEqual(event['search_fields']['repo'], 'repo')
+
+        event = events[1]
+        self.assertEqual(github.metadata_id(event['data']), event['search_fields']['item_id'])
+        self.assertEqual(event['search_fields']['owner'], 'zhquan_example')
+        self.assertEqual(event['search_fields']['repo'], 'repo')
+
+    @httpretty.activate
+    def test_fetch_events_enterprise(self):
+        """Test if it fetches events from a GitHub Enterprise server"""
+
+        events = read_file('data/github/github_events_page_2')
+        issue = read_file('data/github/github_issue_2')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ENTREPRISE_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ENTERPRISE_ISSUES_URL,
+                               body=issue,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.POST,
+                               GITHUB_ENTERPRISE_API_GRAPHQL_URL,
+                               body=events,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        github = GitHubQL("zhquan_example", "repo", ["aaa"], base_url=GITHUB_ENTERPRISE_URL)
+        events = [events for events in github.fetch(from_date=None, to_date=None, category=CATEGORY_EVENT)]
+
+        self.assertEqual(len(events), 2)
+
+        event = events[0]
+        self.assertEqual(event['origin'], 'https://example.com/zhquan_example/repo')
+        self.assertEqual(event['uuid'], '7ae18a45805b971b46dba2874f6deb28e1fb3db1')
+        self.assertEqual(event['updated_on'], 1586265768.0)
+        self.assertEqual(event['category'], CATEGORY_EVENT)
+        self.assertEqual(event['tag'], 'https://example.com/zhquan_example/repo')
+        self.assertEqual(event['data']['actor']['login'], 'valeriocos')
+        self.assertEqual(event['data']['createdAt'], '2020-04-07T13:22:48Z')
+        self.assertEqual(event['data']['eventType'], 'MovedColumnsInProjectEvent')
+        self.assertIn('issue', event['data'])
+
+        event = events[1]
+        self.assertEqual(event['origin'], 'https://example.com/zhquan_example/repo')
+        self.assertEqual(event['uuid'], 'd0d1489be06622577843c91b70cb5543f48be918')
+        self.assertEqual(event['updated_on'], 1586265783.0)
+        self.assertEqual(event['category'], CATEGORY_EVENT)
+        self.assertEqual(event['tag'], 'https://example.com/zhquan_example/repo')
+        self.assertEqual(event['data']['actor']['login'], 'valeriocos')
+        self.assertEqual(event['data']['createdAt'], '2020-04-07T13:23:03Z')
+        self.assertEqual(event['data']['eventType'], 'CrossReferencedEvent')
+        self.assertIn('issue', event['data'])
+
+
+class TestGitHubQLBackendArchive(TestCaseBackendArchive):
+    """GitHub backend tests using an archive"""
+
+    def setUp(self):
+        super().setUp()
+        self.backend_write_archive = GitHubQL("zhquan_example", "repo", ["aaa"], archive=self.archive)
+        self.backend_read_archive = GitHubQL("zhquan_example", "repo", ["aaa"], archive=self.archive)
+
+    @httpretty.activate
+    def test_fetch_events(self):
+        """Test whether a list of events is returned from archive"""
+
+        events = read_file('data/github/github_events_page_2')
+        issue = read_file('data/github/github_issue_2')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUES_URL,
+                               body=issue,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.POST,
+                               GITHUB_API_GRAPHQL_URL,
+                               body=events,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        self._test_fetch_from_archive(category=CATEGORY_EVENT, from_date=None)
+
+
+class TestGitHubQLClient(unittest.TestCase):
+    """GitHubQL API client tests"""
+
+    @httpretty.activate
+    def test_init(self):
+        rate_limit = read_file('data/github/rate_limit')
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        client = GitHubQLClient('zhquan_example', 'repo', ['aaa'])
+
+        self.assertEqual(client.owner, 'zhquan_example')
+        self.assertEqual(client.repository, 'repo')
+        self.assertEqual(client.max_retries, GitHubQLClient.MAX_RETRIES)
+        self.assertEqual(client.sleep_time, GitHubQLClient.DEFAULT_SLEEP_TIME)
+        self.assertEqual(client.max_retries, GitHubQLClient.MAX_RETRIES)
+        self.assertEqual(client.base_url, 'https://api.github.com')
+        self.assertTrue(client.ssl_verify)
+        self.assertEqual(client.graphql_url, 'https://api.github.com/graphql')
+
+        client = GitHubQLClient('zhquan_example', 'repo', ['aaa'], base_url=None,
+                                sleep_for_rate=False, min_rate_to_sleep=3,
+                                sleep_time=20, max_retries=2, max_items=1,
+                                archive=None, from_archive=False, ssl_verify=False)
+        self.assertEqual(client.owner, 'zhquan_example')
+        self.assertEqual(client.repository, 'repo')
+        self.assertEqual(client.tokens, ['aaa'])
+        self.assertEqual(client.n_tokens, 1)
+        self.assertEqual(client.current_token, 'aaa')
+        self.assertEqual(client.base_url, GITHUB_API_URL)
+        self.assertFalse(client.sleep_for_rate)
+        self.assertEqual(client.min_rate_to_sleep, 3)
+        self.assertEqual(client.sleep_time, 20)
+        self.assertEqual(client.max_retries, 2)
+        self.assertEqual(client.max_items, 1)
+        self.assertIsNone(client.archive)
+        self.assertFalse(client.from_archive)
+        self.assertFalse(client.ssl_verify)
+        self.assertEqual(client.graphql_url, 'https://api.github.com/graphql')
+
+        client = GitHubQLClient('zhquan_example', 'repo', ['aaa'],
+                                min_rate_to_sleep=RateLimitHandler.MAX_RATE_LIMIT + 1)
+        self.assertEqual(client.min_rate_to_sleep, RateLimitHandler.MAX_RATE_LIMIT)
+
+        client = GitHubQLClient('zhquan_example', 'repo', ['aaa'],
+                                min_rate_to_sleep=RateLimitHandler.MAX_RATE_LIMIT - 1)
+        self.assertEqual(client.min_rate_to_sleep, RateLimitHandler.MAX_RATE_LIMIT - 1)
+
+        client = GitHubQLClient('zhquan_example', 'repo', ['aaa'])
+        self.assertEqual(client.tokens, ['aaa'])
+        self.assertEqual(client.n_tokens, 1)
+        self.assertEqual(client.current_token, 'aaa')
+
+        client = GitHubQLClient('zhquan_example', 'repo', ['aaa', 'bbb'])
+        self.assertEqual(client.tokens, ['aaa', 'bbb'])
+        self.assertEqual(client.n_tokens, 2)
+
+        client = GitHubQLClient('zhquan_example', 'repo', [])
+        self.assertEqual(client.tokens, [])
+        self.assertEqual(client.current_token, None)
+        self.assertEqual(client.n_tokens, 0)
+
+    @httpretty.activate
+    def test_events(self):
+        """Test whether the GraphQL API call works properly"""
+
+        events = read_file('data/github/github_events_page_2')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.POST,
+                               GITHUB_API_GRAPHQL_URL,
+                               body=events, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        client = GitHubQLClient("zhquan_example", "repo", ["aaa"], None)
+        events = [event for event in client.events(issue_number=1, is_pull=False, from_date=DEFAULT_DATETIME)]
+        self.assertEqual(len(events[0]), 2)
+        self.assertEqual(httpretty.last_request().headers["Authorization"], "token aaa")
+
+    @httpretty.activate
+    def test_events_pagination(self):
+        """Test whether the GraphQL API call works properly on paginated results"""
+
+        requests = []
+
+        events_page_1 = read_file('data/github/github_events_page_1')
+        events_page_2 = read_file('data/github/github_events_page_2')
+        bodies_json = [events_page_1, events_page_2]
+
+        def request_callback(method, uri, headers):
+            body = bodies_json.pop(0)
+            requests.append(httpretty.last_request())
+            return 200, headers, body
+
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.POST,
+                               GITHUB_API_GRAPHQL_URL,
+                               responses=[httpretty.Response(body=request_callback)
+                                          for _ in range(2)],
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        client = GitHubQLClient("zhquan_example", "repo", ["aaa"], None)
+        events = [event for event in client.events(issue_number=1, is_pull=False, from_date=DEFAULT_DATETIME)]
+        self.assertEqual(len(events[0]), 2)
+        self.assertEqual(len(events[1]), 2)
+        self.assertEqual(httpretty.last_request().headers["Authorization"], "token aaa")
+
+    @httpretty.activate
+    def test_events_error(self):
+        """Test whether GraphQL API call"""
+
+        events = read_file('data/github/github_events_error')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.POST,
+                               GITHUB_API_GRAPHQL_URL,
+                               body=events, status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        client = GitHubQLClient("zhquan_example", "repo", ["aaa"], None)
+
+        with self.assertLogs(logger, level='ERROR') as cm:
+            events = [event for event in client.events(issue_number=1,
+                                                       is_pull=False,
+                                                       from_date=DEFAULT_DATETIME)]
+            self.assertEqual(cm.output[0], 'ERROR:perceval.backends.core.githubql:Events not collected for issue 1'
+                                           ' in zhquan_example/repo due to: Parse error on "=" (EQUALS) at [7, 80]')
+            self.assertEqual(events, [])
+            self.assertEqual(httpretty.last_request().headers["Authorization"], "token aaa")
+
+
+class TestGitHubQLCommand(unittest.TestCase):
+    """GitHubQLCommand unit tests"""
+
+    def test_backend_class(self):
+        """Test if the backend class is GitHubQL"""
+
+        self.assertIs(GitHubQLCommand.BACKEND, GitHubQL)
+
+
+if __name__ == "__main__":
+    unittest.main(warnings='ignore')


### PR DESCRIPTION
This class allows the fetch the issue events of a GitHub repository. Note that the events retrieved included also the ones of pull requests, since in GitHub, every pull request is an issue, but an issue may not be a pull request. Pull requests can be identified by the attribute `pull_request` included in `data.issue`.

The following event types from issues and pull requests:
- ADDED_TO_PROJECT_EVENT
- MOVED_COLUMNS_IN_PROJECT_EVENT
- REMOVED_FROM_PROJECT_EVENT
- CROSS_REFERENCED_EVENT
- LABELED_EVENT
- UNLABELED_EVENT
- CLOSED_EVENT

Due to the limitation of not fetching events after a given date from the endpoint `timeline` of GitHub v3, the events are fetched via the GitHub v4 (based on GraphQL).

All issues of a given tracker are retrieved in ascending order based on the last time they were updated. For each issue, its events (optionally from/until a given date) are collected using a GraphQL call. Each event is returned by Perceval together with the corresponding issue (available in data.issue).

Since the events are collected issue by issue, the incremental fetching is not supported. This limitation is due to the fact that events that occur on an issue may not update the issue attributes. Since there is no way to identify new events from the attributes of an issue, all issues must be fetched for every execution.

No user information beyond the login is included in data returned by this backend. Thus, the backend doesn't require filter classified support.

The backend can be executed in the following way:
```
perceval githubql chaoss grimoirelab-toolkit
--category event -t xxx
--sleep-for-rate
--no-archive
--from-date 2019-01-01
```

Tests have been added accordingly.
Backend version is 0.1.0