### PR TITLE
[docs] Move scripts from tutorial

### DIFF
--- a/docs/perceval/gerrit.md
+++ b/docs/perceval/gerrit.md
@@ -91,7 +91,7 @@ If the ssh interface to Gerrit is not in the default port (29418), you can speci
 ### Using Perceval as a Python module
 
 As expected, the Perceval backend for Gerrit can be used from Python. See the following
-example (also available as `perceval_gerrit_1.py`:
+example (also available as `[perceval_gerrit_1.py](https://github.com/chaoss/grimoirelab-perceval/blob/master/docs/scripts/perceval_gerrit_1.py)`:
 
 ```py
 #! /usr/bin/env python3
@@ -118,7 +118,7 @@ This will retrieve all reviews that had any change during the last day, and prin
 ### A more complete example
 
 See below a more complete example of exploiting the data retrieved from Gerrit (also
-available as `perceval_gerrit_2.py`:
+available as `[perceval_gerrit_2.py](https://github.com/chaoss/grimoirelab-perceval/blob/master/docs/scripts/perceval_gerrit_2.py)`:
 
 ```py
 #! /usr/bin/env python3

--- a/docs/perceval/git.md
+++ b/docs/perceval/git.md
@@ -141,7 +141,7 @@ Of course, differences will be longer for larger repositories.
 ### Using Perceval as a Python module
 
 But we know that Perceval is a Python library. So, let’s use it as a Python library, from
-a Python script `perceval_git_1.py`:
+a Python script `[perceval_git_1.py](https://github.com/chaoss/grimoirelab-perceval/blob/master/docs/scripts/perceval_git_1.py)`:
 
 ```py
 #! /usr/bin/env python3
@@ -192,7 +192,7 @@ $ perceval git https://<username>:<api-token>@github.com/chaoss/grimoirelab-perc
 After the first example of using Perceval to get data from git repositories, we can write
 a slightly useful Python script: one that counts commits in a git repository. The complete
 script is described in the Tools and Tips chapter, and the code can be accessed as
-`perceval_git_counter.py`. Its skeleton is as follows:
+`[perceval_git_counter.py](https://github.com/chaoss/grimoirelab-perceval/blob/master/docs/scripts/perceval_git_counter.py)`. Its skeleton is as follows:
 
 ```py
 import argparse

--- a/docs/perceval/github.md
+++ b/docs/perceval/github.md
@@ -244,7 +244,7 @@ Of course, in this case, all items (issues and ñpull requests) will be written 
 
 As in the case of the git backend (and any other backend, for that matter) we can use a
 Python script to retrieve the data, instead of the `perceval` command. For example
-(`perceval_github_1.py`):
+(`[perceval_github_1.py](https://github.com/chaoss/grimoirelab-perceval/blob/master/docs/scripts/perceval_github_1.py)`):
 
 ```py
 #! /usr/bin/env python3

--- a/docs/perceval/mail-archives.md
+++ b/docs/perceval/mail-archives.md
@@ -103,7 +103,7 @@ In this case, we can also see a small difference on the body of the messages. Fo
 
 As usual, we can use Perceval as a Python module for analyzing messages in mbox files.
 Using the same two `archives` we downloaded above, in the archives directory, we can for
-example show the subject for all messages (code below is in `perceval_mbox_1.py`]:
+example show the subject for all messages (code below is in `[perceval_mbox_1.py](https://github.com/chaoss/grimoirelab-perceval/blob/master/docs/scripts/perceval_mbox_1.py)`]:
 
 ```py
 #! /usr/bin/env python3

--- a/docs/scripts/perceval_gerrit_1.py
+++ b/docs/scripts/perceval_gerrit_1.py
@@ -1,0 +1,17 @@
+#! /usr/bin/env python3
+
+from datetime import datetime, timedelta
+from perceval.backends.core.gerrit import Gerrit
+
+# hostname of the Gerrit instance
+hostname = 'gerrit.opnfv.org'
+# user for sshing to the Gerrit instance
+user = 'jgbarah'
+# retrieve only reviews changed since one day ago
+from_date = datetime.now() - timedelta(days=1)
+# create a Gerrit object, pointing to hostname, using user for ssh access
+repo = Gerrit(hostname=hostname, user=user)
+
+# fetch all reviews as an iterator, and iterate it printing each review id
+for review in repo.fetch(from_date=from_date):
+    print(review['data']['number'])

--- a/docs/scripts/perceval_gerrit_2.py
+++ b/docs/scripts/perceval_gerrit_2.py
@@ -1,0 +1,27 @@
+#! /usr/bin/env python3
+
+import datetime
+
+from perceval.backends.core.gerrit import Gerrit
+
+# hostname of the Gerrit instance
+hostname = 'gerrit.opnfv.org'
+# user for sshing to the Gerrit instance
+user = 'jgbarah'
+# retrieve only reviews changed since this date
+from_date = datetime.datetime.now() - datetime.timedelta(days=1)
+# create a Gerrit object, pointing to hostname, using user for ssh access
+repo = Gerrit(hostname=hostname, user=user)
+
+# fetch all reviews as an iterator, and iterate it printing each review id
+for review in repo.fetch(from_date=from_date):
+    print("Review:", review['data']['number'], review['data']['url'], end='')
+    print(review['data']['status'], review['data']['open'])
+    print("  Patchsets:")
+    for patch in review['data']['patchSets']:
+        print("    ", patch['number'], "Draft:", patch['isDraft'], patch['kind'])
+    print("  Comments:")
+    for comment in review['data']['comments']:
+        print("    Comment:")
+        for line in comment['message'].splitlines():
+            print("      ", line)

--- a/docs/scripts/perceval_git_1.py
+++ b/docs/scripts/perceval_git_1.py
@@ -1,0 +1,14 @@
+#! /usr/bin/env python3
+
+from perceval.backends.core.git import Git
+
+# url for the git repo to analyze
+repo_url = 'http://github.com/grimoirelab/perceval.git'
+# directory for letting Perceval clone the git repo
+repo_dir = '/tmp/perceval.git'
+
+# create a Git object, pointing to repo_url, using repo_dir for cloning
+repo = Git(uri=repo_url, gitpath=repo_dir)
+# fetch all commits as an iteratoir, and iterate it printing each hash
+for commit in repo.fetch():
+    print(commit['data']['commit'])

--- a/docs/scripts/perceval_git_counter.py
+++ b/docs/scripts/perceval_git_counter.py
@@ -1,0 +1,18 @@
+#! /usr/bin/env python3
+
+import argparse
+from perceval.backends.core.git import Git
+
+parser = argparse.ArgumentParser(description = "Count commits in a git repo")
+parser.add_argument("repo", help = "Repository url")
+parser.add_argument("dir", help = "Directory for cloning the repository")
+parser.add_argument("--print", action='store_true', help = "Print hashes")
+args = parser.parse_args()
+
+repo = Git(uri=args.repo, gitpath=args.dir)
+count = 0
+for commit in repo.fetch():
+    if args.print:
+        print(commit['data']['commit'])
+    count += 1
+print("Number of commmits: %d." % count)

--- a/docs/scripts/perceval_github_1.py
+++ b/docs/scripts/perceval_github_1.py
@@ -1,0 +1,29 @@
+#! /usr/bin/env python3
+
+import argparse
+
+from perceval.backends.core.github import GitHub
+
+# Parse command line arguments
+parser = argparse.ArgumentParser(
+    description = "Simple parser for GitHub issues and pull requests"
+    )
+parser.add_argument("-t", "--token",
+                    help = "GitHub token")
+parser.add_argument("-r", "--repo",
+                    help = "GitHub repository, as 'owner/repo'")
+args = parser.parse_args()
+
+# Owner and repository names
+(owner, repo) = args.repo.split('/')
+
+# create a Git object, pointing to repo_url, using repo_dir for cloning
+repo = GitHub(owner=owner, repository=repo, api_token=args.token)
+# fetch all issues/pull requests as an iteratoir, and iterate it printing
+# their number, and whether they are issues or pull requessts
+for item in repo.fetch():
+    if 'pull_request' in item['data']:
+        kind = 'Pull request'
+    else:
+        kind = 'Issue'
+    print(item['data']['number'], ':', kind)

--- a/docs/scripts/perceval_mbox_1.py
+++ b/docs/scripts/perceval_mbox_1.py
@@ -1,0 +1,15 @@
+#! /usr/bin/env python3
+
+from perceval.backends.core.mbox import MBox
+
+# uri (label) for the mailing list to analyze
+mbox_uri = 'http://mail-archives.apache.org/mod_mbox/httpd-announce/'
+# directory for letting Perceval where mbox archives are
+# you need to have the archives to analyzed there before running the script
+mbox_dir = 'archives'
+
+# create a mbox object, using mbox_uri as label, mbox_dir as directory to scan
+repo = MBox(uri=mbox_uri, dirpath=mbox_dir)
+# fetch all messages as an iteratoir, and print first 60 chars for each subject
+for message in repo.fetch():
+    print(message['data']['Subject'][0:59])


### PR DESCRIPTION
This PR moves the scripts from the tutorial repository to perceval docs folder. Future scripts could be added to this folder and guides can be written using them.