### PR TITLE
[mattermost] Support running with channel names

### DIFF
--- a/tests/data/mattermost/mattermost_channel.json
+++ b/tests/data/mattermost/mattermost_channel.json
@@ -5,7 +5,7 @@
     "display_name": "GrimoireLab channel",
     "extra_update_at": 1540874407361,
     "header": "the secret header",
-    "id": "abcdef4ut3dij8gywe38ktn51a",
+    "id": "abcdefghijkl",
     "last_post_at": 1564408427459,
     "name": "grimoirelab",
     "props": null,


### PR DESCRIPTION
The current mattermost backend runs using a channel ID in order to select which channel is being scraped.  However, this can get in the way in certain circumstances.  Mainly, the channel ID can't be derived from a mattermost URL like

https://my-mattermost.link/some-team/channels/some-channel

This PR allows the mattermost backend to be called with a team name and a channel name as an alternative to the normal behavior.

This means that tools like grimoirelab-elk would be able to accept a normal mattermost URL instead of requiring a unique repository format, which would improve intuitivity.  Additionally, the channel/team names are easier for users to find than the channel ID, which means a smoother user experience.

This does not break the existing workflow, and the previous usage still exists, just with the ability to alternatively specify names. Similarly, any new function parameters use keyword arguments, as to prevent creating a breaking change.

Love to hear your thoughts!

― Emi