### PR TITLE
[slack] Fix username KeyError

### DIFF
--- a/perceval/backends/core/slack.py
+++ b/perceval/backends/core/slack.py
@@ -184,9 +184,9 @@ class Slack(Backend):
         are combined because there have been cases where two messages were sent
         by different users at the same time.
 
-        In the case where neither the 'user' or 'bot_id' attributes are present
-        (e.g, bot deleted), the fallback option is to generate the identifier
-        using the 'ts' and 'username' values.
+        In the case where neither the 'user', 'bot_id', or 'username' attributes
+        are present (e.g, bot deleted), the fallback option is to generate the
+        identifier using the 'ts' value.
         """
         if 'user' in item:
             nick = item['user']
@@ -194,8 +194,10 @@ class Slack(Backend):
             nick = item['comment']['user']
         elif 'bot_id' in item:
             nick = item['bot_id']
-        else:
+        elif 'username' in item:
             nick = item['username']
+        else:
+            nick = ""
 
         return item['ts'] + nick
 

--- a/releases/unreleased/slack-identifier-extraction-fixed.yml
+++ b/releases/unreleased/slack-identifier-extraction-fixed.yml
@@ -1,0 +1,8 @@
+---
+title: Slack identifier extraction fixed
+category: fixed
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    Extract the identifier without user information when the user was
+    deleted.

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -858,6 +858,55 @@ class TestSlackClient(unittest.TestCase):
 
         self.assertEqual(user, '{"ok":false,"user":null}')
 
+    def test_metadata_id(self):
+
+        client = Slack('CHANNEL', 'TOKEN')
+
+        # When 'user', 'bot_id', 'comment', or 'username' do not exist.
+        item = {
+            'type': 'message',
+            'text': 'A file was commented on',
+            'ts': '1529335169.000726',
+            'channel_info': {
+                'id': 'CHANNEL',
+                'name': 'test',
+                'is_channel': True,
+                'num_members': 4
+            }
+        }
+        metadata_id = client.metadata_id(item)
+        expected_id = item['ts']
+
+        self.assertEqual(metadata_id, expected_id)
+
+        # With 'username'
+        item['username'] = "username"
+        metadata_id = client.metadata_id(item)
+        expected_id = item['ts'] + item['username']
+
+        self.assertEqual(metadata_id, expected_id)
+
+        # With 'bot_id'
+        item['bot_id'] = "1"
+        metadata_id = client.metadata_id(item)
+        expected_id = item['ts'] + item['bot_id']
+
+        self.assertEqual(metadata_id, expected_id)
+
+        # With 'comment'
+        item['comment'] = {"user": "user"}
+        metadata_id = client.metadata_id(item)
+        expected_id = item['ts'] + item['comment']['user']
+
+        self.assertEqual(metadata_id, expected_id)
+
+        # With 'user'
+        item['user'] = "user"
+        metadata_id = client.metadata_id(item)
+        expected_id = item['ts'] + item['user']
+
+        self.assertEqual(metadata_id, expected_id)
+
 
 class TestSlackCommand(unittest.TestCase):
     """SlackCommand unit tests"""


### PR DESCRIPTION
This code fixes the `KeyError: username` when the user was removed.

when a user was deleted, the item doesn't have any user information,
so the "metadata_id" method will generate the identifier using only
the 'ts' value.

Signed-off-by: Quan Zhou <quan@bitergia.com>