### PR TITLE
[git] Update references changed on the remote repo only

### DIFF
--- a/perceval/backends/core/git.py
+++ b/perceval/backends/core/git.py
@@ -1304,6 +1304,8 @@ class GitRepository:
             self._update_ref(old_ref, delete=True)
 
         # Update new references
+        current_refs = {ref.refname: ref.hash for ref in self._discover_refs()}
+
         for new_ref in refs:
             refname = new_ref.refname
 
@@ -1313,6 +1315,10 @@ class GitRepository:
                 continue
             elif not refname.startswith('refs/heads/') and not refname.startswith('refs/tags/'):
                 logger.debug("Reference %s not needed; ignored for updating in sync process",
+                             refname)
+                continue
+            elif refname in current_refs and new_ref.hash == current_refs[refname]:
+                logger.debug("Reference %s already up to date in sync process",
                              refname)
                 continue
             else:

--- a/releases/unreleased/git-sync-perfomance-improved.yml
+++ b/releases/unreleased/git-sync-perfomance-improved.yml
@@ -1,0 +1,14 @@
+---
+title: Git sync improved for `--latest-items` flag
+category: performance
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  The speed updating a git repository when `--lates-items`
+  is set was very poor. The main problem was when the
+  references were updated to the new hashes. All the
+  active refs on the repository were modified, even when
+  they were up-to-date. Now, only references updated
+  on the remote repository are modified on the local one.
+  Repositories are synched 2 times faster than before.
+


### PR DESCRIPTION
When repositories are synched, the backend needs to update the local references to the ones set on the remote repository. The backend processed all the references, including those up to date. This made the synchronization very slow.

With this commit, only the references that were updated on the remote repository will be modified locally. We have improved the performance by 2. Repositories are in sync two or more times than before.

Performance data using `https://github.com/eclipse-platform/eclipse.platform.releng.buildtools.git`, when the repository hasn't been updated.

- Before this patch
```
time perceval git https://github.com/eclipse-platform/eclipse.platform.releng.buildtools.git --latest-items

real	0m5,380s
user	0m1,802s
sys	0m2,000s
```

- Using this patch
```
time perceval git https://github.com/eclipse-platform/eclipse.platform.releng.buildtools.git --latest-items

real	0m2,551s
user	0m0,823s
sys	0m0,115s
```