### PR TITLE
Supybot now supports logs without timezone information

### DIFF
--- a/perceval/backends/core/supybot.py
+++ b/perceval/backends/core/supybot.py
@@ -314,7 +314,7 @@ class SupybotParser:
 
     :param stream: an iterator which produces Supybot log lines
     """
-    TIMESTAMP_PATTERN = r"""^(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[\+\-]\d{4})\s\s
+    TIMESTAMP_PATTERN = r"""^(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[\+\-]?\d{0,4})\s\s
                         (?P<msg>.+)$
                         """
     COMMENT_PATTERN = r"^<(?P<nick>(.*?)(!.*)?)>\s(?P<body>.+)$"

--- a/tests/data/supybot/supybot_date_without_tz.log
+++ b/tests/data/supybot/supybot_date_without_tz.log
@@ -1,0 +1,3 @@
+2021-01-12T11:28:19  *** grimoire_bot <grimoire_bot!~limnoria@45.55.49.14> has joined #rit-foss
+2021-01-12T11:29:41  <nolski> test
+2021-01-12T11:29:41  <xbot1313> Test Case Passed!


### PR DESCRIPTION
Supybot now supports logs without timezone information

Supybot is deprecated and the logs generated by its successor,
Limoria, do not contain timezone information.

Test failing when no timezone information was given has been modified
to pass now.
An additional log file based on the issue report #709 has been added
to the test suite.

Resolves: #709