### PR TITLE
Migrate files for branch rename from master to main

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,4 +9,4 @@ jobs:
   check-changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: bitergia/release-tools-check-changelog@master
+      - uses: bitergia/release-tools-check-changelog@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build package using Poetry and store result
-        uses: chaoss/grimoirelab-github-actions/build@master
+        uses: chaoss/grimoirelab-github-actions/build@main
         with:
           artifact-name: perceval-dist
           artifact-path: dist
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create a new release on the repository
-        uses: chaoss/grimoirelab-github-actions/release@master
+        uses: chaoss/grimoirelab-github-actions/release@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Publish the package on PyPI
-        uses: chaoss/grimoirelab-github-actions/publish@master
+        uses: chaoss/grimoirelab-github-actions/publish@main
         with:
           artifact-name: perceval-dist
           artifact-path: dist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to GrimoireLab Perceval
 
 These are some general guidelines and information related to how we contribute to 
-GrimoireLab. You can read about it from the [CONTRIBUTING.md](https://github.com/chaoss/grimoirelab/blob/master/CONTRIBUTING.md).
+GrimoireLab. You can read about it from the [CONTRIBUTING.md](https://github.com/chaoss/grimoirelab/blob/main/CONTRIBUTING.md).
 
 ## Changelog Entries
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Perceval [![Build Status](https://github.com/chaoss/grimoirelab-perceval/workflows/tests/badge.svg)](https://github.com/chaoss/grimoirelab-perceval/actions?query=workflow:tests+branch:master+event:push) [![Coverage Status](https://img.shields.io/coveralls/chaoss/grimoirelab-perceval.svg)](https://coveralls.io/r/chaoss/grimoirelab-perceval?branch=master) [![PyPI version](https://badge.fury.io/py/perceval.svg)](https://badge.fury.io/py/perceval) [![Documentation in RTD](https://readthedocs.org/projects/perceval/badge/)](http://perceval.readthedocs.io)
+# Perceval [![Build Status](https://github.com/chaoss/grimoirelab-perceval/workflows/tests/badge.svg)](https://github.com/chaoss/grimoirelab-perceval/actions?query=workflow:tests+branch:main+event:push) [![Coverage Status](https://img.shields.io/coveralls/chaoss/grimoirelab-perceval.svg)](https://coveralls.io/r/chaoss/grimoirelab-perceval?branch=main) [![PyPI version](https://badge.fury.io/py/perceval.svg)](https://badge.fury.io/py/perceval) [![Documentation in RTD](https://readthedocs.org/projects/perceval/badge/)](http://perceval.readthedocs.io)
 
 Send Sir Perceval on a quest to retrieve and gather data from software
 repositories.
@@ -141,7 +141,7 @@ A Perceval Docker image is available at
 [DockerHub](https://hub.docker.com/r/grimoirelab/perceval/).
 
 Detailed information on how to run and/or build this image can be found
-[here](https://github.com/chaoss/grimoirelab-perceval/tree/master/docker/images/).
+[here](https://github.com/chaoss/grimoirelab-perceval/tree/main/docker/images/).
 
 ## Documentation
 

--- a/docs/perceval/perceval-backends.md
+++ b/docs/perceval/perceval-backends.md
@@ -16,7 +16,7 @@ A Perceval retriever is built with three components:
 
 
 Backend and CommandLine extend the abstract classes in
-[backend.py](https://github.com/grimoirelab/perceval/blob/master/perceval/backend.py).
+[backend.py](https://github.com/grimoirelab/perceval/blob/main/perceval/backend.py).
 They require the definition of several methods:
 
 - Backend:
@@ -39,8 +39,8 @@ They require the definition of several methods:
 - `setup_cmd_parser()` initializes the command parser for the backend.
 
 All backends have their own unit tests and corresponding data, saved in the folder
-[/tests](https://github.com/grimoirelab/perceval/tree/master/tests) and
-[/tests/data](https://github.com/grimoirelab/perceval/tree/master/tests/data)
+[/tests](https://github.com/grimoirelab/perceval/tree/main/tests) and
+[/tests/data](https://github.com/grimoirelab/perceval/tree/main/tests/data)
 respectively. Since most backends fetch data from HTTP APIs, their tests rely on HTTPretty
 (version==0.8.6), a mocking tool that simulates HTTP requests.
 
@@ -75,9 +75,9 @@ calling the `fetch_from_cache()` method.
 
 A strategy to deal with such a complexity is to add markers before and after pushing items
 to the cache. Examples of this strategy have been implemented for
-[GitHub](https://github.com/grimoirelab/perceval/blob/master/perceval/backends/core/github.py)
+[GitHub](https://github.com/grimoirelab/perceval/blob/main/perceval/backends/core/github.py)
 and [Launchpad
-backends](https://github.com/grimoirelab/perceval/blob/master/perceval/backends/core/launchpad.py).
+backends](https://github.com/grimoirelab/perceval/blob/main/perceval/backends/core/launchpad.py).
 
 The Python-like pseudocode below shows this strategy for extracting issues, comments and
 their authors.


### PR DESCRIPTION
Update files to support the migration of GrimoireLab repositories as part of the default branch transition from master to main.