### PR TITLE
Weblate 0.1.0

### DIFF
--- a/perceval/backends/core/weblate.py
+++ b/perceval/backends/core/weblate.py
@@ -1,0 +1,372 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Quan Zhou <quan@bitergia.com>
+#
+
+import logging
+
+import requests
+
+from grimoirelab_toolkit.datetime import str_to_datetime
+from grimoirelab_toolkit.uris import urijoin
+
+from ...backend import (Backend,
+                        BackendCommand,
+                        BackendCommandArgumentParser,
+                        DEFAULT_SEARCH_FIELD)
+from ...client import HttpClient, RateLimitHandler
+from ...utils import DEFAULT_DATETIME
+
+# Range before sleeping until rate limit reset
+MIN_RATE_LIMIT = 10
+# Default sleep time and retries to deal with connection/server problems
+DEFAULT_SLEEP_TIME = 1
+MAX_RETRIES = 5
+
+CATEGORY_CHANGE = "changes"
+
+
+logger = logging.getLogger(__name__)
+
+
+class Weblate(Backend):
+    """Weblate backend for Perceval.
+
+    This class retrieves the activities from Weblate API.
+
+    :param url: the URL of a Weblate instance
+    :param project: a Weblate project
+    :param api_token: Weblate API token
+    :param tag: label used to mark the data
+    :param archive: archive to store/retrieve items
+    :param max_retries: number of max retries to a data source
+        before raising a RetryError exception
+    :param sleep_for_rate: sleep until rate limit is reset
+    :param min_rate_to_sleep: minimum rate needed to sleep until
+         it will be reset
+    :param sleep_time: time (in seconds) to sleep in case
+        of connection problems
+    :param ssl_verify: enable/disable SSL verification
+    """
+    version = '0.1.0'
+
+    CATEGORIES = [CATEGORY_CHANGE]
+
+    def __init__(self, url, project=None, api_token=None, tag=None, archive=None,
+                 sleep_for_rate=False, min_rate_to_sleep=MIN_RATE_LIMIT,
+                 max_retries=MAX_RETRIES, sleep_time=DEFAULT_SLEEP_TIME, ssl_verify=True):
+
+        super().__init__(url, tag=tag, archive=archive, ssl_verify=ssl_verify)
+
+        self.api_token = api_token
+        self.project = project
+        self.max_retries = max_retries
+        self.sleep_time = sleep_time
+        self.sleep_for_rate = sleep_for_rate
+        self.min_rate_to_sleep = min_rate_to_sleep
+
+        self.client = None
+
+    def search_fields(self, item):
+        """Add search fields to an item.
+
+        It adds the values of `metadata_id` plus the `project`.
+
+        :param item: the item to extract the search fields values
+
+        :returns: a dict of search fields
+        """
+        search_fields = {
+            DEFAULT_SEARCH_FIELD: self.metadata_id(item)
+        }
+
+        return search_fields
+
+    def fetch(self, category=CATEGORY_CHANGE, from_date=DEFAULT_DATETIME):
+        """Fetch changes from Weblate API.
+
+        The method retrieves the activity that occurred on a project via the Weblate API.
+
+        :param category: the category of items to fetch
+
+        :returns: a generator of data
+        """
+        if not from_date:
+            from_date = DEFAULT_DATETIME
+
+        kwargs = {
+            'from_date': from_date
+        }
+        items = super().fetch(category, **kwargs)
+
+        return items
+
+    def fetch_items(self, category, **kwargs):
+        """Fetch change items
+
+        :param category: the category of items to fetch
+        :param kwargs: backend arguments
+
+        :returns: a generator of items
+        """
+        from_date = kwargs['from_date']
+        logger.info("Fetching %s items on '%s' from '%s", category, self.origin, from_date)
+
+        changes_groups = self.client.changes(from_date=from_date)
+        for changes in changes_groups:
+            for change in changes:
+                user = change.get('user', None)
+                if user:
+                    change['user_data'] = self.client.user(user)
+                author = change.get('author', None)
+                if author:
+                    change['author_data'] = self.client.user(user)
+
+                yield change
+
+        logger.info("Fetch process completed")
+
+    @classmethod
+    def has_archiving(cls):
+        """Returns whether it supports archiving items on the fetch process.
+
+        :returns: this backend supports items archive
+        """
+        return True
+
+    @classmethod
+    def has_resuming(cls):
+        """Returns whether it supports to resume the fetch process.
+
+        :returns: this backend supports items resuming
+        """
+        return True
+
+    @staticmethod
+    def metadata_id(item):
+        """Extracts the identifier from an item."""
+
+        return str(item['id'])
+
+    @staticmethod
+    def metadata_updated_on(item):
+        """Extracts the update time from an item.
+
+        The timestamp used is extracted from 'timestamp' field.
+        This date is converted to UNIX timestamp format taking into
+        account the timezone of the date.
+
+        :param item: item generated by the backend
+
+        :returns: a UNIX timestamp
+        """
+        ts = item['timestamp']
+        ts = str_to_datetime(ts)
+
+        return ts.timestamp()
+
+    @staticmethod
+    def metadata_category(item):
+        """Extracts the category from a Weblate item.
+
+        This backend only generates one type of item which is
+        'changes'.
+        """
+        return CATEGORY_CHANGE
+
+    def _init_client(self, from_archive=False):
+        """Init client"""
+
+        return WeblateClient(self.origin, self.api_token, self.project,
+                             self.sleep_for_rate, self.min_rate_to_sleep, self.sleep_time, self.max_retries,
+                             archive=self.archive, from_archive=from_archive, ssl_verify=True)
+
+
+class WeblateClient(HttpClient, RateLimitHandler):
+    """WeblateClient API client.
+
+    Client for fetching activities data from Weblate API.
+
+    :param origin: URL of a Weblate instance
+    :param api_token: Weblate API token
+    :param project: a Weblate project
+    :param sleep_for_rate: sleep until rate limit is reset
+    :param min_rate_to_sleep: minimun rate needed to sleep until
+         it will be reset
+    :param sleep_time: time (in seconds) to sleep in case
+        of connection problems
+    :param max_retries: number of max retries to a data source
+        before raising a RetryError exception
+    :param archive: an archive to store/read fetched data
+    :param from_archive: it tells whether to write/read the archive
+    :param ssl_verify: enable/disable SSL verification
+    """
+    # Resource parameters
+    PAFTER = 'timestamp_after'
+
+    def __init__(self, origin, api_token, project=None, sleep_for_rate=False, min_rate_to_sleep=MIN_RATE_LIMIT,
+                 sleep_time=DEFAULT_SLEEP_TIME, max_retries=MAX_RETRIES,
+                 archive=None, from_archive=False, ssl_verify=True):
+
+        url = urijoin(origin, 'api')
+        self.api_token = api_token
+        self.project = project
+
+        super().__init__(url, sleep_time=sleep_time, max_retries=max_retries,
+                         extra_headers=self._set_extra_headers(),
+                         archive=archive, from_archive=from_archive, ssl_verify=ssl_verify)
+        super().setup_rate_limit_handler(sleep_for_rate=sleep_for_rate, min_rate_to_sleep=min_rate_to_sleep)
+
+    def _set_extra_headers(self):
+        """Set extra headers for session"""
+
+        headers = {}
+        if self.api_token:
+            headers = {'Authorization': "Token %s" % self.api_token}
+
+        return headers
+
+    def user(self, url):
+        """Fetch user data"""
+
+        user = {}
+        try:
+            response = self.fetch(url)
+            user = response.json()
+        except requests.exceptions.HTTPError as error:
+            # The endpoint users returns a list of users if you have permissions to see
+            # manage users (details at https://docs.weblate.org/en/latest/api.html#get--api-users-). If not, then
+            # you get to see only your own details.
+            # The except block covers the case of a token which lacks of permission to see users' detail. Due to
+            # the specificity of this backend (tailored to a specific customer), one of the requirements of the
+            # backend could be to have a token with the proper permission and get rid of this except block. In
+            # the case that the backend should work with any token, it probably makes sense to avoid adding
+            # a log message here, since the except block will be triggered for any document collected by Perceval.
+            pass  # FIXME
+
+        return user
+
+    def changes(self, from_date=None):
+        """Fetch changes of a project."""
+
+        payload = {}
+
+        if from_date:
+            payload[self.PAFTER] = from_date.isoformat()
+
+        if self.project:
+            path = urijoin(self.base_url, 'projects', self.project, 'changes')
+        else:
+            path = urijoin(self.base_url, 'changes')
+
+        return self.fetch_items(path, payload)
+
+    def fetch_items(self, path, payload):
+        """Return the items from Weblate API using links pagination"""
+
+        current_page = 1  # current page
+        fetch = True
+        url_next = path
+        logger.debug("Get Weblate paginated items from " + url_next)
+        response = self.fetch(url_next, payload=payload)
+
+        while fetch:
+            page = response.json()
+            results = page.get('results', [])
+
+            logger.debug("Count: %i/%i, page %s" % (len(results), page['count'], current_page))
+
+            yield results
+
+            if 'next' not in page:
+                fetch = False
+                continue
+
+            current_page += 1
+            url_next = page['next']
+            response = self.fetch(url_next)
+
+    def calculate_time_to_reset(self):
+        """Number of seconds to wait. They are contained in the rate limit reset header"""
+
+        time_to_reset = 0 if self.rate_limit_reset_ts / 1000 < 0 else self.rate_limit_reset_ts / 1000
+        return time_to_reset
+
+    def fetch(self, url, payload=None, headers=None, method=HttpClient.GET, stream=False, auth=None):
+        """Fetch the data from a given URL.
+
+        :param url: link to the resource
+        :param payload: payload of the request
+        :param headers: headers of the request
+        :param method: type of request call (GET or POST)
+        :param stream: defer downloading the response body until the response content is available
+        :param auth: auth of the request
+
+        :returns a response object
+        """
+        if not self.from_archive:
+            self.sleep_for_rate_limit()
+
+        response = super().fetch(url, payload, headers, method, stream, auth)
+
+        if not self.from_archive:
+            self.update_rate_limit(response)
+
+        return response
+
+
+class WeblateCommand(BackendCommand):
+    """Class to run Weblate backend from the command line."""
+
+    BACKEND = Weblate
+
+    @classmethod
+    def setup_cmd_parser(cls):
+        """Returns the Weblate argument parser."""
+
+        parser = BackendCommandArgumentParser(cls.BACKEND,
+                                              archive=True,
+                                              from_date=True,
+                                              ssl_verify=True,
+                                              token_auth=True)
+
+        # Weblate options
+        group = parser.parser.add_argument_group('Weblate arguments')
+        group.add_argument('--sleep-for-rate', dest='sleep_for_rate',
+                           action='store_true',
+                           help="sleep for getting more rate")
+        group.add_argument('--min-rate-to-sleep', dest='min_rate_to_sleep',
+                           default=MIN_RATE_LIMIT, type=int,
+                           help="sleep until reset when the rate limit reaches this value")
+        group.add_argument('--project', dest='project', help="Weblate project")
+
+        # Generic client options
+        group.add_argument('--max-retries', dest='max_retries',
+                           default=MAX_RETRIES, type=int,
+                           help="number of API call retries")
+        group.add_argument('--sleep-time', dest='sleep_time',
+                           default=DEFAULT_SLEEP_TIME, type=int,
+                           help="sleeping time between API call retries")
+
+        # Positional arguments
+        parser.parser.add_argument('url',
+                                   help="Weblate URL")
+
+        return parser

--- a/tests/data/weblate/weblate_changes.json
+++ b/tests/data/weblate/weblate_changes.json
@@ -1,0 +1,35 @@
+{
+  "count": 10,
+  "next": "https://my.weblate.org/api/changes/?page=2",
+  "previous": null,
+  "results": [
+    {
+      "unit": null,
+      "component": null,
+      "translation": null,
+      "glossary_term": null,
+      "user": "https://my.weblate.org/api/users/1",
+      "author": "https://my.weblate.org/api/users/1",
+      "timestamp": "2019-07-11T16:20:20.958070Z",
+      "action": 50,
+      "target": "",
+      "id": 1,
+      "action_name": "Created project",
+      "url": "https://my.weblate.org/api/changes/1/"
+    },
+    {
+      "unit": null,
+      "component": null,
+      "translation": null,
+      "glossary_term": null,
+      "user": "https://my.weblate.org/api/users/2",
+      "author": "https://my.weblate.org/api/users/2",
+      "timestamp": "2019-07-11T16:21:11.939033Z",
+      "action": 50,
+      "target": "",
+      "id": 2,
+      "action_name": "Created project",
+      "url": "https://my.weblate.org/api/changes/2/"
+    }
+  ]
+}

--- a/tests/data/weblate/weblate_changes_archived.json
+++ b/tests/data/weblate/weblate_changes_archived.json
@@ -1,0 +1,62 @@
+{
+  "count": 10,
+  "previous": null,
+  "results": [
+    {
+      "unit": null,
+      "component": null,
+      "translation": null,
+      "glossary_term": null,
+      "user": "https://my.weblate.org/api/users/1",
+      "author": "https://my.weblate.org/api/users/1",
+      "timestamp": "2019-07-11T16:20:20.958070Z",
+      "action": 50,
+      "target": "",
+      "id": 1,
+      "action_name": "Created project",
+      "url": "https://my.weblate.org/api/changes/1/"
+    },
+    {
+      "unit": null,
+      "component": null,
+      "translation": null,
+      "glossary_term": null,
+      "user": "https://my.weblate.org/api/users/2",
+      "author": "https://my.weblate.org/api/users/2",
+      "timestamp": "2019-07-11T16:21:11.939033Z",
+      "action": 50,
+      "target": "",
+      "id": 2,
+      "action_name": "Created project",
+      "url": "https://my.weblate.org/api/changes/2/"
+    },
+    {
+      "unit": null,
+      "component": "https://my.weblate.org/api/components/libo_ui-master/instsetoo_nativeinc_openofficewindowsmsi_languages/",
+      "translation": null,
+      "glossary_term": null,
+      "user": "https://my.weblate.org/api/users/2",
+      "author": "https://my.weblate.org/api/users/2",
+      "timestamp": "2020-07-11T17:21:03.378436Z",
+      "action": 51,
+      "target": "",
+      "id": 3,
+      "action_name": "Created component",
+      "url": "https://my.weblate.org/api/changes/3/"
+    },
+    {
+      "unit": null,
+      "component": "https://my.weblate.org/api/components/libo_ui-master/instsetoo_nativeinc_openofficewindowsmsi_languages/",
+      "translation": null,
+      "glossary_term": null,
+      "user": null,
+      "author": null,
+      "timestamp": "2020-07-11T17:21:04.609924Z",
+      "action": 21,
+      "target": "",
+      "id": 4,
+      "action_name": "Rebased repository",
+      "url": "https://my.weblate.org/api/changes/4/"
+    }
+  ]
+}

--- a/tests/data/weblate/weblate_changes_expected.json
+++ b/tests/data/weblate/weblate_changes_expected.json
@@ -1,0 +1,196 @@
+[
+    {
+        "backend_name": "Weblate",
+        "backend_version": "0.1.0",
+        "perceval_version": "0.17.1",
+        "timestamp": 1600344221.316199,
+        "origin": "https://my.weblate.org",
+        "uuid": "83a1ea675884a0cdeff02d30a7013e1600907524",
+        "updated_on": 1562862020.95807,
+        "classified_fields_filtered": null,
+        "category": "changes",
+        "search_fields": {
+            "item_id": "1"
+        },
+        "tag": "https://my.weblate.org",
+        "data": {
+            "unit": null,
+            "component": null,
+            "translation": null,
+            "glossary_term": null,
+            "user": "https://my.weblate.org/api/users/1",
+            "author": "https://my.weblate.org/api/users/1",
+            "timestamp": "2019-07-11T16:20:20.958070Z",
+            "action": 50,
+            "target": "",
+            "id": 1,
+            "action_name": "Created project",
+            "url": "https://my.weblate.org/api/changes/1/",
+            "user_data": {
+                "email": "quan@bitergia.com",
+                "full_name": "quan zhou",
+                "username": "quan",
+                "groups": [
+                    "https://my.weblate.org/api/groups/2/",
+                    "https://my.weblate.org/api/groups/3/"
+                ],
+                "is_superuser": false,
+                "is_active": true,
+                "date_joined": "2020-09-16T09:03:33.581180Z",
+                "url": "https://my.weblate.org/api/users/1/"
+            },
+            "author_data": {
+                "email": "quan@bitergia.com",
+                "full_name": "quan zhou",
+                "username": "quan",
+                "groups": [
+                    "https://my.weblate.org/api/groups/2/",
+                    "https://my.weblate.org/api/groups/3/"
+                ],
+                "is_superuser": false,
+                "is_active": true,
+                "date_joined": "2020-09-16T09:03:33.581180Z",
+                "url": "https://my.weblate.org/api/users/1/"
+            }
+        }
+    },
+    {
+        "backend_name": "Weblate",
+        "backend_version": "0.1.0",
+        "perceval_version": "0.17.1",
+        "timestamp": 1600344221.351258,
+        "origin": "https://my.weblate.org",
+        "uuid": "ca17062e0fe54ffb3bb80d2f6967f56709d43bfe",
+        "updated_on": 1562862071.939033,
+        "classified_fields_filtered": null,
+        "category": "changes",
+        "search_fields": {
+            "item_id": "2"
+        },
+        "tag": "https://my.weblate.org",
+        "data": {
+            "unit": null,
+            "component": null,
+            "translation": null,
+            "glossary_term": null,
+            "user": "https://my.weblate.org/api/users/2",
+            "author": "https://my.weblate.org/api/users/2",
+            "timestamp": "2019-07-11T16:21:11.939033Z",
+            "action": 50,
+            "target": "",
+            "id": 2,
+            "action_name": "Created project",
+            "url": "https://my.weblate.org/api/changes/2/",
+            "user_data": {
+                "email": "tom@jerry.com",
+                "full_name": "tom jerry",
+                "username": "tom",
+                "groups": [
+                    "https://my.weblate.org/api/groups/2/",
+                    "https://my.weblate.org/api/groups/3/"
+                ],
+                "is_superuser": false,
+                "is_active": true,
+                "date_joined": "2020-09-17T09:03:33.581180Z",
+                "url": "https://my.weblate.org/api/users/2/"
+            },
+            "author_data": {
+                "email": "tom@jerry.com",
+                "full_name": "tom jerry",
+                "username": "tom",
+                "groups": [
+                    "https://my.weblate.org/api/groups/2/",
+                    "https://my.weblate.org/api/groups/3/"
+                ],
+                "is_superuser": false,
+                "is_active": true,
+                "date_joined": "2020-09-17T09:03:33.581180Z",
+                "url": "https://my.weblate.org/api/users/2/"
+            }
+        }
+    },
+    {
+        "backend_name": "Weblate",
+        "backend_version": "0.1.0",
+        "perceval_version": "0.17.1",
+        "timestamp": 1600344221.399991,
+        "origin": "https://my.weblate.org",
+        "uuid": "957659c9f35d7b35795296ff69f69b87356e6fe6",
+        "updated_on": 1594488063.378436,
+        "classified_fields_filtered": null,
+        "category": "changes",
+        "search_fields": {
+            "item_id": "3"
+        },
+        "tag": "https://my.weblate.org",
+        "data": {
+            "unit": null,
+            "component": "https://my.weblate.org/api/components/libo_ui-master/instsetoo_nativeinc_openofficewindowsmsi_languages/",
+            "translation": null,
+            "glossary_term": null,
+            "user": "https://my.weblate.org/api/users/2",
+            "author": "https://my.weblate.org/api/users/2",
+            "timestamp": "2020-07-11T17:21:03.378436Z",
+            "action": 51,
+            "target": "",
+            "id": 3,
+            "action_name": "Created component",
+            "url": "https://my.weblate.org/api/changes/3/",
+            "user_data": {
+                "email": "tom@jerry.com",
+                "full_name": "tom jerry",
+                "username": "tom",
+                "groups": [
+                    "https://my.weblate.org/api/groups/2/",
+                    "https://my.weblate.org/api/groups/3/"
+                ],
+                "is_superuser": false,
+                "is_active": true,
+                "date_joined": "2020-09-17T09:03:33.581180Z",
+                "url": "https://my.weblate.org/api/users/2/"
+            },
+            "author_data": {
+                "email": "tom@jerry.com",
+                "full_name": "tom jerry",
+                "username": "tom",
+                "groups": [
+                    "https://my.weblate.org/api/groups/2/",
+                    "https://my.weblate.org/api/groups/3/"
+                ],
+                "is_superuser": false,
+                "is_active": true,
+                "date_joined": "2020-09-17T09:03:33.581180Z",
+                "url": "https://my.weblate.org/api/users/2/"
+            }
+        }
+    },
+    {
+        "backend_name": "Weblate",
+        "backend_version": "0.1.0",
+        "perceval_version": "0.17.1",
+        "timestamp": 1600344221.401215,
+        "origin": "https://my.weblate.org",
+        "uuid": "eab568229e67d6f630832ee1446e247d6207a3b3",
+        "updated_on": 1594488064.609924,
+        "classified_fields_filtered": null,
+        "category": "changes",
+        "search_fields": {
+            "item_id": "4"
+        },
+        "tag": "https://my.weblate.org",
+        "data": {
+            "unit": null,
+            "component": "https://my.weblate.org/api/components/libo_ui-master/instsetoo_nativeinc_openofficewindowsmsi_languages/",
+            "translation": null,
+            "glossary_term": null,
+            "user": null,
+            "author": null,
+            "timestamp": "2020-07-11T17:21:04.609924Z",
+            "action": 21,
+            "target": "",
+            "id": 4,
+            "action_name": "Rebased repository",
+            "url": "https://my.weblate.org/api/changes/4/"
+        }
+    }
+]

--- a/tests/data/weblate/weblate_changes_page_2.json
+++ b/tests/data/weblate/weblate_changes_page_2.json
@@ -1,0 +1,34 @@
+{
+  "count": 10,
+  "previous": "https://my.weblate.org/api/changes",
+  "results": [
+    {
+      "unit": null,
+      "component": "https://my.weblate.org/api/components/libo_ui-master/instsetoo_nativeinc_openofficewindowsmsi_languages/",
+      "translation": null,
+      "glossary_term": null,
+      "user": "https://my.weblate.org/api/users/2",
+      "author": "https://my.weblate.org/api/users/2",
+      "timestamp": "2020-07-11T17:21:03.378436Z",
+      "action": 51,
+      "target": "",
+      "id": 3,
+      "action_name": "Created component",
+      "url": "https://my.weblate.org/api/changes/3/"
+    },
+    {
+      "unit": null,
+      "component": "https://my.weblate.org/api/components/libo_ui-master/instsetoo_nativeinc_openofficewindowsmsi_languages/",
+      "translation": null,
+      "glossary_term": null,
+      "user": null,
+      "author": null,
+      "timestamp": "2020-07-11T17:21:04.609924Z",
+      "action": 21,
+      "target": "",
+      "id": 4,
+      "action_name": "Rebased repository",
+      "url": "https://my.weblate.org/api/changes/4/"
+    }
+  ]
+}

--- a/tests/data/weblate/weblate_user_1.json
+++ b/tests/data/weblate/weblate_user_1.json
@@ -1,0 +1,13 @@
+{
+    "email": "quan@bitergia.com",
+    "full_name": "quan zhou",
+    "username": "quan",
+    "groups": [
+        "https://my.weblate.org/api/groups/2/",
+        "https://my.weblate.org/api/groups/3/"
+    ],
+    "is_superuser": false,
+    "is_active": true,
+    "date_joined": "2020-09-16T09:03:33.581180Z",
+    "url": "https://my.weblate.org/api/users/1/"
+}

--- a/tests/data/weblate/weblate_user_2.json
+++ b/tests/data/weblate/weblate_user_2.json
@@ -1,0 +1,13 @@
+{
+    "email": "tom@jerry.com",
+    "full_name": "tom jerry",
+    "username": "tom",
+    "groups": [
+        "https://my.weblate.org/api/groups/2/",
+        "https://my.weblate.org/api/groups/3/"
+    ],
+    "is_superuser": false,
+    "is_active": true,
+    "date_joined": "2020-09-17T09:03:33.581180Z",
+    "url": "https://my.weblate.org/api/users/2/"
+}

--- a/tests/data/weblate/weblate_user_no_permission.json
+++ b/tests/data/weblate/weblate_user_no_permission.json
@@ -1,0 +1,3 @@
+{
+    "detail": "Not found."
+}

--- a/tests/test_weblate.py
+++ b/tests/test_weblate.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Quan Zhou <quan@bitergia.com>
+#
+
+
+import datetime
+import dateutil
+import httpretty
+import json
+import os
+import pkg_resources
+import unittest
+import warnings
+
+pkg_resources.declare_namespace('perceval.backends')
+
+from perceval.backend import BackendCommandArgumentParser
+from perceval.backends.core.weblate import (Weblate,
+                                            WeblateClient,
+                                            WeblateCommand)
+
+
+WEBLATE_API_URL = 'https://my.weblate.org/api/'
+WEBLATE_CHANGES_API_URL = WEBLATE_API_URL + 'changes'
+WEBLATE_CHANGES_PAGE_2_API_URL = WEBLATE_CHANGES_API_URL + '/?page=2'
+WEBLATE_USERS_API_URL = WEBLATE_API_URL + 'users'
+WEBLATE_USER_1_API_URL = WEBLATE_USERS_API_URL + '/1'
+WEBLATE_USER_2_API_URL = WEBLATE_USERS_API_URL + '/2'
+WEBLATE_USER_NO_PERMISSION_API_URL = WEBLATE_USERS_API_URL + '/NoPermission'
+
+NO_CHECK_FIELDS = ['timestamp', 'backend_version', 'perceval_version']
+
+
+def read_file(filename, mode='r'):
+    with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), filename), mode) as f:
+        content = f.read()
+    return content
+
+
+def setup_http_server(archived_changes=False):
+    """Setup a mock HTTP server"""
+
+    http_requests = []
+
+    if archived_changes:
+        changes = read_file('data/weblate/weblate_changes_archived.json', 'rb')
+    else:
+        changes = read_file('data/weblate/weblate_changes.json', 'rb')
+    changes_page_2 = read_file('data/weblate/weblate_changes_page_2.json', 'rb')
+
+    user_1 = read_file('data/weblate/weblate_user_1.json', 'rb')
+    user_2 = read_file('data/weblate/weblate_user_2.json', 'rb')
+    user_no_permission = read_file('data/weblate/weblate_user_no_permission.json', 'rb')
+
+    def request_callback(_, uri, headers):
+        last_request = httpretty.last_request()
+        params = last_request.querystring
+
+        status = 200
+
+        if uri.startswith(WEBLATE_CHANGES_API_URL):
+            if 'timestamp_after' in params and '2020-01-01T00:00:00 00:00' in params['timestamp_after']:
+                body = changes_page_2
+            elif 'page' not in params:
+                body = changes
+            else:
+                body = changes_page_2
+        elif uri.startswith(WEBLATE_USER_1_API_URL):
+            body = user_1
+        elif uri.startswith(WEBLATE_USER_2_API_URL):
+            body = user_2
+        elif uri.startswith(WEBLATE_USER_NO_PERMISSION_API_URL):
+            body = user_no_permission
+        else:
+            raise
+
+        http_requests.append(last_request)
+
+        return status, headers, body
+
+    httpretty.register_uri(httpretty.GET,
+                           WEBLATE_CHANGES_API_URL,
+                           responses=[
+                               httpretty.Response(body=request_callback)
+                           ])
+
+    httpretty.register_uri(httpretty.GET,
+                           WEBLATE_CHANGES_PAGE_2_API_URL,
+                           responses=[
+                               httpretty.Response(body=request_callback)
+                           ])
+
+    httpretty.register_uri(httpretty.GET,
+                           WEBLATE_USER_1_API_URL,
+                           responses=[
+                               httpretty.Response(body=request_callback)
+                           ])
+
+    httpretty.register_uri(httpretty.GET,
+                           WEBLATE_USER_2_API_URL,
+                           responses=[
+                               httpretty.Response(body=request_callback)
+                           ])
+
+    httpretty.register_uri(httpretty.GET,
+                           WEBLATE_USER_NO_PERMISSION_API_URL,
+                           status=404,
+                           responses=[
+                               httpretty.Response(body=request_callback)
+                           ])
+
+    return http_requests
+
+
+class TestWeblateBackend(unittest.TestCase):
+    """Weblate backend tests"""
+
+    def test_initialization(self):
+        """Test whether attributes are initialized"""
+
+        weblate = Weblate('https://my.weblate.org', api_token='xxyyzz')
+
+        self.assertEqual(weblate.origin, 'https://my.weblate.org')
+        self.assertListEqual(weblate.categories, ['changes'])
+        self.assertEqual(weblate.api_token, 'xxyyzz')
+
+    def test_has_archiving(self):
+        """Test if it returns True when has_archiving is called"""
+
+        self.assertEqual(Weblate.has_archiving(), True)
+
+    def test_has_resuming(self):
+        """Test if it returns True when has_resuming is called"""
+
+        self.assertEqual(Weblate.has_resuming(), True)
+
+    @httpretty.activate
+    def test_fetch(self):
+        """Test if it fetches a list of changes"""
+
+        warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
+
+        http_requests = setup_http_server()
+
+        weblate = Weblate('https://my.weblate.org')
+        changes = [change for change in weblate.fetch(from_date=None)]
+
+        changes_expected = json.loads(read_file('data/weblate/weblate_changes_expected.json', 'r'))
+        self.assertEqual(len(changes), len(changes_expected))
+
+        # remove timestamp due to this value change for each execution
+        changes_no_timestamp = [{k: v for k, v in change.items() if k not in NO_CHECK_FIELDS} for change in changes]
+        changes_expected_no_timestamp = [{k: v for k, v in change.items() if k not in NO_CHECK_FIELDS}
+                                         for change in changes_expected]
+        self.assertListEqual(changes_no_timestamp, changes_expected_no_timestamp)
+
+        requests_path_expected = [
+            '/api/changes?timestamp_after=1970-01-01T00%3A00%3A00%2B00%3A00',
+            '/api/users/1',
+            '/api/users/1',
+            '/api/users/2',
+            '/api/users/2',
+            '/api/changes/?page=2',
+            '/api/users/2',
+            '/api/users/2'
+        ]
+        self.assertEqual(len(http_requests), len(requests_path_expected))
+        for i in range(len(http_requests)):
+            self.assertEqual(http_requests[i].path, requests_path_expected[i])
+
+    @httpretty.activate
+    def test_fetch_archived(self):
+        """Test if it fetches a list of changes from an archived file"""
+
+        http_requests = setup_http_server(archived_changes=True)
+
+        weblate = Weblate('https://my.weblate.org')
+        changes = [change for change in weblate.fetch(from_date=None)]
+
+        changes_expected = json.loads(read_file('data/weblate/weblate_changes_expected.json', 'r'))
+        self.assertEqual(len(changes), len(changes_expected))
+
+        # remove timestamp due to this value change for each execution
+        changes_no_timestamp = [{k: v for k, v in change.items() if k not in NO_CHECK_FIELDS} for change in changes]
+        changes_expected_no_timestamp = [{k: v for k, v in change.items() if k not in NO_CHECK_FIELDS} for change in
+                                         changes_expected]
+        self.assertListEqual(changes_no_timestamp, changes_expected_no_timestamp)
+
+        requests_path_expected = [
+            '/api/changes?timestamp_after=1970-01-01T00%3A00%3A00%2B00%3A00',
+            '/api/users/1',
+            '/api/users/1',
+            '/api/users/2',
+            '/api/users/2',
+            '/api/users/2',
+            '/api/users/2'
+        ]
+        self.assertEqual(len(http_requests), len(requests_path_expected))
+        for i in range(len(http_requests)):
+            self.assertEqual(http_requests[i].path, requests_path_expected[i])
+
+    @httpretty.activate
+    def test_fetch_from_date(self):
+        """Test if it fetches a list of changes since a given date"""
+
+        http_requests = setup_http_server()
+
+        from_date = datetime.datetime(2020, 1, 1, 00, 00, 00, 00,
+                                      tzinfo=dateutil.tz.tzutc())
+
+        weblate = Weblate('https://my.weblate.org')
+        changes = [change for change in weblate.fetch(from_date=from_date)]
+
+        changes_expected_all = json.loads(read_file('data/weblate/weblate_changes_expected.json', 'r'))
+        changes_expected = changes_expected_all[2:]
+        self.assertEqual(len(changes), len(changes_expected))
+
+        # remove timestamp due to this value change for each execution
+        changes_no_timestamp = [{k: v for k, v in change.items() if k not in NO_CHECK_FIELDS} for change in changes]
+        changes_expected_no_timestamp = [{k: v for k, v in change.items() if k not in NO_CHECK_FIELDS} for change in
+                                         changes_expected]
+        self.assertListEqual(changes_no_timestamp, changes_expected_no_timestamp)
+
+        requests_path_expected = [
+            '/api/changes?timestamp_after=2020-01-01T00%3A00%3A00%2B00%3A00',
+            '/api/users/2',
+            '/api/users/2'
+        ]
+        self.assertEqual(len(http_requests), len(requests_path_expected))
+        for i in range(len(http_requests)):
+            self.assertEqual(http_requests[i].path, requests_path_expected[i])
+
+    def test_metadata_updated_on(self):
+        """Test if metadata_updated_on converts date correctly"""
+
+        weblate = Weblate('https://my.weblate.org')
+        metadata_updated_on = weblate.metadata_updated_on({'timestamp': '2020-01-01'})
+        self.assertEqual(metadata_updated_on, 1577836800.0)
+
+
+class TestWeblateClient(unittest.TestCase):
+    """Weblate API client tests."""
+
+    def test_init(self):
+        """Test initialization"""
+
+        client = WeblateClient('https://my.weblate.org', api_token="xxyyzz")
+        self.assertEqual(client.api_token, 'xxyyzz')
+        self.assertTrue(client.ssl_verify)
+
+        client = WeblateClient('https://my.weblate.org', api_token="xxyyzz",
+                               project="test", ssl_verify=False)
+        self.assertEqual(client.api_token, 'xxyyzz')
+        self.assertEqual(client.project, "test")
+        self.assertFalse(client.ssl_verify)
+
+    @httpretty.activate
+    def test_user(self):
+        """Test user API call"""
+
+        http_requests = setup_http_server()
+
+        client = WeblateClient('https://my.weblate.org', api_token="xxyyzz")
+
+        user_1 = client.user(WEBLATE_USER_1_API_URL)
+
+        user_1_expected = json.loads(read_file('data/weblate/weblate_user_1.json', 'r'))
+        self.assertDictEqual(user_1, user_1_expected)
+
+        requests_path_expected = [
+            '/api/users/1'
+        ]
+        self.assertEqual(len(http_requests), len(requests_path_expected))
+        for i in range(len(http_requests)):
+            self.assertEqual(http_requests[i].path, requests_path_expected[i])
+
+    @httpretty.activate
+    def test_user_no_permission(self):
+        """Test user API call when we don't have manager permission"""
+
+        http_requests = setup_http_server()
+
+        client = WeblateClient('https://my.weblate.org', api_token="xxyyzz")
+
+        user = client.user(WEBLATE_USER_NO_PERMISSION_API_URL)
+
+        user_expected = json.loads(read_file('data/weblate/weblate_user_no_permission.json', 'r'))
+        self.assertDictEqual(user, user_expected)
+
+        requests_path_expected = [
+            '/api/users/NoPermission'
+        ]
+        self.assertEqual(len(http_requests), len(requests_path_expected))
+        for i in range(len(http_requests)):
+            self.assertEqual(http_requests[i].path, requests_path_expected[i])
+
+    @httpretty.activate
+    def test_changes(self):
+        """Test changes API call"""
+
+        http_requests = setup_http_server()
+
+        client = WeblateClient('https://my.weblate.org', api_token="xxyyzz")
+
+        changes = [change for change in client.changes()]
+
+        changes_raw = json.loads(read_file('data/weblate/weblate_changes.json', 'r'))
+        changes_raw_page_2 = json.loads(read_file('data/weblate/weblate_changes_page_2.json', 'r'))
+        changes_expected_page_1 = changes_raw['results']
+        changes_expected_page_2 = changes_raw_page_2['results']
+        self.assertEqual(len(changes[0]), len(changes_expected_page_1))
+        self.assertEqual(len(changes[1]), len(changes_expected_page_2))
+        self.assertListEqual(changes[0], changes_expected_page_1)
+        self.assertListEqual(changes[1], changes_expected_page_2)
+
+        requests_path_expected = [
+            '/api/changes',
+            '/api/changes/?page=2'
+        ]
+        self.assertEqual(len(http_requests), len(requests_path_expected))
+        for i in range(len(http_requests)):
+            self.assertEqual(http_requests[i].path, requests_path_expected[i])
+
+    @httpretty.activate
+    def test_fetch(self):
+        """Test if it fetches a list of changes"""
+
+        http_requests = setup_http_server()
+
+        client = WeblateClient('https://my.weblate.org', api_token="xxyyzz")
+
+        changes_response = client.fetch(WEBLATE_CHANGES_API_URL)
+        changes_raw = changes_response.json()
+
+        changes_raw_expected = json.loads(read_file('data/weblate/weblate_changes.json', 'r'))
+        self.assertDictEqual(changes_raw, changes_raw_expected)
+
+        requests_path_expected = [
+            '/api/changes'
+        ]
+        self.assertEqual(len(http_requests), len(requests_path_expected))
+        for i in range(len(http_requests)):
+            self.assertEqual(http_requests[i].path, requests_path_expected[i])
+
+
+class TestWeblateCommand(unittest.TestCase):
+    """WeblateCommand unit tests"""
+
+    def test_backend_class(self):
+        """Test if the backend class is Weblate"""
+
+        self.assertIs(WeblateCommand.BACKEND, Weblate)
+
+    def test_setup_cmd_parser(self):
+        """Test if it parser object is correctly initialized"""
+
+        parser = WeblateCommand.setup_cmd_parser()
+        self.assertIsInstance(parser, BackendCommandArgumentParser)
+        self.assertEqual(parser._backend, Weblate)
+        from_date = datetime.datetime(2020, 1, 1, 00, 00, 00, 00,
+                                      tzinfo=dateutil.tz.tzutc())
+
+        args = ['https://my.weblate.org', '--no-archive',
+                '-t', 'xxyyzz',
+                '--from-date', '2020-01-01',
+                '--sleep-for-rate',
+                '--min-rate-to-sleep', '10',
+                '--project', 'test',
+                '--max-retries', '5',
+                '--sleep-time', '1']
+
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.url, 'https://my.weblate.org')
+        self.assertTrue(parsed_args.no_archive)
+        self.assertEqual(parsed_args.api_token, 'xxyyzz')
+        self.assertEqual(parsed_args.from_date, from_date)
+        self.assertTrue(parsed_args.sleep_for_rate)
+        self.assertEqual(parsed_args.min_rate_to_sleep, 10)
+        self.assertEqual(parsed_args.project, 'test')
+        self.assertEqual(parsed_args.max_retries, 5)
+        self.assertEqual(parsed_args.sleep_time, 1)
+
+
+if __name__ == "__main__":
+    unittest.main(warnings='ignore')


### PR DESCRIPTION
Backend to extract changes from a Weblate instance.
The changes can be collected for a given project or for all
the projects in the instance.

The initial tests have been done on:
- https://hosted.weblate.org (Weblate API 4.2)
- https://translations.documentfoundation.org (Weblate API 4.1)

Notes:
- Sleep for rate is working in >=4.1.
- Incremental fetching works for all projects in >=4.1.
- Incremental fetching works for single projects in >=4.2.
- Users details can be fetched only if the token has enough permissions.
  See details at: https://docs.weblate.org/en/latest/api.html#get--api-users-.

The backend can be executed as follows:
```
perceval weblate
https://translations.documentfoundation.org
-t
<token>
--from-date
2020-01-01
--no-archive
```

The token can be obtained after registering to a weblate
instance (e.g., https://translations.documentfoundation.org/),
via the page <instance>/accounts/profile/#api

Test added correctly.