### PR TITLE
[tests] Do not print data running 'run_tests.py'

### DIFF
--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -2072,6 +2072,8 @@ class TestGitRepository(TestCaseGit):
         # Create a loose object in the repository
         process = subprocess.Popen(['git', 'hash-object', '-w', '--stdin'],
                                    stdin=subprocess.PIPE,
+                                   stdout=subprocess.DEVNULL,
+                                   stderr=subprocess.DEVNULL,
                                    cwd=new_path,
                                    env={'LANG': 'C'})
         process.communicate(input=b"Data test")
@@ -2079,8 +2081,12 @@ class TestGitRepository(TestCaseGit):
         self.assertTrue(repo.has_loose_objects())
 
         # Group loose objects in a packfile and remove unreachable objects
-        subprocess.run(['git', 'gc'], cwd=new_path, check=True)
-        subprocess.run(['git', 'prune'], cwd=new_path, check=True)
+        subprocess.run(['git', 'gc'],
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                       cwd=new_path, check=True)
+        subprocess.run(['git', 'prune'],
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                       cwd=new_path, check=True)
 
         self.assertFalse(repo.has_loose_objects())
 

--- a/tests/test_gitter.py
+++ b/tests/test_gitter.py
@@ -204,7 +204,6 @@ class TestGitterBackend(unittest.TestCase):
         from_date = datetime.datetime(2020, 3, 24, 0, 0, tzinfo=dateutil.tz.tzutc())
         backend = Gitter(group='testapicomm', room='community', api_token='aaa', max_items=1)
         messages = [m for m in backend.fetch(from_date=from_date)]
-        print(messages)
         self.assertEqual(len(messages), 1)
 
         message = messages[0]


### PR DESCRIPTION
Some tests procuced some noise when the are run with 'run_tests.py' script. Data is send to '/dev/null' or similar.