### PR TITLE
[github] Fix 404 Client Error when user is not found.

### DIFF
--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -837,9 +837,17 @@ class GitHubClient(HttpClient, RateLimitHandler):
 
         logger.debug("Getting info for %s" % url_user)
 
-        r = self.fetch(url_user)
-        user = r.text
-        self._users[login] = user
+        try:
+            r = self.fetch(url_user)
+            user = r.text
+            self._users[login] = user
+        except requests.exceptions.HTTPError as error:
+            # When the login is no longer exist or the token has no permission
+            if error.response.status_code == 404:
+                logger.error("Can't get github login: %s", error)
+                user = '{}'
+            else:
+                raise error
 
         return user
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -4196,6 +4196,33 @@ class TestGitHubClient(unittest.TestCase):
         self.assertEqual(headers, san_h)
         self.assertEqual(payload, san_p)
 
+    @httpretty.activate
+    def test_no_user_info(self):
+        """Test get_user returns 404"""
+
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_API_URL + '/users/no_exist',
+                               body='', status=404,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        client = GitHubClient("no_exist", "repo", ["aaa"], None)
+        response = client.user("no_exist")
+        self.assertEqual(response, '{}')
+
 
 class TestGitHubCommand(unittest.TestCase):
     """GitHubCommand unit tests"""


### PR DESCRIPTION
This code fixes when user is no longer exists or the token
doesn't have permission to get the information.

Test added accordingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>