### PR TITLE
[mattermost] Change the key from 'data.metadata.images' to value

### DIFF
--- a/perceval/backends/core/mattermost.py
+++ b/perceval/backends/core/mattermost.py
@@ -73,7 +73,7 @@ class Mattermost(Backend):
         of connection problems
     :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.4.1'
+    version = '0.5.0'
 
     CATEGORIES = [CATEGORY_POST]
     EXTRA_SEARCH_FIELDS = {
@@ -152,6 +152,9 @@ class Mattermost(Backend):
                 if post['update_at'] < since:
                     fetching = False
                     break
+
+                if 'metadata' in post and 'images' in post['metadata']:
+                    post['metadata']['images'] = self._parse_images(post['metadata']['images'])
 
                 # Fetch user data
                 user_id = post['user_id']
@@ -252,6 +255,12 @@ class Mattermost(Backend):
         # 'order' key.
         for post_id in parsed_posts['order']:
             yield parsed_posts['posts'][post_id]
+
+    def _parse_images(self, images):
+        """Parse images and returns a list of images."""
+
+        list_images = [{**images[i], **{'url': i}} for i in images]
+        return list_images
 
     def _get_or_fetch_user(self, user_id):
         if user_id in self._users:

--- a/tests/data/mattermost/mattermost_posts.json
+++ b/tests/data/mattermost/mattermost_posts.json
@@ -96,7 +96,23 @@
             "type": "",
             "props": {},
             "hashtags": "",
-            "pending_post_id": ""
+            "pending_post_id": "",
+            "metadata": {
+                "images": {
+                    "https://image-one-url.png": {
+                        "width": 1280,
+                        "height": 640,
+                        "format": "png",
+                        "frame_count": 0
+                    },
+                    "https://image-two-url.png": {
+                        "width": 1280,
+                        "height": 640,
+                        "format": "png",
+                        "frame_count": 0
+                    }
+                }
+            }
         }
     }
 }

--- a/tests/test_mattermost.py
+++ b/tests/test_mattermost.py
@@ -203,6 +203,25 @@ class TestMattermostBackend(unittest.TestCase):
             self.assertEqual(post['data']['channel_data']['name'], expected_channel[0])
             self.assertEqual(post['data']['channel_data']['display_name'], expected_channel[1])
 
+        # Check image
+        images_expected = [
+            {
+                'width': 1280,
+                'height': 640,
+                'format': 'png',
+                'frame_count': 0,
+                'url': 'https://image-one-url.png'
+            },
+            {
+                'width': 1280,
+                'height': 640,
+                'format': 'png',
+                'frame_count': 0,
+                'url': 'https://image-two-url.png'
+            }
+        ]
+        self.assertListEqual(posts[2]['data']['metadata']['images'], images_expected)
+
         # Check requests
         expected = [
             {


### PR DESCRIPTION
This code converts the key (URL) to value when the field
'data.metadata.images' exists, thus the ES index does not have a
field for each image URL and consequently avoid the error
'Limit of total fields [1000] in index [...] has been exceeded'.

From:
```
{
  ...
  "images": {
    "https://.../api/v4/image?...": {
      "width": 1280,
      "height": 640,
      ...
    }
  }
}
```

To:
```
{
  ...
  "images": [
    {
      "url": "https://.../api/v4/image?...",
      "width": 1280,
      "height": 640,
      ...
    }
  ]
}

```
Signed-off-by: Quan Zhou <quan@bitergia.com>