### PR TITLE
Add one community backend to Community components

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ and contact the maintainers for any issues or questions related to them.
 - Weblate backend: [chaoss/grimoirelab-perceval-weblate](https://github.com/chaoss/grimoirelab-perceval-weblate)
 - Zulip backend: [vchrombie/grimoirelab-perceval-zulip](https://github.com/vchrombie/grimoirelab-perceval-zulip)
 - OSF backend: [gitlab.com/open-rit/perceval-osf](https://gitlab.com/open-rit/perceval-osf)
+- Gitee backend: [grimoirelab-gitee/grimoirelab-perceval-gitee](https://github.com/grimoirelab-gitee/grimoirelab-perceval-gitee)
 
 ## Running tests
 


### PR DESCRIPTION
This commit adds the perceval-gitee backend repo link to the list of community-maintained backends in the README.md file.

The support for grimoirelab-gitee was developed by @WillemJiang, @heming6666, @eyehwan, and @shanchenqi.

References
- https://github.com/chaoss/grimoirelab-perceval/issues/644
- https://github.com/chaoss/grimoirelab/pull/445
