### PR TITLE
[deps] Update flake8 dependency to 4.0.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -153,17 +153,17 @@ sgmllib3k = "*"
 
 [[package]]
 name = "flake8"
-version = "3.9.2"
+version = "4.0.1"
 description = "the modular source code checker: pep8 pyflakes and co"
 category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = ">=3.6"
 
 [package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+importlib-metadata = {version = "<4.3", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
-pycodestyle = ">=2.7.0,<2.8.0"
-pyflakes = ">=2.3.0,<2.4.0"
+pycodestyle = ">=2.8.0,<2.9.0"
+pyflakes = ">=2.4.0,<2.5.0"
 
 [[package]]
 name = "furo"
@@ -219,20 +219,19 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.12.0"
+version = "4.2.0"
 description = "Read metadata from Python packages"
-category = "main"
+category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.6"
 
 [package.dependencies]
 typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["jaraco.packaging (>=9)", "rst.linker (>=1.9)", "sphinx"]
-perf = ["ipython"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
+docs = ["jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pep517", "pyfakefs", "pytest (>=4.6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy"]
 
 [[package]]
 name = "Jinja2"
@@ -335,11 +334,11 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pycodestyle"
-version = "2.7.0"
+version = "2.8.0"
 description = "Python style guide checker"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pycparser"
@@ -351,7 +350,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pyflakes"
-version = "2.3.1"
+version = "2.4.0"
 description = "passive checker of Python programs"
 category = "dev"
 optional = false
@@ -439,6 +438,19 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "setuptools"
+version = "65.3.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "main"
+optional = true
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
 name = "sgmllib3k"
 version = "1.0.0"
 description = "Py3k port of sgmllib."
@@ -472,7 +484,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "Sphinx"
-version = "4.5.0"
+version = "4.3.2"
 description = "Python documentation generator"
 category = "main"
 optional = true
@@ -484,11 +496,11 @@ babel = ">=1.3"
 colorama = {version = ">=0.3.5", markers = "sys_platform == \"win32\""}
 docutils = ">=0.14,<0.18"
 imagesize = "*"
-importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
 Jinja2 = ">=2.3"
 packaging = "*"
 Pygments = ">=2.0"
 requests = ">=2.5.0"
+setuptools = "*"
 snowballstemmer = ">=1.1"
 sphinxcontrib-applehelp = "*"
 sphinxcontrib-devhelp = "*"
@@ -499,7 +511,7 @@ sphinxcontrib-serializinghtml = ">=1.1.5"
 
 [package.extras]
 docs = ["sphinxcontrib-websupport"]
-lint = ["docutils-stubs", "flake8 (>=3.5.0)", "isort", "mypy (>=0.931)", "types-requests", "types-typed-ast"]
+lint = ["docutils-stubs", "flake8 (>=3.5.0)", "isort", "mypy (>=0.920)", "types-pkg-resources", "types-requests", "types-typed-ast"]
 test = ["cython", "html5lib", "pytest", "pytest-cov", "typed-ast"]
 
 [[package]]
@@ -598,7 +610,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 name = "zipp"
 version = "3.8.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -612,7 +624,7 @@ docs = ["furo", "myst-parser"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "841320d40f1c5724baa7f40b35dd1067503fad29b1f0e43129bfda81dee63680"
+content-hash = "dd70a99deafd628848be16f3f96dfe725adc50e36bf8150b82a433974428b73f"
 
 [metadata.files]
 alabaster = [
@@ -816,8 +828,8 @@ feedparser = [
     {file = "feedparser-6.0.10.tar.gz", hash = "sha256:27da485f4637ce7163cdeab13a80312b93b7d0c1b775bef4a47629a3110bca51"},
 ]
 flake8 = [
-    {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
-    {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
+    {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
+    {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
 ]
 furo = [
     {file = "furo-2021.11.23-py3-none-any.whl", hash = "sha256:6d396451ad1aadce380c662fca9362cb10f4fd85f296d74fe3ca32006eb641d7"},
@@ -839,8 +851,8 @@ imagesize = [
     {file = "imagesize-1.4.1.tar.gz", hash = "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},
-    {file = "importlib_metadata-4.12.0.tar.gz", hash = "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670"},
+    {file = "importlib_metadata-4.2.0-py3-none-any.whl", hash = "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b"},
+    {file = "importlib_metadata-4.2.0.tar.gz", hash = "sha256:b7e52a1f8dec14a75ea73e0891f3060099ca1d8e6a462a4dff11c3e119ea1b31"},
 ]
 Jinja2 = [
     {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
@@ -909,16 +921,16 @@ packaging = [
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pycodestyle = [
-    {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
-    {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
+    {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
+    {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
 ]
 pycparser = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
 ]
 pyflakes = [
-    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
-    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
+    {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
+    {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
 ]
 Pygments = [
     {file = "Pygments-2.13.0-py3-none-any.whl", hash = "sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42"},
@@ -979,6 +991,10 @@ requests = [
     {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
     {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
 ]
+setuptools = [
+    {file = "setuptools-65.3.0-py3-none-any.whl", hash = "sha256:2e24e0bec025f035a2e72cdd1961119f557d78ad331bb00ff82efb2ab8da8e82"},
+    {file = "setuptools-65.3.0.tar.gz", hash = "sha256:7732871f4f7fa58fb6bdcaeadb0161b2bd046c85905dbaa066bdcbcc81953b57"},
+]
 sgmllib3k = [
     {file = "sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9"},
 ]
@@ -995,8 +1011,8 @@ soupsieve = [
     {file = "soupsieve-2.3.2.post1.tar.gz", hash = "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"},
 ]
 Sphinx = [
-    {file = "Sphinx-4.5.0-py3-none-any.whl", hash = "sha256:ebf612653238bcc8f4359627a9b7ce44ede6fdd75d9d30f68255c7383d3a6226"},
-    {file = "Sphinx-4.5.0.tar.gz", hash = "sha256:7bf8ca9637a4ee15af412d1a1d9689fec70523a68ca9bb9127c2f3eeb344e2e6"},
+    {file = "Sphinx-4.3.2-py3-none-any.whl", hash = "sha256:6a11ea5dd0bdb197f9c2abc2e0ce73e01340464feaece525e64036546d24c851"},
+    {file = "Sphinx-4.3.2.tar.gz", hash = "sha256:0a8836751a68306b3fe97ecbe44db786f8479c3bf4b80e3a7f5c838657b4698c"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ furo = { version = "^2021.8.31", optional = true }
 
 [tool.poetry.dev-dependencies]
 httpretty = "^1.1.4"
-flake8 = "^3.9.1"
+flake8 = "^4.0.1"
 coverage = "^5.5"
 
 [tool.poetry.extras]

--- a/tests/test_askbot.py
+++ b/tests/test_askbot.py
@@ -33,10 +33,7 @@ import unittest
 
 import bs4
 import httpretty
-import pkg_resources
 import requests
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.backends.core.askbot import (Askbot,

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -31,10 +31,7 @@ import shutil
 import unittest
 
 import httpretty
-import pkg_resources
 import requests
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.errors import BackendError, ParseError

--- a/tests/test_bugzillarest.py
+++ b/tests/test_bugzillarest.py
@@ -31,9 +31,6 @@ import shutil
 import unittest
 
 import httpretty
-import pkg_resources
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.errors import BackendError

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -30,10 +30,7 @@ import tempfile
 import unittest
 
 import httpretty
-import pkg_resources
 import requests
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from grimoirelab_toolkit.datetime import datetime_utcnow
 

--- a/tests/test_confluence.py
+++ b/tests/test_confluence.py
@@ -32,10 +32,7 @@ import unittest
 import urllib
 
 import httpretty
-import pkg_resources
 import requests
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.utils import DEFAULT_DATETIME

--- a/tests/test_discourse.py
+++ b/tests/test_discourse.py
@@ -32,9 +32,6 @@ import unittest
 import copy
 
 import httpretty
-import pkg_resources
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.utils import DEFAULT_DATETIME

--- a/tests/test_dockerhub.py
+++ b/tests/test_dockerhub.py
@@ -32,11 +32,8 @@ import unittest.mock
 
 import dateutil
 import httpretty
-import pkg_resources
 
 from grimoirelab_toolkit.uris import urijoin
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.backends.core.dockerhub import (DockerHub,

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -28,10 +28,6 @@ import os
 import shutil
 import unittest.mock
 
-import pkg_resources
-
-pkg_resources.declare_namespace('perceval.backends')
-
 from perceval.backend import BackendCommandArgumentParser
 from perceval.errors import BackendError
 from perceval.utils import DEFAULT_DATETIME

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -36,9 +36,6 @@ import unittest
 import unittest.mock
 
 import dateutil.tz
-import pkg_resources
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser, uuid
 from perceval.errors import RepositoryError

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -41,10 +41,7 @@ import unittest.mock
 import copy
 
 import httpretty
-import pkg_resources
 import requests
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from grimoirelab_toolkit.datetime import datetime_utcnow
 from perceval.backend import BackendCommandArgumentParser

--- a/tests/test_githubql.py
+++ b/tests/test_githubql.py
@@ -26,9 +26,6 @@ import os
 import unittest.mock
 
 import httpretty
-import pkg_resources
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.client import RateLimitHandler
 from perceval.utils import DEFAULT_DATETIME

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -34,10 +34,7 @@ import time
 import unittest
 
 import httpretty
-import pkg_resources
 import requests
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from grimoirelab_toolkit.datetime import datetime_utcnow
 from perceval.backend import BackendCommandArgumentParser

--- a/tests/test_gitter.py
+++ b/tests/test_gitter.py
@@ -24,13 +24,10 @@ import copy
 import datetime
 import httpretty
 import os
-import pkg_resources
 import unittest
 import unittest.mock
 import dateutil.tz
 import time
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.errors import (BackendError,

--- a/tests/test_googlehits.py
+++ b/tests/test_googlehits.py
@@ -30,9 +30,6 @@ import unittest.mock
 
 import dateutil
 import httpretty
-import pkg_resources
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.backends.core.googlehits import (GoogleHits,

--- a/tests/test_groupsio.py
+++ b/tests/test_groupsio.py
@@ -25,15 +25,12 @@
 import datetime
 import httpretty
 import os
-import pkg_resources
 import requests
 import shutil
 import tempfile
 import unittest
 import unittest.mock
 import zipfile
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.errors import BackendError

--- a/tests/test_hyperkitty.py
+++ b/tests/test_hyperkitty.py
@@ -32,9 +32,6 @@ import unittest.mock
 
 import dateutil.tz
 import httpretty
-import pkg_resources
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.utils import DEFAULT_DATETIME

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -32,9 +32,6 @@ import time
 import unittest
 
 import httpretty
-import pkg_resources
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.backends.core.jenkins import (logger,

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -32,11 +32,8 @@ import os
 import unittest
 
 import httpretty
-import pkg_resources
 
 from grimoirelab_toolkit.datetime import str_to_datetime
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.utils import DEFAULT_DATETIME

--- a/tests/test_launchpad.py
+++ b/tests/test_launchpad.py
@@ -27,11 +27,8 @@ import datetime
 import httpretty
 import json
 import os
-import pkg_resources
 import requests
 import unittest
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.backends.core.launchpad import (Launchpad,

--- a/tests/test_mattermost.py
+++ b/tests/test_mattermost.py
@@ -28,9 +28,6 @@ import unittest
 import copy
 
 import httpretty
-import pkg_resources
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.utils import DEFAULT_DATETIME

--- a/tests/test_mbox.py
+++ b/tests/test_mbox.py
@@ -28,14 +28,11 @@ import bz2
 import datetime
 import gzip
 import os
-import pkg_resources
 import shutil
 import tempfile
 import unittest
 import unittest.mock
 import zipfile
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.utils import DEFAULT_DATETIME

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -30,15 +30,12 @@ import datetime
 import dateutil
 import httpretty
 import os
-import pkg_resources
 import unittest
 import urllib
 import unittest.mock
 
 from grimoirelab_toolkit.datetime import (datetime_to_utc,
                                           str_to_datetime)
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.errors import BackendError

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -29,15 +29,12 @@ import datetime
 import dateutil.tz
 import httpretty
 import os
-import pkg_resources
 import time
 import unittest
 import unittest.mock
 import warnings
 
 import requests
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.errors import RateLimitError, RepositoryError

--- a/tests/test_nntp.py
+++ b/tests/test_nntp.py
@@ -26,13 +26,10 @@
 import collections
 import nntplib
 import os
-import pkg_resources
 import shutil
 import tempfile
 import unittest
 import unittest.mock
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.archive import Archive
 from perceval.backend import BackendCommandArgumentParser

--- a/tests/test_pagure.py
+++ b/tests/test_pagure.py
@@ -24,12 +24,9 @@ import datetime
 import os
 import unittest.mock
 import httpretty
-import pkg_resources
 import requests
 import dateutil.tz
 import copy
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.utils import (DEFAULT_DATETIME, DEFAULT_LAST_DATETIME)

--- a/tests/test_phabricator.py
+++ b/tests/test_phabricator.py
@@ -29,11 +29,8 @@ import datetime
 import httpretty
 import json
 import os
-import pkg_resources
 import requests
 import unittest
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.utils import DEFAULT_DATETIME

--- a/tests/test_pipermail.py
+++ b/tests/test_pipermail.py
@@ -28,14 +28,11 @@
 import datetime
 import httpretty
 import os
-import pkg_resources
 import requests
 import shutil
 import tempfile
 import unittest
 import unittest.mock
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.utils import DEFAULT_DATETIME

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -28,10 +28,7 @@ import copy
 import datetime
 import httpretty
 import os
-import pkg_resources
 import unittest
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.utils import DEFAULT_DATETIME

--- a/tests/test_rocketchat.py
+++ b/tests/test_rocketchat.py
@@ -25,14 +25,11 @@ import copy
 import datetime
 import httpretty
 import os
-import pkg_resources
 import unittest
 import unittest.mock
 import dateutil.tz
 import time
 import json
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.errors import RateLimitError

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -27,10 +27,7 @@
 
 import httpretty
 import os
-import pkg_resources
 import unittest
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.backends.core.rss import RSS, RSSCommand, RSSClient

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -28,11 +28,8 @@ import datetime
 import dateutil
 import httpretty
 import os
-import pkg_resources
 import unittest
 import unittest.mock
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.utils import DEFAULT_DATETIME

--- a/tests/test_stackexchange.py
+++ b/tests/test_stackexchange.py
@@ -30,14 +30,11 @@ import datetime
 import httpretty
 import json
 import os
-import pkg_resources
 import time
 import unittest
 import urllib
 
 from perceval.errors import BackendError
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.utils import DEFAULT_DATETIME

--- a/tests/test_supybot.py
+++ b/tests/test_supybot.py
@@ -26,12 +26,9 @@
 
 import datetime
 import os
-import pkg_resources
 import shutil
 import tempfile
 import unittest
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.errors import ParseError

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -26,11 +26,8 @@
 
 import httpretty
 import os
-import pkg_resources
 import unittest
 import urllib
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.backends.core.telegram import (Telegram,

--- a/tests/test_twitter.py
+++ b/tests/test_twitter.py
@@ -31,9 +31,6 @@ import unittest.mock
 
 import dateutil
 import httpretty
-import pkg_resources
-
-pkg_resources.declare_namespace('perceval.backends')
 
 from grimoirelab_toolkit.datetime import str_to_datetime
 from perceval.backend import BackendCommandArgumentParser


### PR DESCRIPTION
This PR updates the `flake8` dependency to 4.0.1 to make it consistent with other grimoirelab repositories and keep dependencies more stable.

It also updates how the package is installed in the release because it was not installing the new package.