### PR TITLE
[github] Handle reactions without user information

### DIFF
--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -389,7 +389,7 @@ class GitHub(Backend):
         for raw_reactions in group_reactions:
 
             for reaction in json.loads(raw_reactions):
-                reaction['user_data'] = self.__get_user(reaction['user']['login'])
+                reaction['user_data'] = self.__get_user(reaction['user']['login']) if reaction['user'] else None
                 reactions.append(reaction)
 
         return reactions
@@ -424,7 +424,7 @@ class GitHub(Backend):
         for raw_reactions in group_reactions:
 
             for reaction in json.loads(raw_reactions):
-                reaction['user_data'] = self.__get_user(reaction['user']['login'])
+                reaction['user_data'] = self.__get_user(reaction['user']['login']) if reaction['user'] else None
                 reactions.append(reaction)
 
         return reactions
@@ -538,7 +538,7 @@ class GitHub(Backend):
         for raw_reactions in group_reactions:
 
             for reaction in json.loads(raw_reactions):
-                reaction['user_data'] = self.__get_user(reaction['user']['login'])
+                reaction['user_data'] = self.__get_user(reaction['user']['login']) if reaction['user'] else None
                 reactions.append(reaction)
 
         return reactions

--- a/tests/data/github/github_issue_comment_1_reactions
+++ b/tests/data/github/github_issue_comment_1_reactions
@@ -46,5 +46,12 @@
     },
     "content": "+1",
     "created_at": "2016-11-26T11:38:39Z"
+  },
+  {
+    "id": 3,
+    "node_id": "dfhji==",
+    "user": null,
+    "content": "heart",
+    "created_at": "2021-08-03T10:46:13Z"
   }
 ]

--- a/tests/data/github/github_issue_comments_1
+++ b/tests/data/github/github_issue_comments_1
@@ -10,10 +10,10 @@
             "+1": 1,
             "-1": 0,
             "confused": 0,
-            "heart": 1,
+            "heart": 2,
             "hooray": 0,
             "laugh": 0,
-            "total_count": 2,
+            "total_count": 3,
             "url": "https://api.github.com/repos/zhquan_example/repo/issues/comments/1/reactions"
     },
     "user": {

--- a/tests/data/github/github_request_pull_request_1_comment_2_reactions
+++ b/tests/data/github/github_request_pull_request_1_comment_2_reactions
@@ -118,5 +118,11 @@
     },
     "content": "confused",
     "created_at": "2016-11-26T11:37:39Z"
+  },
+  {
+    "id": 6,
+    "user": null,
+    "content": "-1",
+    "created_at": "2021-08-03T10:46:13Z"
   }
 ]

--- a/tests/data/github/github_request_pull_request_1_comments
+++ b/tests/data/github/github_request_pull_request_1_comments
@@ -83,12 +83,12 @@
         "pull_request_url": "https://api.github.com/repos/zhquan_example/repo/pulls/1",
         "reactions": {
             "+1": 1,
-            "-1": 0,
+            "-1": 1,
             "confused": 1,
             "heart": 1,
             "hooray": 1,
             "laugh": 1,
-            "total_count": 5,
+            "total_count": 6,
             "url": "https://api.github.com/repos/zhquan_example/repo/pulls/comments/2/reactions"
         },
         "updated_at": "2015-12-22T12:03:01Z",

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -685,7 +685,7 @@ class TestGitHubBackend(unittest.TestCase):
         self.assertEqual(pull['data']['requested_reviewers_data'][0]['login'], 'zhquan_example')
         self.assertEqual(len(pull['data']['review_comments_data']), 2)
         self.assertEqual(len(pull['data']['review_comments_data'][0]['reactions_data']), 0)
-        self.assertEqual(len(pull['data']['review_comments_data'][1]['reactions_data']), 5)
+        self.assertEqual(len(pull['data']['review_comments_data'][1]['reactions_data']), 6)
         self.assertEqual(pull['data']['review_comments_data'][1]['reactions_data'][0]['content'], 'heart')
         self.assertEqual(len(pull['data']['commits_data']), 1)
         self.assertEqual(len(pull['data']['reviews_data']), 2)
@@ -812,7 +812,7 @@ class TestGitHubBackend(unittest.TestCase):
         self.assertEqual(pull['data']['requested_reviewers_data'][0]['login'], 'zhquan_example')
         self.assertEqual(len(pull['data']['review_comments_data']), 2)
         self.assertEqual(len(pull['data']['review_comments_data'][0]['reactions_data']), 0)
-        self.assertEqual(len(pull['data']['review_comments_data'][1]['reactions_data']), 5)
+        self.assertEqual(len(pull['data']['review_comments_data'][1]['reactions_data']), 6)
         self.assertEqual(pull['data']['review_comments_data'][1]['reactions_data'][0]['content'], 'heart')
         self.assertEqual(len(pull['data']['commits_data']), 1)
         self.assertEqual(len(pull['data']['reviews_data']), 2)
@@ -935,7 +935,7 @@ class TestGitHubBackend(unittest.TestCase):
         self.assertNotIn('requested_reviewers_data', pull['data'])
         self.assertEqual(len(pull['data']['review_comments_data']), 2)
         self.assertEqual(len(pull['data']['review_comments_data'][0]['reactions_data']), 0)
-        self.assertEqual(len(pull['data']['review_comments_data'][1]['reactions_data']), 5)
+        self.assertEqual(len(pull['data']['review_comments_data'][1]['reactions_data']), 6)
         self.assertEqual(pull['data']['review_comments_data'][1]['reactions_data'][0]['content'], 'heart')
         self.assertNotIn('user_data', pull['data']['review_comments_data'][1]['reactions_data'][0])
         self.assertEqual(len(pull['data']['commits_data']), 1)
@@ -1425,7 +1425,7 @@ class TestGitHubBackend(unittest.TestCase):
             self.assertEqual(pull['data']['requested_reviewers_data'][0]['login'], 'zhquan_example')
             self.assertEqual(len(pull['data']['review_comments_data']), 2)
             self.assertEqual(len(pull['data']['review_comments_data'][0]['reactions_data']), 0)
-            self.assertEqual(len(pull['data']['review_comments_data'][1]['reactions_data']), 5)
+            self.assertEqual(len(pull['data']['review_comments_data'][1]['reactions_data']), 6)
             self.assertEqual(pull['data']['review_comments_data'][1]['reactions_data'][0]['content'], 'heart')
             self.assertEqual(len(pull['data']['reviews_data']), 2)
             self.assertEqual(pull['data']['reviews_data'][0]['user_data']['login'], 'zhquan_example')
@@ -1752,7 +1752,7 @@ class TestGitHubBackend(unittest.TestCase):
             self.assertNotIn('requested_reviewers_data', pull['data'])
             self.assertEqual(len(pull['data']['review_comments_data']), 2)
             self.assertEqual(len(pull['data']['review_comments_data'][0]['reactions_data']), 0)
-            self.assertEqual(len(pull['data']['review_comments_data'][1]['reactions_data']), 5)
+            self.assertEqual(len(pull['data']['review_comments_data'][1]['reactions_data']), 6)
             self.assertEqual(pull['data']['review_comments_data'][1]['reactions_data'][0]['content'], 'heart')
             self.assertEqual(len(pull['data']['reviews_data']), 2)
             self.assertNotIn('user_data', pull['data']['reviews_data'][0])
@@ -1913,7 +1913,7 @@ class TestGitHubBackend(unittest.TestCase):
         self.assertEqual(pull['data']['requested_reviewers_data'][0]['login'], 'zhquan_example')
         self.assertEqual(len(pull['data']['review_comments_data']), 2)
         self.assertEqual(len(pull['data']['review_comments_data'][0]['reactions_data']), 0)
-        self.assertEqual(len(pull['data']['review_comments_data'][1]['reactions_data']), 5)
+        self.assertEqual(len(pull['data']['review_comments_data'][1]['reactions_data']), 6)
         self.assertEqual(pull['data']['review_comments_data'][1]['reactions_data'][0]['content'], 'heart')
         self.assertEqual(len(pull['data']['commits_data']), 1)
         self.assertEqual(len(pull['data']['reviews_data']), 2)
@@ -2202,7 +2202,7 @@ class TestGitHubBackend(unittest.TestCase):
         self.assertEqual(pull['data']['reviews_data'][0]['user_data']['login'], 'zhquan_example')
         self.assertEqual(len(pull['data']['review_comments_data']), 2)
         self.assertEqual(len(pull['data']['review_comments_data'][0]['reactions_data']), 0)
-        self.assertEqual(len(pull['data']['review_comments_data'][1]['reactions_data']), 5)
+        self.assertEqual(len(pull['data']['review_comments_data'][1]['reactions_data']), 6)
         self.assertEqual(pull['data']['review_comments_data'][1]['reactions_data'][0]['content'], 'heart')
         self.assertEqual(len(pull['data']['commits_data']), 1)
         self.assertEqual(pull['data']['updated_at'], '2016-01-04T17:42:23Z')
@@ -2449,7 +2449,7 @@ class TestGitHubBackend(unittest.TestCase):
         self.assertEqual(pull['data']['requested_reviewers_data'][0]['login'], 'zhquan_example')
         self.assertEqual(len(pull['data']['review_comments_data']), 2)
         self.assertEqual(len(pull['data']['review_comments_data'][0]['reactions_data']), 0)
-        self.assertEqual(len(pull['data']['review_comments_data'][1]['reactions_data']), 5)
+        self.assertEqual(len(pull['data']['review_comments_data'][1]['reactions_data']), 6)
         self.assertEqual(pull['data']['review_comments_data'][1]['reactions_data'][0]['content'], 'heart')
         self.assertEqual(len(pull['data']['commits_data']), 1)
         self.assertEqual(len(pull['data']['reviews_data']), 2)
@@ -3332,6 +3332,38 @@ class TestGitHubClient(unittest.TestCase):
         self.assertEqual(issue_comment_reactions_raw[0], issue_comment_reactions)
 
     @httpretty.activate
+    def test_issue_comment_user_reactions(self):
+        """Test issue comment user reactions API call"""
+
+        issue_comment_reactions = read_file('data/github/github_issue_comment_1_reactions')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUE_COMMENT_1_REACTION_URL,
+                               body=issue_comment_reactions,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        client = GitHubClient("zhquan_example", "repo", ["aaa"])
+
+        issue_comment_reactions_raw = [json.loads(rev) for rev in client.issue_comment_reactions(1)][0]
+
+        self.assertEqual(issue_comment_reactions_raw[0]['user']['login'], 'zhquan_example')
+        self.assertEqual(issue_comment_reactions_raw[1]['user']['login'], 'zhquan_example')
+        self.assertIsNone(issue_comment_reactions_raw[2]['user'])
+
+    @httpretty.activate
     def test_pulls(self):
         """Test pulls API call"""
 
@@ -3730,6 +3762,40 @@ class TestGitHubClient(unittest.TestCase):
 
         pull_comment_reactions_raw = [rev for rev in client.pull_review_comment_reactions(2)]
         self.assertEqual(pull_comment_reactions_raw[0], pull_comment_reactions)
+
+    @httpretty.activate
+    def test_pull_review_comment_user_reactions(self):
+        """Test pull review comment user reactions API call"""
+
+        pull_comment_reactions = read_file('data/github/github_request_pull_request_1_comment_2_reactions')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_PULL_REQUEST_1_COMMENTS_2_REACTIONS,
+                               body=pull_comment_reactions,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        client = GitHubClient("zhquan_example", "repo", ["aaa"])
+
+        pull_comment_reactions_raw = [json.loads(rev) for rev in client.pull_review_comment_reactions(2)][0]
+        self.assertEqual(pull_comment_reactions_raw[0]['user']['login'], 'zhquan_example')
+        self.assertEqual(pull_comment_reactions_raw[1]['user']['login'], 'zhquan_example')
+        self.assertEqual(pull_comment_reactions_raw[2]['user']['login'], 'zhquan_example')
+        self.assertEqual(pull_comment_reactions_raw[3]['user']['login'], 'zhquan_example')
+        self.assertEqual(pull_comment_reactions_raw[4]['user']['login'], 'zhquan_example')
+        self.assertIsNone(pull_comment_reactions_raw[5]['user'])
 
     @httpretty.activate
     def test_abuse_rate_limit(self):


### PR DESCRIPTION
This code handles the reactions when there is no user information.
It will be set to 'None'.

Tests updated accordingly.

Fixes #746

Signed-off-by: Quan Zhou <quan@bitergia.com>