### PR TITLE
[confluence] Support fetch by spaces.

### DIFF
--- a/releases/unreleased/confluence-supports-fetch-by-spaces.yml
+++ b/releases/unreleased/confluence-supports-fetch-by-spaces.yml
@@ -1,0 +1,9 @@
+---
+title: Confluence supports fetch by spaces
+category: added
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    This allows fetching confluence by specific spaces. By
+    default it will fetch the entire instance, but adding the
+    `--spaces` argument will fetch only these spaces.

--- a/tests/data/confluence/confluence_content_3.json
+++ b/tests/data/confluence/confluence_content_3.json
@@ -1,0 +1,89 @@
+{
+    "_expandable": {
+        "container": "",
+        "metadata": "",
+        "operations": "",
+        "children": "/rest/api/content/3/child?parentVersion=3",
+        "restrictions": "/rest/api/content/3/restriction/byOperation",
+        "ancestors": "",
+        "descendants": "/rest/api/content/3/descendant",
+        "space": "/rest/api/space/TEST"
+    },
+    "body": {
+        "storage": {
+            "value": "Value text",
+            "representation": "storage",
+            "_expandable": {
+                "content": "/rest/api/content/3?status=historical&version=3"
+            }
+        },
+        "_expandable": {
+            "editor": "",
+            "view": "",
+            "export_view": "",
+            "styled_view": "",
+            "anonymous_export_view": ""
+        }
+    },
+    "extensions": {
+        "position": 1
+    },
+    "history": {
+        "latest": false,
+        "createdBy": {
+            "type": "known",
+            "username": "smith",
+            "userKey": "a80255c66b579d45016b9b47dbf20051",
+            "profilePicture": {
+                "path": "/images/icons/profilepics/default.svg",
+                "width": 48,
+                "height": 48,
+                "isDefault": true
+            },
+            "displayName": "Smith John",
+            "_links": {
+                "self": "https://example.com/rest/api/user?key=a80255c66b579d45016b9b47dbf20051"
+            },
+            "_expandable": {
+                "status": ""
+            }
+        },
+        "createdDate": "2019-07-26T20:16:58.000Z",
+        "latest": true
+    },
+    "id": "3",
+    "status": "current",
+    "title": "PERCEVAL",
+    "type": "page",
+    "version": {
+        "by": {
+            "type": "known",
+            "username": "smith",
+            "userKey": "2c9fac3d6a43e63e016e47429dd70000",
+            "profilePicture": {
+                "path": "/download/attachments/507281416/user-avatar",
+                "width": 48,
+                "height": 48,
+                "isDefault": false
+            },
+            "displayName": "John Smith",
+            "_links": {
+                "self": "https://example.com/rest/api/user?key=2c9fac3d6a43e63e016e47429dd70000"
+            },
+            "_expandable": {
+                "status": ""
+            }
+        },
+        "when": "2021-01-12T15:46:37.336Z",
+        "message": "",
+        "number": 3,
+        "minorEdit": false,
+        "hidden": false,
+        "_links": {
+            "self": "https://example.com/rest/experimental/content/3/version/3"
+        },
+        "_expandable": {
+            "content": "/rest/api/content/3?status=historical&version=3"
+        }
+    }
+}

--- a/tests/data/confluence/confluence_content_space.json
+++ b/tests/data/confluence/confluence_content_space.json
@@ -1,0 +1,70 @@
+{
+    "results": [
+        {
+            "id": "3",
+            "type": "page",
+            "status": "current",
+            "title": "PERCEVAL",
+            "ancestors": [
+                {
+                    "id": "3",
+                    "type": "page",
+                    "status": "current",
+                    "title": "Community Home",
+                    "extensions": {
+                        "position": 0
+                    },
+                    "_links": {
+                        "webui": "/display/TEST/Community+Home",
+                        "edit": "/pages/resumedraft.action?draftId=3",
+                        "tinyui": "/x/AgAoDw",
+                        "self": "https://example.com/rest/api/content/3"
+                    },
+                    "_expandable": {
+                        "container": "/rest/api/space/TEST",
+                        "metadata": "",
+                        "operations": "",
+                        "children": "/rest/api/content/3/child",
+                        "restrictions": "/rest/api/content/3/restriction/byOperation",
+                        "history": "/rest/api/content/3/history",
+                        "ancestors": "",
+                        "body": "",
+                        "version": "",
+                        "descendants": "/rest/api/content/3/descendant",
+                        "space": "/rest/api/space/TEST"
+                    }
+                }
+            ],
+            "extensions": {
+                "position": 1
+            },
+            "_links": {
+                "webui": "/display/TEST/PERCEVAL",
+                "edit": "/pages/resumedraft.action?draftId=4&draftShareId=57d3099b-f2df-45f2-bd63-7aa8430435a5",
+                "tinyui": "/x/LYDTGw",
+                "self": "https://example.com/rest/api/content4"
+            },
+            "_expandable": {
+                "container": "/rest/api/space/TEST",
+                "metadata": "",
+                "operations": "",
+                "children": "/rest/api/content4/child",
+                "restrictions": "/rest/api/content4/restriction/byOperation",
+                "history": "/rest/api/content4/history",
+                "body": "",
+                "version": "",
+                "descendants": "/rest/api/content4/descendant",
+                "space": "/rest/api/space/TEST"
+            }
+        }
+    ],
+    "start": 0,
+    "limit": 200,
+    "size": 1,
+    "totalSize": 1,
+    "_links": {
+        "self": "https://example.com/rest/api/content/search?expand=ancestors&cql=space+in+%28TEST%29+and+lastModified%3E%3D%272022-05-05+00%3A00%27+order+by+lastModified",
+        "base": "https://example.com",
+        "context": ""
+    }
+}


### PR DESCRIPTION
This code allows fetching confluence by specific spaces. By
default it will fetch the entire instance, but adding the
`--spaces` argument will fetch only these spaces.

New optional argument:
- `--spaces`: List of spaces to fetch

Tests added accordingly.
Version updated to 0.13.0.

Signed-off-by: Quan Zhou <quan@bitergia.com>