### PR TITLE
[phabricator] Allow to blacklist ids

### DIFF
--- a/releases/unreleased/[phabricator]-new-blacklist-ids-argument-added.yml
+++ b/releases/unreleased/[phabricator]-new-blacklist-ids-argument-added.yml
@@ -1,0 +1,12 @@
+---
+title: '[phabricator] Skip a list of items by id'
+category: added
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    Perceval will not fetch the items set with the `--blacklist-ids` argument.
+    In the following example, `perceval` will skip the items with ids `123`
+    and `456`:
+    ```
+    perceval phabricator <PHAB_URL> -t <API_TOKEN> --blacklist-ids 123 456
+    ```


### PR DESCRIPTION
This code allows to prevent perceval to fetch a list of ids. Add
the parameter `--blacklist-ids` on the Phabricator backend to
includ the ids to the blacklist.

Tests updated accordingly.
Version updated to 0.14.0

Signed-off-by: Quan Zhou <quan@bitergia.com>