### PR TITLE
Confluence token authentication

### DIFF
--- a/releases/unreleased/add-token-auth-for-confluence.yml
+++ b/releases/unreleased/add-token-auth-for-confluence.yml
@@ -1,0 +1,9 @@
+title: Clonfluence authentication with personal access tokens
+category: added
+author: devpod.cn <support@devpod.cn>
+issue:
+notes: >
+    Authentication in `confluence` backend is supported using
+    personal access tokens. Confluence Data Center and server
+    editions 7.9 and later can use personal access tokens without
+    a username. For Confluence Cloud, username and token are required.


### PR DESCRIPTION
Support token authentication for Confluence backend.

For Confluence Data Center or server editions, just use the personal access token:
`perceval confluence 'http://[YOUR_CONFLUENCE_SITE]/' -t [PERSONAL_ACCESS_TOKEN]`

For Confluence cloud:
`perceval confluence -u 'someone@example.com' -t [API_TOKEN] 'https://[YOUR_SITE].atlassian.net/wiki'`