### PR TITLE
[bugzillarest] Fix check_bugzilla_type on custom instance

### DIFF
--- a/perceval/backends/core/bugzillarest.py
+++ b/perceval/backends/core/bugzillarest.py
@@ -65,7 +65,7 @@ class BugzillaREST(Backend):
     :param archive: archive to store/retrieve items
     :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.11.0'
+    version = '0.12.0'
 
     CATEGORIES = [CATEGORY_BUG]
     EXTRA_SEARCH_FIELDS = {
@@ -331,8 +331,11 @@ class BugzillaRESTClient(HttpClient):
         url = self.URL % {'base': self.base_url, 'resource': self.RVERSION}
 
         params = {self.PBUGZILLA_KEY: self.api_key}
-        r = self.fetch(url, payload=params)
-        if 'version' not in r.json():
+        try:
+            r = self.fetch(url, payload=params)
+            if 'version' not in r.json():
+                self.bugzilla_custom = True
+        except requests.exceptions.HTTPError:
             self.bugzilla_custom = True
 
     def login(self, user, password):

--- a/releases/unreleased/check_bugzilla_type-on-custom-instance-fixed.yml
+++ b/releases/unreleased/check_bugzilla_type-on-custom-instance-fixed.yml
@@ -1,0 +1,10 @@
+---
+title: '[bugzillarest] Failback when checking custom instances'
+category: fixed
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    Some Bugzilla instances return a HTTP 400 error when checking
+    if their are custom instances or not. On those cases, the backend will
+    capture the error and consider the version of that Bugzilla instance
+    as custom.

--- a/tests/test_bugzillarest.py
+++ b/tests/test_bugzillarest.py
@@ -600,6 +600,17 @@ class TestBugzillaRESTClient(unittest.TestCase):
         client = BugzillaRESTClient(BUGZILLA_SERVER_URL, api_key='abcdef')
         self.assertTrue(client.bugzilla_custom)
 
+        # Set up a mock HTTP server
+        body_400_error = "400 Client Error: Bad Request for url: " + BUGZILLA_VERSION_URL + "?api_key=abcdef"
+        httpretty.register_uri(httpretty.GET,
+                               BUGZILLA_VERSION_URL,
+                               body=body_400_error,
+                               status=400)
+
+        # Test custom Bugzilla version https://bugzilla.redhat.com
+        client = BugzillaRESTClient(BUGZILLA_SERVER_URL, api_key='abcdef')
+        self.assertTrue(client.bugzilla_custom)
+
     @httpretty.activate
     def test_bugs(self):
         """Test bugs API call"""


### PR DESCRIPTION
The current https://bugzilla.redhat.com returns a 400 Client Error
instead of a JSON format on the `GET /rest/version?api_key=xxx`
request in the `check_bugzilla_type` method.

This code catches that exception and sets the instance as custom.

Test updated accordingly.
Version update to 0.12.0.

Signed-off-by: Quan Zhou <quan@bitergia.com>