### PR TITLE
[mbox] Fix mbox to-date argument

### DIFF
--- a/perceval/backends/core/mbox.py
+++ b/perceval/backends/core/mbox.py
@@ -67,7 +67,7 @@ class MBox(Backend):
     :param archive: archive to store/retrieve items
     :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.13.1'
+    version = '0.13.2'
 
     CATEGORIES = [CATEGORY_MESSAGE]
 
@@ -113,13 +113,14 @@ class MBox(Backend):
         :returns: a generator of items
         """
         from_date = kwargs['from_date']
+        to_date = kwargs['to_date']
 
-        logger.info("Looking for messages from '%s' on '%s' since %s",
-                    self.uri, self.dirpath, str(from_date))
+        logger.info("Looking for messages from '%s' on '%s' since %s until %s",
+                    self.uri, self.dirpath, str(from_date), str(to_date))
 
         mailing_list = MailingList(self.uri, self.dirpath)
 
-        messages = self._fetch_and_parse_messages(mailing_list, from_date)
+        messages = self._fetch_and_parse_messages(mailing_list, from_date, to_date)
 
         for message in messages:
             yield message
@@ -350,6 +351,7 @@ class MBoxCommand(BackendCommand):
 
         parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
+                                              to_date=True,
                                               ssl_verify=True)
 
         # Required arguments

--- a/releases/unreleased/mbox-to-date-argument-fixed.yml
+++ b/releases/unreleased/mbox-to-date-argument-fixed.yml
@@ -1,0 +1,8 @@
+---
+title: Mbox to-date argument fixed
+category: fixed
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    It fixes the `--to-date` argument. This parameter was added to
+    fetch data until a specific date.

--- a/tests/test_mbox.py
+++ b/tests/test_mbox.py
@@ -333,6 +333,31 @@ class TestMBoxBackend(TestBaseMBox):
             self.assertEqual(message['category'], 'message')
             self.assertEqual(message['tag'], 'http://example.com/')
 
+    def test_fetch_to_date(self):
+        """Test whether a list of messages is returned to a given date"""
+
+        to_date = datetime.datetime(2008, 1, 1)
+
+        backend = MBox('http://example.com/', self.tmp_path)
+        messages = [m for m in backend.fetch(to_date=to_date)]
+
+        expected = [
+            ('<BAY12-DAV6Dhd2stb2e0000c0ce@hotmail.com>', 'bd0185317b013beb21ad3ea04635de3db72496ad', 1095843820.0),
+            ('<FB0C1D9DAED2D411BB990002A52C30EC03838593@example.com>', 'ddda42422c55d08d56c017a6f128fcd7447484ea', 1043881350.0),
+            ('<20020823171132.541DB44147@example.com>', '4e255acab6442424ecbf05cb0feb1eccb587f7de', 1030123489.0)
+        ]
+
+        self.assertEqual(len(messages), len(expected))
+
+        for x in range(len(messages)):
+            message = messages[x]
+            self.assertEqual(message['data']['Message-ID'], expected[x][0])
+            self.assertEqual(message['origin'], 'http://example.com/')
+            self.assertEqual(message['uuid'], expected[x][1])
+            self.assertEqual(message['updated_on'], expected[x][2])
+            self.assertEqual(message['category'], 'message')
+            self.assertEqual(message['tag'], 'http://example.com/')
+
     @unittest.mock.patch('perceval.backends.core.mbox.str_to_datetime')
     def test_fetch_exception(self, mock_str_to_datetime):
         """Test whether an exception is thrown when the the fetch_items method fails"""


### PR DESCRIPTION
This code allows to use `to-date` argument. It was missing to add `to-date` in the backend command argument parser. Also, add it to the `fetch_items` method to fetch data until that date.

Test added accordingly.
Version updated to 0.13.2.

Signed-off-by: Quan Zhou <quan@bitergia.com>