### PR TITLE
[docs]  Add OSF community backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ and contact the maintainers for any issues or questions related to them.
 - Bundle for FINOS ecosystem: [Bitergia/grimoirelab-perceval-finos](https://github.com/Bitergia/grimoirelab-perceval-finos)
 - Weblate backend: [chaoss/grimoirelab-perceval-weblate](https://github.com/chaoss/grimoirelab-perceval-weblate)
 - Zulip backend: [vchrombie/grimoirelab-perceval-zulip](https://github.com/vchrombie/grimoirelab-perceval-zulip)
+- OSF backend: [gitlab.com/open-rit/perceval-osf](https://gitlab.com/open-rit/perceval-osf)
 
 ## Running tests
 


### PR DESCRIPTION
The OSF perceval backend was forked from the weblate backend, and developed primarily by Open@RIT member @suhascv, with some contributions from me.  It currently supports collecting a number of global statistics about OSF, as well as activity logs and forks for specific projects.

This commit adds a link to the perceval-osf backend to the list of community-maintained backends in the README.  We at open@rit would greatly appreciate the inclusion!

—Emi