### PR TITLE
[stackexchange] Change the fetch order to 'asc'

### DIFF
--- a/perceval/backends/core/stackexchange.py
+++ b/perceval/backends/core/stackexchange.py
@@ -59,7 +59,7 @@ class StackExchange(Backend):
     :param archive: archive to store/retrieve items
     :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.12.0'
+    version = '0.12.1'
 
     CATEGORIES = [CATEGORY_QUESTION]
     EXTRA_SEARCH_FIELDS = {
@@ -296,7 +296,7 @@ class StackExchangeClient(HttpClient):
 
         return url, headers, payload
 
-    def __build_payload(self, page, from_date, order='desc', sort='activity'):
+    def __build_payload(self, page, from_date, order='asc', sort='activity'):
         payload = {self.PPAGE: page,
                    self.PPAGESIZE: self.max_questions,
                    self.PORDER: order,

--- a/tests/test_stackexchange.py
+++ b/tests/test_stackexchange.py
@@ -287,7 +287,7 @@ class TestStackExchangeClient(unittest.TestCase):
         payload = {
             'page': ['1'],
             'pagesize': ['1'],
-            'order': ['desc'],
+            'order': ['asc'],
             'sort': ['activity'],
             'tagged': ['python'],
             'site': ['stackoverflow'],
@@ -319,7 +319,7 @@ class TestStackExchangeClient(unittest.TestCase):
         payload = {
             'page': ['1'],
             'pagesize': ['1'],
-            'order': ['desc'],
+            'order': ['asc'],
             'sort': ['activity'],
             'tagged': ['python'],
             'site': ['stackoverflow'],
@@ -350,7 +350,7 @@ class TestStackExchangeClient(unittest.TestCase):
         payload = {
             'page': ['1'],
             'pagesize': ['1'],
-            'order': ['desc'],
+            'order': ['asc'],
             'sort': ['activity'],
             'tagged': ['python'],
             'site': ['stackoverflow'],
@@ -394,7 +394,7 @@ class TestStackExchangeClient(unittest.TestCase):
             {
                 'page': ['1'],
                 'pagesize': ['1'],
-                'order': ['desc'],
+                'order': ['asc'],
                 'sort': ['activity'],
                 'tagged': ['python'],
                 'site': ['stackoverflow'],
@@ -404,7 +404,7 @@ class TestStackExchangeClient(unittest.TestCase):
             {
                 'page': ['2'],
                 'pagesize': ['1'],
-                'order': ['desc'],
+                'order': ['asc'],
                 'sort': ['activity'],
                 'tagged': ['python'],
                 'site': ['stackoverflow'],


### PR DESCRIPTION
This change is required to retrieve items incrementally.

Backend version is 0.12.1.

Signed-off-by: Quan Zhou <quan@bitergia.com>