### PR TITLE
[CI] Use poetry for the CI github actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,43 +4,33 @@ on: [push, pull_request]
 
 jobs:
   tests:
-    
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-    
+
     name: Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
-        
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-        
+      - name: Install and set up Poetry
+        run: |
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+          echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
       - name: Install dependencies
         run: |
-          pip install --upgrade setuptools==49.6.0
-          pip install --upgrade pip==18.1
-          pip install --upgrade wheel
-          pip install -r "requirements.txt"
-          pip install -r "requirements_tests.txt"
-          pip install flake8 coveralls
-        
-      - name: Install
-        run: ./setup.py install
-        
+          poetry install -vvv
+          poetry add -D coveralls
       - name: Lint with flake8
         run: |
-          flake8 .
-        
+          poetry run flake8
       - name: Tests and Coverage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd tests
-          coverage run --source=perceval run_tests.py
-          # --service=github is a workaround for bug
-          # https://github.com/coveralls-clients/coveralls-python/issues/251
-          coveralls --service=github
+          poetry run coverage run --source=perceval run_tests.py
+          poetry run coveralls --service=github


### PR DESCRIPTION
This commit enables to use of poetry for the installation of the dependencies & tool and running the test-suite in the CI github actions workflow. This is needed as we are migrating the GrimoireLab tools to using poetry.
 
