### PR TITLE
Add configurations of the metadata files to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,12 @@ packages = [
     { include = "tests", format = "sdist" },
 ]
 
+include = [
+    { path = "AUTHORS", format = "sdist" },
+    { path = "NEWS", format = "sdist" },
+    { path = "README.md", format = "sdist" },
+]
+
 classifiers = [
    "Development Status :: 4 - Beta",
    "Intended Audience :: Developers",


### PR DESCRIPTION
This PR adds the configurations of the metadata files to the `pyproject.toml` file. This is needed to include these files when the package is built using poetry.