### PR TITLE
[ci] Fix coveralls parallel run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,3 +44,5 @@ jobs:
         uses: coverallsapp/github-action@643bc377ffa44ace6394b2b5d0d3950076de9f63 # v2.3.0
         with:
           coverage-reporter-version: "v0.6.9"
+          flag-name: run ${{ join(matrix.*, ' - ') }}
+          parallel: true


### PR DESCRIPTION
The error "Can't add a job to a build that is already closed" is fixed assigning a unique name to each parallel run of the tests.