### PR TITLE
[githubql] Add MergedEvent info

### DIFF
--- a/perceval/backends/core/githubql.py
+++ b/perceval/backends/core/githubql.py
@@ -17,6 +17,7 @@
 #
 # Authors:
 #     Valerio Cosentino <valcos@bitergia.com>
+#     Quan Zhou <quan@bitergia.com>
 #
 
 import json
@@ -47,7 +48,8 @@ EVENT_TYPES = [
     'CROSS_REFERENCED_EVENT',
     'LABELED_EVENT',
     'UNLABELED_EVENT',
-    'CLOSED_EVENT'
+    'CLOSED_EVENT',
+    'MERGED_EVENT'
 ]
 
 QUERY_TEMPLATE = """
@@ -192,6 +194,23 @@ QUERY_TEMPLATE = """
                     closedAt
                     state
                   }
+                }
+                ... on MergedEvent {
+                  actor {
+                    login
+                  },
+                  id
+                  createdAt
+                  pullRequest {
+                    closed
+                    closedAt
+                    createdAt
+                    merged
+                    mergedAt
+                    updatedAt
+                    url
+                  }
+                  url
                 }
               }
               pageInfo {

--- a/tests/data/github/github_events_page_1
+++ b/tests/data/github/github_events_page_1
@@ -33,6 +33,24 @@
                                 "name": "duplicate",
                                 "updatedAt": "2020-04-07T10:30:46Z"
                             }
+                        },
+                        {
+                            "eventType": "MergedEvent",
+                            "actor": {
+                                "login": "zhquan"
+                            },
+                            "id": "DDExOk1lcmdlZEV2ZW50MTE0NDMwMzM2",
+                            "createdAt": "2020-10-23T18:45:14Z",
+                            "pullRequest": {
+                                "closed": true,
+                                "closedAt": "2020-10-23T18:45:14Z",
+                                "createdAt": "2020-10-23T18:45:06Z",
+                                "merged": true,
+                                "mergedAt": "2020-10-23T18:45:14Z",
+                                "updatedAt": "2020-10-23T18:45:14Z",
+                                "url": "https://github.com/zhquan/test-merged-event/pull/3"
+                            },
+                            "url": "https://github.com/zhquan/test-merged-event/pull/3#event-114430334"
                         }
                     ],
                     "pageInfo": {

--- a/tests/test_githubql.py
+++ b/tests/test_githubql.py
@@ -222,7 +222,7 @@ class TestGitHubQLBackend(unittest.TestCase):
         github = GitHubQL("zhquan_example", "repo", ["aaa"])
         events = [events for events in github.fetch(from_date=None, to_date=None, category=CATEGORY_EVENT)]
 
-        self.assertEqual(len(events), 4)
+        self.assertEqual(len(events), 5)
 
         event = events[0]
         self.assertEqual(event['origin'], 'https://github.com/zhquan_example/repo')
@@ -248,6 +248,17 @@ class TestGitHubQLBackend(unittest.TestCase):
 
         event = events[2]
         self.assertEqual(event['origin'], 'https://github.com/zhquan_example/repo')
+        self.assertEqual(event['uuid'], 'b6a2db57d14632a1228def9c25720f5ade396448')
+        self.assertEqual(event['updated_on'], 1603478714.0)
+        self.assertEqual(event['category'], CATEGORY_EVENT)
+        self.assertEqual(event['tag'], 'https://github.com/zhquan_example/repo')
+        self.assertEqual(event['data']['actor']['login'], 'zhquan')
+        self.assertEqual(event['data']['createdAt'], '2020-10-23T18:45:14Z')
+        self.assertEqual(event['data']['eventType'], 'MergedEvent')
+        self.assertIn('issue', event['data'])
+
+        event = events[3]
+        self.assertEqual(event['origin'], 'https://github.com/zhquan_example/repo')
         self.assertEqual(event['uuid'], 'b46499fd01d2958d836241770063adff953b280e')
         self.assertEqual(event['updated_on'], 1586265768.0)
         self.assertEqual(event['category'], CATEGORY_EVENT)
@@ -257,7 +268,7 @@ class TestGitHubQLBackend(unittest.TestCase):
         self.assertEqual(event['data']['eventType'], 'MovedColumnsInProjectEvent')
         self.assertIn('issue', event['data'])
 
-        event = events[3]
+        event = events[4]
         self.assertEqual(event['origin'], 'https://github.com/zhquan_example/repo')
         self.assertEqual(event['uuid'], 'd05238b1254cf69deac49248ad8cc855482a6737')
         self.assertEqual(event['updated_on'], 1586265783.0)
@@ -267,6 +278,7 @@ class TestGitHubQLBackend(unittest.TestCase):
         self.assertEqual(event['data']['createdAt'], '2020-04-07T13:23:03Z')
         self.assertEqual(event['data']['eventType'], 'CrossReferencedEvent')
         self.assertIn('issue', event['data'])
+
 
     @httpretty.activate
     def test_fetch_events_until_date(self):
@@ -612,7 +624,7 @@ class TestGitHubQLClient(unittest.TestCase):
 
         client = GitHubQLClient("zhquan_example", "repo", ["aaa"], None)
         events = [event for event in client.events(issue_number=1, is_pull=False, from_date=DEFAULT_DATETIME)]
-        self.assertEqual(len(events[0]), 2)
+        self.assertEqual(len(events[0]), 3)
         self.assertEqual(len(events[1]), 2)
         self.assertEqual(httpretty.last_request().headers["Authorization"], "token aaa")
 


### PR DESCRIPTION
This code adds MergedEvent info as:
- actor
  - login
- id
- createAt
- pullRequest
  - closed
  - closedAt
  - createdAt
  - merged
  - mergedAt
  - updatedAt
  - url
- url

Tests updated accordingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>