### PR TITLE
[github] Extend 'max_items' for all requests

### DIFF
--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -111,7 +111,7 @@ class GitHub(Backend):
         of connection problems
     :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.26.0'
+    version = '0.27.0'
 
     CATEGORIES = [CATEGORY_ISSUE, CATEGORY_PULL_REQUEST, CATEGORY_REPO]
 
@@ -628,7 +628,6 @@ class GitHubClient(HttpClient, RateLimitHandler):
     PSINCE = 'since'
 
     # Predefined values
-    VPER_PAGE = 100
     VDIRECTION_ASC = 'asc'
     VSORT_UPDATED = 'updated'
     VSTATE_ALL = 'all'
@@ -684,7 +683,7 @@ class GitHubClient(HttpClient, RateLimitHandler):
         """Get reactions of an issue"""
 
         payload = {
-            self.PPER_PAGE: self.VPER_PAGE,
+            self.PPER_PAGE: self.max_items,
             self.PDIRECTION: self.VDIRECTION_ASC,
             self.PSORT: self.VSORT_UPDATED
         }
@@ -696,7 +695,7 @@ class GitHubClient(HttpClient, RateLimitHandler):
         """Get reactions of an issue comment"""
 
         payload = {
-            self.PPER_PAGE: self.VPER_PAGE,
+            self.PPER_PAGE: self.max_items,
             self.PDIRECTION: self.VDIRECTION_ASC,
             self.PSORT: self.VSORT_UPDATED
         }
@@ -708,7 +707,7 @@ class GitHubClient(HttpClient, RateLimitHandler):
         """Get the issue comments from pagination"""
 
         payload = {
-            self.PPER_PAGE: self.VPER_PAGE,
+            self.PPER_PAGE: self.max_items,
             self.PDIRECTION: self.VDIRECTION_ASC,
             self.PSORT: self.VSORT_UPDATED
         }
@@ -784,7 +783,7 @@ class GitHubClient(HttpClient, RateLimitHandler):
         """Get pull request commits"""
 
         payload = {
-            self.PPER_PAGE: self.VPER_PAGE
+            self.PPER_PAGE: self.max_items
         }
 
         commit_url = urijoin(self.RPULLS, str(pr_number), self.RCOMMITS)
@@ -794,7 +793,7 @@ class GitHubClient(HttpClient, RateLimitHandler):
         """Get pull request review comments"""
 
         payload = {
-            self.PPER_PAGE: self.VPER_PAGE,
+            self.PPER_PAGE: self.max_items,
             self.PDIRECTION: self.VDIRECTION_ASC,
             self.PSORT: self.VSORT_UPDATED
         }
@@ -806,7 +805,7 @@ class GitHubClient(HttpClient, RateLimitHandler):
         """Get pull request reviews"""
 
         payload = {
-            self.PPER_PAGE: self.VPER_PAGE,
+            self.PPER_PAGE: self.max_items,
             self.PDIRECTION: self.VDIRECTION_ASC,
             self.PSORT: self.VSORT_UPDATED
         }
@@ -818,7 +817,7 @@ class GitHubClient(HttpClient, RateLimitHandler):
         """Get reactions of a review comment"""
 
         payload = {
-            self.PPER_PAGE: self.VPER_PAGE,
+            self.PPER_PAGE: self.max_items,
             self.PDIRECTION: self.VDIRECTION_ASC,
             self.PSORT: self.VSORT_UPDATED
         }

--- a/perceval/backends/core/githubql.py
+++ b/perceval/backends/core/githubql.py
@@ -461,6 +461,7 @@ class GitHubQLClient(GitHubClient):
     :param ssl_verify: enable/disable SSL verification
     """
     VACCEPT = 'application/vnd.github.squirrel-girl-preview,application/vnd.github.starfox-preview+json'
+    VPER_PAGE = 100
 
     def __init__(self, owner, repository, tokens=None, github_app_id=None, github_app_pk_filepath=None,
                  base_url=None, sleep_for_rate=False, min_rate_to_sleep=MIN_RATE_LIMIT,


### PR DESCRIPTION
This code extends `max_items` for all requests instead of a
default value `VPER_PAGE = 100`.

Fixes #755

Signed-off-by: Quan Zhou <quan@bitergia.com>