### PR TITLE
[git] Fix file stats for merged files on subdirs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,4 +41,6 @@ jobs:
           cd tests
           poetry run coverage run --source=perceval run_tests.py
       - name: Coveralls
-        uses: coverallsapp/github-action@f350da2c033043742f89e8c0b7b5145a1616da6d # v2.1.2
+        uses: coverallsapp/github-action@643bc377ffa44ace6394b2b5d0d3950076de9f63 # v2.3.0
+        with:
+          coverage-reporter-version: "v0.6.9"

--- a/perceval/backends/core/git.py
+++ b/perceval/backends/core/git.py
@@ -804,7 +804,14 @@ class GitParser:
             prefix = f[0:i]
             inner = f[i + 1:f.find(' => ', i)]
             suffix = f[j + 1:]
-            return prefix + inner + suffix
+            old_filepath = prefix + inner + suffix
+
+            # Remove double '/' for corner cases like
+            # 'dir/{ => subdir}/filename'.
+            # The resulting old path on these entries is 'dir//filename'.
+            old_filepath = old_filepath.replace('//', '/')
+
+            return old_filepath
         elif ' => ' in f:
             return f.split(' => ')[0]
         else:

--- a/releases/unreleased/wrong-filepath-for-movedcopied-files.yml
+++ b/releases/unreleased/wrong-filepath-for-movedcopied-files.yml
@@ -1,0 +1,16 @@
+---
+title: Empty stats for moved/copied files in git
+category: fixed
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  Stats about changes on a file were not reported correctly
+  for files that where moved to a subdirectory. They
+  were reported as an invalid entry and without
+  action associated.
+  For example, the file `dir/filename` was moved to `dir/subdir/filename`,
+  but it was reported as `dir//filename`. Therefore,
+  the entry of the file `dir/subdire/filename` didn't
+  have the stats about added and deleted lines.
+  This error has been fixed and stats are reported
+  correctly.

--- a/tests/data/git/git_log_moved.txt
+++ b/tests/data/git/git_log_moved.txt
@@ -1,0 +1,12 @@
+commit 1e6250992e6cddebfaf4e6fdf241171091874523 ff93e98029e7b8356bf87456df0254332f4a6549
+Author:     John Smith <jsmith@example.com>
+AuthorDate: Tue Nov 22 14:00:06 2016 +0100
+Commit:     John Smith <jsmith@example.com>
+CommitDate: Tue Nov 22 14:00:06 2016 +0100
+
+    [backends] Move backends to core sub-package
+
+:000000 100644 0000000 e69de29 A	perceval/backends/core/__init__.py
+:100644 100644 232acb3 7923641 R098	perceval/backends/bugzilla.py	perceval/backends/core/bugzilla.py
+0	0	perceval/backends/core/__init__.py
+4	4	perceval/backends/{ => core}/bugzilla.py

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1129,6 +1129,47 @@ class TestGitParser(TestCaseGit):
 
         self.assertDictEqual(commits[9], expected)
 
+    def test_parser_renamed_files(self):
+        """Check it moved or copied files are correctly renamed"""
+
+        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "data/git/git_log_moved.txt"), 'r') as f:
+            parser = GitParser(f)
+            commits = [commit for commit in parser.parse()]
+
+        self.assertEqual(len(commits), 1)
+
+        expected = {
+            'commit': '1e6250992e6cddebfaf4e6fdf241171091874523',
+            'parents': ['ff93e98029e7b8356bf87456df0254332f4a6549'],
+            'refs': [],
+            'Author': 'John Smith <jsmith@example.com>',
+            'AuthorDate': 'Tue Nov 22 14:00:06 2016 +0100',
+            'Commit': 'John Smith <jsmith@example.com>',
+            'CommitDate': 'Tue Nov 22 14:00:06 2016 +0100',
+            'message': '[backends] Move backends to core sub-package',
+            'files': [
+                {
+                    'file': 'perceval/backends/bugzilla.py',
+                    'newfile': 'perceval/backends/core/bugzilla.py',
+                    'added': '4',
+                    'removed': '4',
+                    'modes': ['100644', '100644'],
+                    'indexes': ['232acb3', '7923641'],
+                    'action': 'R098'
+                },
+                {
+                    'file': 'perceval/backends/core/__init__.py',
+                    'added': '0',
+                    'removed': '0',
+                    'modes': ['000000', '100644'],
+                    'indexes': ['0000000', 'e69de29'],
+                    'action': 'A'
+                }
+            ]
+        }
+
+        self.assertDictEqual(commits[0], expected)
+
     def test_parser_merge_commit(self):
         """Test if it parses all the available data on a merge commit"""
 


### PR DESCRIPTION
Stats about changes on a file were not reported correctly for files that where moved to a subdirectory. They were reported as an invalid entry and without action associated.

For example, the file `dir/filename` was moved to `dir/subdir/filename`, but it was reported as `dir//filename`. Therefore, the entry of the file `dir/subdire/filename` didn't have the stats about added and deleted lines. This error has been fixed and stats are reported correctly.