### PR TITLE
Add a CONTRIBUTING file referring to GrimoireLab

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contributing to GrimoireLab-Perceval
+
+Contributions to this repository should follow the guidelines [here](https://github.com/chaoss/grimoirelab/blob/master/CONTRIBUTING.md)
+


### PR DESCRIPTION
Add a CONTRIBUTING.md file referring users to the central GrimoireLab
documentation (specifically the CONTRIBUTING.md file). This could help
any future contributors find the right standards up front.
