### PR TITLE
[mbox] Include a default value for `--to-date` in mbox backend

### DIFF
--- a/perceval/backends/core/mbox.py
+++ b/perceval/backends/core/mbox.py
@@ -95,6 +95,8 @@ class MBox(Backend):
         """
         if not from_date:
             from_date = DEFAULT_DATETIME
+        if not to_date:
+            to_date = DEFAULT_LAST_DATETIME
 
         kwargs = {
             'from_date': from_date,

--- a/releases/unreleased/default-value-for-mbox-to-date.yml
+++ b/releases/unreleased/default-value-for-mbox-to-date.yml
@@ -1,0 +1,7 @@
+---
+title: Default value for mbox to-date
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: 810
+notes: |
+  Include a default value for `--to-date` argument in mbox backend.

--- a/tests/test_mbox.py
+++ b/tests/test_mbox.py
@@ -267,7 +267,7 @@ class TestMBoxBackend(TestBaseMBox):
         """Test whether it parses a set of mbox files"""
 
         backend = MBox('http://example.com/', self.tmp_path)
-        messages = [m for m in backend.fetch(from_date=None)]
+        messages = [m for m in backend.fetch(from_date=None, to_date=None)]
 
         expected = [
             ('<4CF64D10.9020206@domain.com>', '86315b479b4debe320b59c881c1e375216cbf333', 1291210000.0),


### PR DESCRIPTION
This PR includes a default value for `--to-date` in mbox backend when the argument is not defined.

Related to https://github.com/chaoss/grimoirelab-perceval/issues/810