### PR TITLE
[slack] Handle messages without user/bot ID

### DIFF
--- a/perceval/backends/core/slack.py
+++ b/perceval/backends/core/slack.py
@@ -61,7 +61,7 @@ class Slack(Backend):
     :param archive: archive to store/retrieve items
     :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.9.1'
+    version = '0.9.2'
 
     CATEGORIES = [CATEGORY_MESSAGE]
     EXTRA_SEARCH_FIELDS = {
@@ -183,13 +183,19 @@ class Slack(Backend):
         'ts' and 'user' values (or 'bot_id' when the message is sent by a bot)
         are combined because there have been cases where two messages were sent
         by different users at the same time.
+
+        In the case where neither the 'user' or 'bot_id' attributes are present
+        (e.g, bot deleted), the fallback option is to generate the identifier
+        using the 'ts' and 'username' values.
         """
         if 'user' in item:
             nick = item['user']
         elif 'comment' in item:
             nick = item['comment']['user']
-        else:
+        elif 'bot_id' in item:
             nick = item['bot_id']
+        else:
+            nick = item['username']
 
         return item['ts'] + nick
 

--- a/tests/data/slack/slack_history_20150323.json
+++ b/tests/data/slack/slack_history_20150323.json
@@ -9,6 +9,13 @@
             "type": "message"
         },
         {
+            "subtype": "bot_message",
+            "text": "hey hey!",
+            "ts": "1486949200.000069",
+            "type": "message",
+            "username": "Owl Capone"
+        },
+        {
             "subtype": "channel_join",
             "text": "<@U0003|dizquierdo> has joined the channel",
             "ts": "1427799888.000000",

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -453,6 +453,9 @@ class TestSlackBackend(unittest.TestCase):
             ("There are no events this week.",
              'b48fd01f4e010597091b7e44cecfb6074f56a1a6',
              1486969200.000136, 'B0001', 'test channel'),
+            ("hey hey!",
+             '141392fe7515c0710bc4b3d1da82f1d4bec311f4',
+             1486949200.000069, None, 'test channel'),
             ("<@U0003|dizquierdo> has joined the channel",
              'bb95a1facf7d61baaf57322f3d6b6d2d45af8aeb',
              1427799888.0, 'dizquierdo@example.com', 'test channel'),
@@ -479,6 +482,9 @@ class TestSlackBackend(unittest.TestCase):
             # The first message was sent by a bot
             if x == 0:
                 self.assertEqual(message['data']['bot_id'], expc[3])
+            elif x == 1:
+                self.assertNotIn('bot_id', message['data'])
+                self.assertNotIn('user_data', message['data'])
             else:
                 self.assertEqual(message['data']['user_data']['profile']['email'], expc[3])
 


### PR DESCRIPTION
The user/bot ID is used by the backend to create the the Perceval document ID. In the scenario where this information is missing (e.g., bot deleted), the document ID cannot be generated and error is thrown in the method `metadata_id`.

This code proposes to set the username as fallback value for the messages without user/bot ID, thus allowing the creation of the Perceval document ID.

Tests have been added accordingly.
Backend version is 0.9.2.