### PR TITLE
[poetry] Add setuptools to the build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,5 +51,8 @@ grimoirelab-toolkit = "^0.1.12"
 httpretty = "^0.9.6"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = [
+    "poetry-core>=1.0.0",
+    "setuptools>=30.3.0,<50"
+]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This PR adds the setuptools version to the poetry setup configurations. This is needed to fix the `No module named "setuptools"` bug.

Fixes https://github.com/chaoss/grimoirelab-perceval/issues/720

Signed-off-by: Venu Vardhan Reddy Tekula <venu@bitergia.com>