### PR TITLE
[slack] Fix fetch message from a private user

### DIFF
--- a/perceval/backends/core/slack.py
+++ b/perceval/backends/core/slack.py
@@ -61,7 +61,7 @@ class Slack(Backend):
     :param archive: archive to store/retrieve items
     :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.9.3'
+    version = '0.9.4'
 
     CATEGORIES = [CATEGORY_MESSAGE]
     EXTRA_SEARCH_FIELDS = {
@@ -439,6 +439,8 @@ class SlackClient(HttpClient):
         result = r.json()
 
         if not result['ok']:
+            if result['error'] == 'user_not_found':
+                return '{"ok":false,"user":null}'
             raise SlackClientError(error=result['error'])
 
         return r.text

--- a/tests/data/slack/slack_user_U0004_private.json
+++ b/tests/data/slack/slack_user_U0004_private.json
@@ -1,0 +1,4 @@
+{
+    "ok": false,
+    "error": "user_not_found"
+}

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -843,6 +843,21 @@ class TestSlackClient(unittest.TestCase):
         self.assertEqual(headers, s_headers)
         self.assertEqual(payload, s_payload)
 
+    @httpretty.activate
+    def test_private_user(self):
+
+        user_U0004 = read_file('data/slack/slack_user_U0004_private.json', 'rb')
+        httpretty.register_uri(httpretty.GET,
+                               SLACK_USER_INFO_URL + "?user=U0004",
+                               body=user_U0004)
+
+        client = SlackClient('aaaa', max_items=5)
+
+        # Call API
+        user = client.user('U0004')
+
+        self.assertEqual(user, '{"ok":false,"user":null}')
+
 
 class TestSlackCommand(unittest.TestCase):
     """SlackCommand unit tests"""


### PR DESCRIPTION
This code allows fetching message from a private user and set
the `user` data as `None`.

Signed-off-by: Quan Zhou <quan@bitergia.com>