### PR TITLE
Disables stack trace if debug flag is absent

### DIFF
--- a/bin/perceval
+++ b/bin/perceval
@@ -122,13 +122,11 @@ def main():
 
     if args.backend not in PERCEVAL_CMDS:
         raise RuntimeError("Unknown backend %s" % args.backend)
-
     configure_logging(args.debug)
 
     logging.info("Sir Perceval is on his quest.")
-
     klass = PERCEVAL_CMDS[args.backend]
-    cmd = klass(*args.backend_args)
+    cmd = klass(*args.backend_args, debug=args.debug)
     cmd.run()
 
     logging.info("Sir Perceval completed his quest.")

--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -576,15 +576,16 @@ class BackendCommand:
 
     Moreover, the method `setup_cmd_parser` must be implemented to execute
     the backend.
+
+    :param debug: boolean flag to check if application is running in debug mode
     """
     BACKEND = None
 
-    def __init__(self, *args):
+    def __init__(self, *args, debug=False):
         parser = self.setup_cmd_parser()
         self.parsed_args = parser.parse(*args)
-
+        self.debug = debug
         self.archive_manager = None
-
         self._pre_init()
         self._initialize_archive()
         self._post_init()
@@ -625,9 +626,9 @@ class BackendCommand:
 
                 self._log_summary(big.summary)
             except IOError as e:
-                raise RuntimeError(str(e))
+                logger.exception(f"Error!: {e}", exc_info=self.debug)
             except Exception as e:
-                raise RuntimeError(str(e))
+                logger.exception(f"Error!: {e}", exc_info=self.debug)
 
     def _pre_init(self):
         """Override to execute before backend is initialized."""


### PR DESCRIPTION
Fixes #692 

I'm passing in a bool flag (`debug_check`) in the constructor for the `BackendCommand` class, and setting the `logger` package's exception's function parameter `exc_info=debug_check`. The stack trace only gets printed if the debug flag (`-g`) gets passed in, which would mean that the `debug_check` variable is `True`.
This commit uses `logger`'s exception function to raise an exception.

Signed-off-by: Nishanth <nishusheela2011@gmail.com>