### PR TITLE
Fix parsing and display of backend-specific help messages

### DIFF
--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -771,6 +771,9 @@ class BackendCommand:
 
     def __init__(self, *args, debug=False):
         parser = self.setup_cmd_parser()
+
+        parser.parser.prog = "perceval %s" % self.BACKEND.__name__.lower()
+
         self.parsed_args = parser.parse(*args)
         self.debug = debug
         self.archive_manager = None

--- a/releases/unreleased/fixed-missing-backend-name-in-usage-string.yml
+++ b/releases/unreleased/fixed-missing-backend-name-in-usage-string.yml
@@ -1,0 +1,8 @@
+---
+title: Fixed missing backend name in usage string
+category: fixed
+author: Venu Vardhan Reddy Tekula <venu@chaoss.community>
+issue: 799
+notes: >
+  The `perceval` command-line tool now correctly displays the backend name in the usage string
+  when using the `--help` option.


### PR DESCRIPTION
Fixes #799

I took a stab at this bug, by setting the `prog` attribute inside the `BackendCommand`'s `__init__` method, you ensure that the program name (prog) is set correctly when each backend is initialized. This should fix the issue with any backend.

```bash
$ perceval github -h
[2024-08-12 17:42:02,923] - Sir Perceval is on his quest.
usage: perceval github [-h] [--category CATEGORY] [--tag TAG] [--filter-classified] [--from-date FROM_DATE] [--to-date TO_DATE] [--archive-path ARCHIVE_PATH] [--no-archive] [--fetch-archive]
                       [--archived-since ARCHIVED_SINCE] [--no-ssl-verify] [-o OUTFILE] [--json-line] [--enterprise-url BASE_URL] [--sleep-for-rate] [--min-rate-to-sleep MIN_RATE_TO_SLEEP]
                       [-t API_TOKEN [API_TOKEN ...]] [--github-app-id GITHUB_APP_ID] [--github-app-pk-filepath GITHUB_APP_PK_FILEPATH] [--max-items MAX_ITEMS] [--max-retries MAX_RETRIES]
                       [--sleep-time SLEEP_TIME]
                       owner repository
```
```bash
$ perceval jira -h
[2024-08-12 17:44:02,305] - Sir Perceval is on his quest.
usage: perceval jira [-h] [--category CATEGORY] [--tag TAG] [--filter-classified] [--from-date FROM_DATE] [-u USER] [-p PASSWORD] [-t API_TOKEN] [--archive-path ARCHIVE_PATH] [--no-archive]
                     [--fetch-archive] [--archived-since ARCHIVED_SINCE] [--no-ssl-verify] [-o OUTFILE] [--json-line] [--project PROJECT] [--cert CERT] [--max-results MAX_RESULTS]
                     url
```

Do you think you need any tests for this change?

~I am trying to see if I can fix the args order.~
I guess it cannot be fixed, check https://github.com/chaoss/grimoirelab-perceval/issues/799#issuecomment-2285250817

~I will add the changelog file when I finish the PR.~
Added