### PR TITLE
Update dulwich package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Run 'perceval <backend> --help' to get information about a specific backend.
 * python3-requests >= 2.7
 * python3-bs4 (beautifulsoup4) >= 4.3
 * python3-feedparser >= 5.1.3
-* python3-dulwich >= 0.18.5
+* python3-dulwich >= 0.20.0
 * grimoirelab-toolkit >= 0.1.4
 
 Note that you should have also the following packages installed in your system:
@@ -368,7 +368,7 @@ in order to fetch messages from a group or channel, privacy settings must be
 disabled. To know how to create a bot, to obtain its token and to configure it
 please read the [Telegram Bots docs pages](https://core.telegram.org/bots).
 
-Note that the messages are available on the Telegram server until the bot fetches 
+Note that the messages are available on the Telegram server until the bot fetches
 them, but they will not be kept longer than 24 hours.
 
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ python-dateutil>=2.6.0
 requests>=2.7.0
 beautifulsoup4>=4.3.2
 feedparser>=5.1.3
-dulwich>=0.18.5, <0.19
+dulwich>=0.20.0
 urllib3>=1.22
 -e git+https://github.com/chaoss/grimoirelab-toolkit/#egg=grimoirelab-toolkit

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(name="perceval",
           'requests>=2.7.0',
           'beautifulsoup4>=4.3.2',
           'feedparser>=5.1.3',
-          'dulwich>=0.18.5, <0.19',
+          'dulwich>=0.20.0',
           'urllib3>=1.22',
           'grimoirelab-toolkit>=0.1.4'
       ],


### PR DESCRIPTION
Running Perceval with Python 3.8 and dulwich <0.19.6 raises an Exception because a method has been deprecated and removed.

This commit updates the version of `dulwich` to the latest one

Related to: https://github.com/chaoss/grimoirelab-perceval/issues/687
