### PR TITLE
[confluence] Fix error when args not passed on 'fetch_items'

### DIFF
--- a/perceval/backends/core/confluence.py
+++ b/perceval/backends/core/confluence.py
@@ -64,7 +64,7 @@ class Confluence(Backend):
     :param spaces: name of spaces to fetch, (default the entire instance)
     :param max_contents: maximum number of contents to fetch per request
     """
-    version = '0.14.0'
+    version = '0.14.1'
 
     CATEGORIES = [CATEGORY_HISTORICAL_CONTENT]
 
@@ -153,8 +153,8 @@ class Confluence(Backend):
         :returns: a generator of items
         """
 
-        from_date = kwargs['from_date']
-        max_contents = kwargs['max_contents']
+        from_date = kwargs.get('from_date', DEFAULT_DATETIME)
+        max_contents = kwargs.get('max_contents', MAX_CONTENTS)
 
         logger.info("Fetching historical contents of '%s' from %s max contents per query %s",
                     self.url, str(from_date), str(max_contents))

--- a/releases/unreleased/[confluence]-arguments-not-passed-to-'fetch_items'.yml
+++ b/releases/unreleased/[confluence]-arguments-not-passed-to-'fetch_items'.yml
@@ -1,0 +1,8 @@
+---
+title: '[confluence] KeyError exception when arguments not passed to ''fetch_items'''
+category: fixed
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  Required arguments that weren't passed to 'fetch_items'
+  made the code fail with a KeyError exception.


### PR DESCRIPTION
When required arguments weren't given in 'fetch_items' the code failed with a KeyError exception. This patch fixes
the error checking if the arguments are given and, if not, setting the default value parameters.
