### PR TITLE
[github] Fix user_orgs for organizations with restricted access

### DIFF
--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -859,6 +859,9 @@ class GitHubClient(HttpClient, RateLimitHandler):
                 orgs = '[]'
             else:
                 raise error
+        except requests.exceptions.RetryError as error:
+            logger.error("Can't get github login orgs: %s", error)
+            orgs = '[]'
 
         self._users_orgs[login] = orgs
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -2705,6 +2705,18 @@ class TestGitHubBackend(unittest.TestCase):
         github = GitHub("zhquan_example", "repo", ["aaa"])
         _ = [issues for issues in github.fetch()]
 
+        # Check that a RetryError getting user orgs is managed
+        GitHubClient._users_orgs.clear()  # clean cache to get orgs using the API
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ORGS_URL,
+                               body="", status=403,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        github = GitHub("zhquan_example", "repo", ["aaa"], max_retries=0)
+        _ = [issues for issues in github.fetch()]
+
         # Check that a no 402 exception getting user orgs is raised
         GitHubClient._users_orgs.clear()
         httpretty.register_uri(httpretty.GET,


### PR DESCRIPTION
Return an empty list when requesting a list of orgs of a login and GitHub API returns a 403 Unauthorized.

I wasn't sure why a 403 error code should force a retry, I removed it from the list of `EXTRA_STATUS_FORCELIST`


Fixes: #733