### PR TITLE
[nntp] Avoid line too long error

### DIFF
--- a/perceval/backends/core/nntp.py
+++ b/perceval/backends/core/nntp.py
@@ -40,7 +40,7 @@ DEFAULT_OFFSET = 1
 FALLBACK_DATE = '1970-01-01'
 
 # Hack to avoid "line too long" errors
-nntplib._MAXLINE = 4096
+nntplib._MAXLINE = 65536
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This code sets 'nntplib._MAXLINE' to 65536 to avoid the error.

Signed-off-by: Quan Zhou <quan@bitergia.com>