### PR TITLE
[GitHub] Update default from-date to avoid issues with GitHub API

### DIFF
--- a/releases/unreleased/github-api-not-returning-issues.yml
+++ b/releases/unreleased/github-api-not-returning-issues.yml
@@ -1,0 +1,8 @@
+---
+title: GitHub API not returning issues
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: 865
+notes: >
+  The GitHub API does not return issues when using the epoch time (1970-01-01).
+  This has been temporarily fixed by using 1980-01-01 as the from-date.


### PR DESCRIPTION
GitHub API doesn't return issues using the default from date (1970-01-01)

This PR implements a temporary fix to prevent using the epoch time when fetching issues from the GitHub API.

Related to https://github.com/chaoss/grimoirelab-perceval/issues/865

