### PR TITLE
Jira token authentication

### DIFF
--- a/releases/unreleased/add-token-auth-for-jira.yml
+++ b/releases/unreleased/add-token-auth-for-jira.yml
@@ -1,0 +1,14 @@
+title: Jira authentication with token
+category: added
+author: devpod.cn <support@devpod.cn>
+issue: 813
+notes: >
+    Authentication in `jira` backend is supported using
+    personal access tokens. Jira Core/Software (8.14 and later),
+    Jira Service Management (4.15 and later) Data Center and server editions
+    can use personal access tokens without a username. For Jira Cloud, username
+    and token are required.
+    Usage:
+    perceval jira <YOUR_JIRA_SERVER> -u <USERNAME> -p <PASSWORD>
+    perceval jira <YOUR_JIRA_SERVER> -t <PERSONAL_ACCESS_TOKEN>
+    perceval jira <YOUR_JIRA_CLOUD_SITE> -u <USERNAME> -t <TOKEN>

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -682,6 +682,16 @@ class TestJiraClient(unittest.TestCase):
         self.assertEqual(client.cert, "cert")
         self.assertEqual(client.max_results, 100)
 
+        client = JiraClient(url='http://example.com', project='perceval',
+                            user='user', password=None, api_token='token',
+                            ssl_verify=False, cert="cert", max_results=100)
+
+        self.assertEqual(client.base_url, 'http://example.com')
+        self.assertEqual(client.project, 'perceval')
+        self.assertEqual(client.user, 'user')
+        self.assertEqual(client.password, None)
+        self.assertEqual(client.api_token, 'token')
+
     @httpretty.activate
     def test_get_issues(self):
         """Test get issues API call"""
@@ -906,6 +916,14 @@ class TestJiraCommand(unittest.TestCase):
         self.assertTrue(parsed_args.no_archive)
         self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
         self.assertEqual(parsed_args.url, JIRA_SERVER_URL)
+
+        args = ['--backend-user', 'jsmith',
+                '--api-token', 'token_xxx',
+                JIRA_SERVER_URL]
+
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.user, 'jsmith')
+        self.assertEqual(parsed_args.api_token, 'token_xxx')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
For issue #813 .

Usage:
```
    perceval jira <YOUR_JIRA_SERVER> -u <USERNAME> -p <PASSWORD>
    perceval jira <YOUR_JIRA_SERVER> -t <PERSONAL_ACCESS_TOKEN>
    perceval jira <YOUR_JIRA_CLOUD_SITE> -u <USERNAME> -t <TOKEN>
```