### PR TITLE
[git] Assign stats for files with whitespaces

### DIFF
--- a/perceval/backends/core/git.py
+++ b/perceval/backends/core/git.py
@@ -71,7 +71,7 @@ class Git(Backend):
     :raises RepositoryError: raised when there was an error cloning or
         updating the repository.
     """
-    version = '1.0.0'
+    version = '1.0.1'
 
     CATEGORIES = [CATEGORY_COMMIT]
 
@@ -567,7 +567,7 @@ class GitParser:
                       (?P<file>[^\t]+)
                       (?:\t+(?P<newfile>.+))?$"""
 
-    STATS_PATTERN = r"^(?P<added>\d+|-)[ \t]+(?P<removed>\d+|-)[ \t]+(?P<file>.+)$"
+    STATS_PATTERN = r"^(?P<added>\d+|-)\t+(?P<removed>\d+|-)\t+(?P<file>.+)$"
 
     EMPTY_LINE_PATTERN = r"^$"
 

--- a/releases/unreleased/git-file-stats-with-whitespaces-were-not-assigned.yml
+++ b/releases/unreleased/git-file-stats-with-whitespaces-were-not-assigned.yml
@@ -1,0 +1,11 @@
+---
+title: Git stats not assigned with their actions
+category: fixed
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  Git stats were not assigned to their actions in
+  a commit for filenames that contain whitespaces.
+  Instead, an empty stat was created like in a
+  merge commit, where actions normally don't take
+  place.

--- a/tests/data/git/git_log_merge.txt
+++ b/tests/data/git/git_log_merge.txt
@@ -7,9 +7,9 @@ CommitDate: Tue Aug 2 19:47:06 2016 -0400
 
     Merge tag 'for-linus-v4.8' of git://github.com/martinbrandenburg/linux
 
-46  4   Documentation/filesystems/orangefs.txt
-4   0   fs/orangefs/dcache.c
-3   3   fs/orangefs/inode.c
+46	4	Documentation/filesystems/orangefs.txt
+4	0	fs/orangefs/dcache.c
+3	3	fs/orangefs/inode.c
 
 commit 456a68ee1407a77f3e804a30dff245bb6c6b872f ce8e0b86a1e9877f42fe9453ede418519115f367 51a3b654f252210572297f47597b31527c475fb8 (HEAD -> refs/heads/master)
 Merge: ce8e0b8 51a3b65

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1395,6 +1395,19 @@ class TestGitParser(TestCaseGit):
         self.assertEqual(m.group('removed'), "0")
         self.assertEqual(m.group('file'), "bbb/{something => something.renamed}")
 
+        # Test with files that have whitespaces
+        s = "5\t0\t afile.txt"
+        m = pattern.match(s)
+        self.assertEqual(m.group('added'), "5")
+        self.assertEqual(m.group('removed'), "0")
+        self.assertEqual(m.group('file'), " afile.txt")
+
+        s = "5\t0\ta fi le.txt"
+        m = pattern.match(s)
+        self.assertEqual(m.group('added'), "5")
+        self.assertEqual(m.group('removed'), "0")
+        self.assertEqual(m.group('file'), "a fi le.txt")
+
     def test_empty_line(self):
         """Test empty line pattern"""
 


### PR DESCRIPTION
Git commit stats weren't assigned to the action for those files with whitespaces in their filenames.
Actions didn't have stats and empty stats entries were created, like in a merge commit.

The problem was that the regular expression used to parse the stats considered whitespaces as separators.