### PR TITLE
[bugzillarest] Support API key authentication (--api-key)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -195,14 +195,11 @@ python-dateutil = ">=2.8.0,<3.0.0"
 
 [[package]]
 name = "httpretty"
-version = "0.9.7"
+version = "1.1.4"
 description = "HTTP client mock for Python"
 category = "dev"
 optional = false
-python-versions = "*"
-
-[package.dependencies]
-six = "*"
+python-versions = ">=3"
 
 [[package]]
 name = "idna"
@@ -611,7 +608,7 @@ docs = ["furo", "myst-parser"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "5c1dd08573611612dd3a1030a573951d3af1061dd016610aaa87bd6ae3d2ab8e"
+content-hash = "154928b54ee8daaab5e087e575a1a244ea5ed9b3226d184d2605cbf41e916577"
 
 [metadata.files]
 alabaster = [
@@ -755,8 +752,6 @@ cryptography = [
     {file = "cryptography-3.4.8-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34dae04a0dce5730d8eb7894eab617d8a70d0c97da76b905de9efb7128ad7085"},
     {file = "cryptography-3.4.8-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1eb7bb0df6f6f583dd8e054689def236255161ebbcf62b226454ab9ec663746b"},
     {file = "cryptography-3.4.8-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:9965c46c674ba8cc572bc09a03f4c649292ee73e1b683adb1ce81e82e9a6a0fb"},
-    {file = "cryptography-3.4.8-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:3c4129fc3fdc0fa8e40861b5ac0c673315b3c902bbdc05fc176764815b43dd1d"},
-    {file = "cryptography-3.4.8-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:695104a9223a7239d155d7627ad912953b540929ef97ae0c34c7b8bf30857e89"},
     {file = "cryptography-3.4.8-cp36-abi3-win32.whl", hash = "sha256:21ca464b3a4b8d8e86ba0ee5045e103a1fcfac3b39319727bc0fc58c09c6aff7"},
     {file = "cryptography-3.4.8-cp36-abi3-win_amd64.whl", hash = "sha256:3520667fda779eb788ea00080124875be18f2d8f0848ec00733c0ec3bb8219fc"},
     {file = "cryptography-3.4.8-pp36-pypy36_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d2a6e5ef66503da51d2110edf6c403dc6b494cc0082f85db12f54e9c5d4c3ec5"},
@@ -813,7 +808,7 @@ grimoirelab-toolkit = [
     {file = "grimoirelab_toolkit-0.2.0-py3-none-any.whl", hash = "sha256:7a097fe59c6b9a94d7d7fcdbbcb2a5ec3c8ed6e37811eb29a54ac665ddcd2dce"},
 ]
 httpretty = [
-    {file = "httpretty-0.9.7.tar.gz", hash = "sha256:66216f26b9d2c52e81808f3e674a6fb65d4bf719721394a1a9be926177e55fbe"},
+    {file = "httpretty-1.1.4.tar.gz", hash = "sha256:20de0e5dd5a18292d36d928cc3d6e52f8b2ac73daec40d41eb62dee154933b68"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ myst-parser = { version = "^0.15.2", optional = true }
 furo = { version = "^2021.8.31", optional = true }
 
 [tool.poetry.dev-dependencies]
-httpretty = "^0.9.6"
+httpretty = "^1.1.4"
 flake8 = "^3.9.1"
 coverage = "^5.5"
 

--- a/releases/unreleased/[bugzillarest]-api-key-authentication.yml
+++ b/releases/unreleased/[bugzillarest]-api-key-authentication.yml
@@ -1,0 +1,13 @@
+---
+title: '[bugzillarest] API Key authentication'
+category: added
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    A new authentication is available in the `bugzillarest` backend using
+    an API Key. This can be provided using the parameter `--api-key` on
+    the command line. Note that this parameter will invalidate `--backend-user`
+    `--backend-password`, and `--api-token` parameters.
+
+    For developers, this parameter is also available during the initialization
+    of the class `BugzillaRESTClient` under the name `api_key`.


### PR DESCRIPTION
This change adds support for `api_key` authentication. Now there
are three ways to authenticate `user/pass`, `token`, and `api_key`.

The version `5.0.4.rh69` (https://bugzilla.redhat.com) does not
support `Bugzilla_login`, `Bugzilla_password`, `Bugzilla_token`,
and `Bugzilla_api_key` instead it supports a header
`Authorization: Bearer YOURAPIKEY`. More info at
https://bugzilla.redhat.com/docs/en/html/api/core/v1/general.html#authentication

If the instance is `5.0.4.rh69` then it will add the header,
otherwise will add `api_key=YOURAPIKEY` on the URL.

Version updated to 0.11.0
Tests updated accordingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>