### PR TITLE
Revert "[slack] Use channels.history to retrieve message"

### DIFF
--- a/perceval/backends/core/slack.py
+++ b/perceval/backends/core/slack.py
@@ -61,7 +61,7 @@ class Slack(Backend):
     :param archive: archive to store/retrieve items
     :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.9.4'
+    version = '0.10.0'
 
     CATEGORIES = [CATEGORY_MESSAGE]
     EXTRA_SEARCH_FIELDS = {
@@ -310,9 +310,7 @@ class SlackClient(HttpClient):
     AUTHORIZATION_HEADER = 'Authorization'
     RCONVERSATION_MEMBERS = 'conversations.members'
     RCONVERSATION_INFO = 'conversations.info'
-    # conversations.history must replace channels.history after Feb 24th 2021
     RCONVERSATION_HISTORY = 'conversations.history'
-    RCHANNEL_HISTORY = 'channels.history'
     RUSER_INFO = 'users.info'
 
     PCHANNEL = 'channel'
@@ -369,9 +367,7 @@ class SlackClient(HttpClient):
     def history(self, channel, oldest=None, latest=None):
         """Fetch the history of a channel."""
 
-        # the channels.history endpoint will be working until Feb 24th 2021
-        # apps created after June 10th 2020 won't work with this endpoint
-        resource = self.RCHANNEL_HISTORY
+        resource = self.RCONVERSATION_HISTORY
 
         params = {
             self.PCHANNEL: channel,

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -46,7 +46,7 @@ from base import TestCaseBackendArchive
 
 SLACK_API_URL = 'https://slack.com/api/'
 SLACK_CHANNEL_INFO_URL = SLACK_API_URL + SlackClient.RCONVERSATION_INFO
-SLACK_CHANNEL_HISTORY_URL = SLACK_API_URL + SlackClient.RCHANNEL_HISTORY
+SLACK_CHANNEL_HISTORY_URL = SLACK_API_URL + SlackClient.RCONVERSATION_HISTORY
 SLACK_CONVERSATION_MEMBERS = SLACK_API_URL + SlackClient.RCONVERSATION_MEMBERS
 SLACK_USER_INFO_URL = SLACK_API_URL + SlackClient.RUSER_INFO
 
@@ -760,7 +760,7 @@ class TestSlackClient(unittest.TestCase):
 
         req = http_requests[0]
         self.assertEqual(req.method, 'GET')
-        self.assertRegex(req.path, SlackClient.RCHANNEL_HISTORY)
+        self.assertRegex(req.path, SlackClient.RCONVERSATION_HISTORY)
         self.assertDictEqual(req.querystring, expected)
         self.assertIn((SlackClient.AUTHORIZATION_HEADER, 'Bearer aaaa'), req.headers._headers)
 
@@ -787,7 +787,7 @@ class TestSlackClient(unittest.TestCase):
 
         req = http_requests[0]
         self.assertEqual(req.method, 'GET')
-        self.assertRegex(req.path, SlackClient.RCHANNEL_HISTORY)
+        self.assertRegex(req.path, SlackClient.RCONVERSATION_HISTORY)
         self.assertDictEqual(req.querystring, expected)
         self.assertIn((SlackClient.AUTHORIZATION_HEADER, 'Bearer aaaa'), req.headers._headers)
 


### PR DESCRIPTION
This reverts commit fb075a88ce495e65a1e87462f9dd7e662300ddad.

Signed-off-by: linonymous