### PR TITLE
[launchpad] Add missing `package` parameter in launchpad

### DIFF
--- a/perceval/backends/core/launchpad.py
+++ b/perceval/backends/core/launchpad.py
@@ -63,7 +63,7 @@ class Launchpad(Backend):
     :param archive: archive to store/retrieve items
     :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.8.0'
+    version = '0.8.1'
 
     CATEGORIES = [CATEGORY_ISSUE]
 
@@ -515,6 +515,8 @@ class LaunchpadCommand(BackendCommand):
                            help="Items per page")
         group.add_argument('--sleep-time', dest='sleep_time',
                            help="Sleep time in case of connection lost")
+        group.add_argument('--package', dest='package',
+                           help="Distribution package")
 
         # Required arguments
         parser.parser.add_argument('distribution',

--- a/tests/test_launchpad.py
+++ b/tests/test_launchpad.py
@@ -1010,6 +1010,7 @@ class TestLaunchpadCommand(unittest.TestCase):
                 '--from-date', '1970-01-01',
                 '--items-per-page', '75',
                 '--sleep-time', '600',
+                '--package', 'mypackage',
                 'mydistribution']
 
         parsed_args = parser.parse(*args)
@@ -1019,12 +1020,14 @@ class TestLaunchpadCommand(unittest.TestCase):
         self.assertTrue(parsed_args.no_archive)
         self.assertEqual(parsed_args.items_per_page, '75')
         self.assertEqual(parsed_args.sleep_time, '600')
+        self.assertEqual(parsed_args.package, 'mypackage')
         self.assertTrue(parsed_args.ssl_verify)
 
         args = ['--tag', 'test', '--no-archive',
                 '--from-date', '1970-01-01',
                 '--items-per-page', '75',
                 '--sleep-time', '600',
+                '--package', 'mypackage',
                 '--no-ssl-verify',
                 'mydistribution']
 
@@ -1035,6 +1038,7 @@ class TestLaunchpadCommand(unittest.TestCase):
         self.assertTrue(parsed_args.no_archive)
         self.assertEqual(parsed_args.items_per_page, '75')
         self.assertEqual(parsed_args.sleep_time, '600')
+        self.assertEqual(parsed_args.package, 'mypackage')
         self.assertFalse(parsed_args.ssl_verify)
 
 


### PR DESCRIPTION
This PR adds missing parameter `package` in the
launchpad backend. Launchpad can now work on both,
distributions and distribution packages.
Tests have also been added.
Based on the discussion here https://github.com/chaoss/grimoirelab-elk/pull/851#discussion_r418949192

Signed-off-by: Nitish Gupta <imnitish.ng@gmail.com>