### PR TITLE
Deprecate NNTP backend

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Download distribution artifact

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     name: Python ${{ matrix.python-version }}
     steps:

--- a/perceval/backends/core/nntp.py
+++ b/perceval/backends/core/nntp.py
@@ -24,8 +24,18 @@
 
 import io
 import logging
-import nntplib
 import email
+
+
+try:
+    import nntplib
+
+    # Hack to avoid "line too long" errors
+    nntplib._MAXLINE = 65536
+except ImportError:
+    # nntplib has been removed in Python 3.13
+    nntplib = None
+
 
 from grimoirelab_toolkit.datetime import str_to_datetime, InvalidDateError
 
@@ -38,9 +48,6 @@ from ...utils import message_to_dict
 CATEGORY_ARTICLE = "article"
 DEFAULT_OFFSET = 1
 FALLBACK_DATE = '1970-01-01'
-
-# Hack to avoid "line too long" errors
-nntplib._MAXLINE = 65536
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +72,11 @@ class NNTP(Backend):
     }
 
     def __init__(self, host, group, tag=None, archive=None):
+
+        if not nntplib:
+            raise ImportError("nntp is no longer supported in Python >= 3.13 due"
+                              "to nntplib has been removed from the standard library")
+
         origin = host + '-' + group
 
         super().__init__(origin, tag=tag, archive=archive)
@@ -267,6 +279,14 @@ class NNTTPClient():
     OVER = "over"
 
     def __init__(self, host, archive=None, from_archive=False):
+
+        if not nntplib:
+            raise ImportError("nntp is no longer supported in Python >= 3.13 due"
+                              "to nntplib has been removed from the standard library")
+        else:
+            logging.warning("nntp will no longer be supported in Python >= 3.13 due"
+                            "to nntplib has been removed from the standard library")
+
         self.host = host
         self.archive = archive
         self.from_archive = from_archive

--- a/releases/unreleased/nntp-backend-removed.yml
+++ b/releases/unreleased/nntp-backend-removed.yml
@@ -1,0 +1,12 @@
+---
+title: NNTP backend removed for Python > 3.13
+category: removed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  nntplib is no longer part of the Python standard library.
+  It was removed in Python 3.13 after being deprecated in
+  Python 3.11 (PEP 594).
+
+  This version raises an exception when trying to use
+  the NNTP backend and nntplib package is not available.


### PR DESCRIPTION
`nntplib` is no longer part of the Python standard library. It was removed in Python 3.13 after being deprecated in Python 3.11 (PEP 594).

This PR adds a warning when using the NNTP backend to inform users of potential issues in future Python versions (>= 3.13), as nntplib has been removed from the standard library.

This PR also includes Python 3.13 in GitHub action tests

Related to https://github.com/chaoss/grimoirelab-perceval/issues/860