### PR TITLE
[githubql] Fix error `Events not collected for issue...`

### DIFF
--- a/tests/data/github/github_events_page_1
+++ b/tests/data/github/github_events_page_1
@@ -33,24 +33,6 @@
                                 "name": "duplicate",
                                 "updatedAt": "2020-04-07T10:30:46Z"
                             }
-                        },
-                        {
-                            "eventType": "MergedEvent",
-                            "actor": {
-                                "login": "zhquan"
-                            },
-                            "id": "DDExOk1lcmdlZEV2ZW50MTE0NDMwMzM2",
-                            "createdAt": "2020-10-23T18:45:14Z",
-                            "pullRequest": {
-                                "closed": true,
-                                "closedAt": "2020-10-23T18:45:14Z",
-                                "createdAt": "2020-10-23T18:45:06Z",
-                                "merged": true,
-                                "mergedAt": "2020-10-23T18:45:14Z",
-                                "updatedAt": "2020-10-23T18:45:14Z",
-                                "url": "https://github.com/zhquan/test-merged-event/pull/3"
-                            },
-                            "url": "https://github.com/zhquan/test-merged-event/pull/3#event-114430334"
                         }
                     ],
                     "pageInfo": {

--- a/tests/data/github/github_events_page_3
+++ b/tests/data/github/github_events_page_3
@@ -1,0 +1,34 @@
+{
+    "data": {
+        "repository": {
+            "pullRequest": {
+                "timelineItems": {
+                    "nodes": [
+                        {
+                            "eventType": "MergedEvent",
+                            "actor": {
+                                "login": "zhquan"
+                            },
+                            "id": "MDExOk1lcmdlZEV2ZW50Mzg1MTg2NjA3MQ==",
+                            "createdAt": "2020-10-07T18:08:10Z",
+                            "pullRequest": {
+                                "closed": true,
+                                "closedAt": "2020-10-07T18:08:10Z",
+                                "createdAt": "2020-09-25T15:41:15Z",
+                                "merged": true,
+                                "mergedAt": "2020-10-07T18:08:10Z",
+                                "updatedAt": "2020-10-07T18:08:10Z",
+                                "url": "https://github.com/zhquan/test-merged-event/pull/387"
+                            },
+                            "url": "https://github.com/zhquan/test-merged-event/pull/387#event-3851866071"
+                        }
+                    ],
+                    "pageInfo": {
+                        "endCursor": "Y3Vyc29yOnYyOpPPAAABdQQ_xxABqjM4NTE4NjYwOTI=",
+                        "hasNextPage": false
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This code fixes the error `Events not collected for issue ...'`,
which is caused when fetching MergedEvent on issues because
this event type is only available for pull requests.

Tests updated accordingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>