### PR TITLE
[Git] Add argument `base-path` for git backend

### DIFF
--- a/perceval/backends/core/git.py
+++ b/perceval/backends/core/git.py
@@ -70,7 +70,7 @@ class Git(Backend):
     :raises RepositoryError: raised when there was an error cloning or
         updating the repository.
     """
-    version = '0.12.0'
+    version = '0.12.1'
 
     CATEGORIES = [CATEGORY_COMMIT]
 
@@ -338,12 +338,16 @@ class GitCommand(BackendCommand):
 
         if self.parsed_args.git_log:
             git_path = self.parsed_args.git_log
-        elif not self.parsed_args.git_path:
-            base_path = os.path.expanduser('~/.perceval/repositories/')
+        elif self.parsed_args.git_path:
+            git_path = self.parsed_args.git_path
+        else:
+            if self.parsed_args.base_path:
+                base_path = self.parsed_args.base_path
+            else:
+                base_path = os.path.expanduser('~/.perceval/repositories/')
+
             processed_uri = self.parsed_args.uri.lstrip('/')
             git_path = os.path.join(base_path, processed_uri) + '-git'
-        else:
-            git_path = self.parsed_args.git_path
 
         setattr(self.parsed_args, 'gitpath', git_path)
 
@@ -363,6 +367,8 @@ class GitCommand(BackendCommand):
 
         # Mutual exclusive parameters
         exgroup = group.add_mutually_exclusive_group()
+        exgroup.add_argument('--base-path', dest='base_path',
+                             help="Base path where the Git repositories will be cloned")
         exgroup.add_argument('--git-path', dest='git_path',
                              help="Path where the Git repository will be cloned")
         exgroup.add_argument('--git-log', dest='git_log',

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -802,7 +802,7 @@ class TestGitCommand(TestCaseGit):
 
         cmd = GitCommand(*args)
         self.assertEqual(cmd.parsed_args.gitpath,
-                         os.path.join(self.tmp_path, 'testpath/http://example.com/' + '-git'))
+                         os.path.join(self.tmp_path, 'testpath/http://example.com/-git'))
 
         args = ['http://example.com/',
                 '--git-log', os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data/git/git_log.txt')]
@@ -817,11 +817,17 @@ class TestGitCommand(TestCaseGit):
         cmd = GitCommand(*args)
         self.assertEqual(cmd.parsed_args.gitpath, '/tmp/gitpath')
 
+        args = ['http://example.com/',
+                '--base-path', '/tmp/basepath']
+
+        cmd = GitCommand(*args)
+        self.assertEqual(cmd.parsed_args.gitpath, '/tmp/basepath/http://example.com/-git')
+
         args = ['/tmp/gitpath/']
 
         cmd = GitCommand(*args)
         self.assertEqual(cmd.parsed_args.gitpath,
-                         os.path.join(self.tmp_path, 'testpath/tmp/gitpath/' + '-git'))
+                         os.path.join(self.tmp_path, 'testpath/tmp/gitpath/-git'))
 
     def test_setup_cmd_parser(self):
         """Test if it parser object is correctly initialized"""
@@ -856,6 +862,13 @@ class TestGitCommand(TestCaseGit):
         self.assertEqual(parsed_args.uri, 'http://example.com/')
         self.assertEqual(parsed_args.branches, ['master', 'testing'])
         self.assertFalse(parsed_args.no_update)
+
+        args = ['http://example.com/',
+                '--base-path', '/tmp/basepath']
+
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.base_path, '/tmp/basepath')
+        self.assertEqual(parsed_args.uri, 'http://example.com/')
 
     def test_mutual_exclusive_update(self):
         """Test whether an exception is thrown when no-update and latest-items flags are set"""


### PR DESCRIPTION
This code adds argument `base-path` for git backend to decide path where the Git repositories will be cloned.

Version updated to 0.12.1

Fixes #758 

Signed-off-by: Fugang Xiao <xiao623@outlook.com>