### PR TITLE
Adding deletion for old tag references

### DIFF
--- a/perceval/backends/core/git.py
+++ b/perceval/backends/core/git.py
@@ -1297,7 +1297,7 @@ class GitRepository:
 
         # Delete old references
         for old_ref in self._discover_refs():
-            if not old_ref.refname.startswith('refs/heads/'):
+            if not old_ref.refname.startswith('refs/heads/') and not old_ref.refname.startswith('refs/tags/'):
                 continue
             if old_ref.refname in new_refs:
                 continue

--- a/releases/unreleased/fix-issue-#782.yml
+++ b/releases/unreleased/fix-issue-#782.yml
@@ -1,0 +1,6 @@
+title: 'Fix issue #782'
+category: fixed
+author: Matt Gaughan <mgaughan@proton.me>
+issue: 782
+notes: >
+  The issue was that perceval would not delete old tags from upstream references. This change deletes tags locally if tags are deleted upstream. 


### PR DESCRIPTION
title: 'Adding deletion for old tag references'
category: fixed
author: Matt Gaughan <mgaughan@proton.me>
issue:  (782)[https://github.com/chaoss/grimoirelab-perceval/issues/782]
notes: >
    If server deletes reference to tag, local repo will as well. 
    Simple implementation for clarity's sake. 