### PR TITLE
[hyperkitty/mbox] Activate '--to-date' argument

### DIFF
--- a/releases/unreleased/hyperkitty-to-date.yml
+++ b/releases/unreleased/hyperkitty-to-date.yml
@@ -1,0 +1,9 @@
+---
+title: '[hyperkitty/mbox] Option `to-date` to fetch until that date'
+category: added
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    This parameter allows fetching data until a specific date.
+    By default, this value is `2100-01-01`, but this can be changed
+    adding `--to-date`.


### PR DESCRIPTION
This code allows fetching data until a specific date by activating `--to-date`.

Backend version is now 0.7.0.

Tests added accordingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>