### PR TITLE
[docs] Add information for using perceval against private git repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,19 @@ this backend Git program has to be installed on your system.
 $ perceval git 'https://github.com/chaoss/grimoirelab-perceval.git' --from-date '2016-01-01'
 ```
 
+To run the backend against a **private git repository**, you must pass the
+credentials directly in the URL:
+
+```
+perceval git https://<username>:<password>@repository-url
+```
+
+For example, for private GitHub repositories:
+
+```
+$ perceval git https://<username>:<api-token>@github.com/chaoss/grimoirelab-perceval
+```
+
 Git backend can also work with a Git log file as input. We recommend to use the next command to get the most complete log file.
 
 ```

--- a/docs/perceval/git.md
+++ b/docs/perceval/git.md
@@ -178,6 +178,15 @@ cedc42d8d897d1bf64e999b91fb9ce34464440c9
 d7bef8060648f96000a575b1c2af6bc63f9a0ad3
 ```
 
+### Fetch commits from private Git repositories
+
+If you want to fetch commits from a private github repository, you must pass the
+credentials (`username` and `password`/`api-token`) directly in the URL.
+
+```
+$ perceval git https://<username>:<api-token>@github.com/chaoss/grimoirelab-perceval
+```
+
 ### An example: counting commits in a repository
 
 After the first example of using Perceval to get data from git repositories, we can write


### PR DESCRIPTION
This commit adds documentation for using perceval against
private git repositories. The README.md and the read the docs
is updated with an example.

Signed-off-by: Jorge García Rey <jorgegar@inditex.com>