### PR TITLE
[github] GitHub API pagination bug

### DIFF
--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -915,7 +915,6 @@ class GitHubClient(HttpClient, RateLimitHandler):
         """Return the items from github API using links pagination"""
 
         page = 0  # current page
-        last_page = None  # last page
         url_next = urijoin(self.base_url, self.RREPOS, self.owner, self.repository, path)
         logger.debug("Get GitHub paginated items from " + url_next)
 
@@ -924,11 +923,7 @@ class GitHubClient(HttpClient, RateLimitHandler):
         items = response.text
         page += 1
 
-        if 'last' in response.links:
-            last_url = response.links['last']['url']
-            last_page = last_url.split('&page=')[1].split('&')[0]
-            last_page = int(last_page)
-            logger.debug("Page: %i/%i" % (page, last_page))
+        logger.debug(f"Page: {page}")
 
         while items:
             yield items
@@ -941,7 +936,7 @@ class GitHubClient(HttpClient, RateLimitHandler):
                 page += 1
 
                 items = response.text
-                logger.debug("Page: %i/%i" % (page, last_page))
+                logger.debug(f"Page: {page}")
 
     def _get_token_rate_limit(self, token):
         """Return token's remaining API points"""

--- a/releases/unreleased/github-api-pagination-bug.yml
+++ b/releases/unreleased/github-api-pagination-bug.yml
@@ -1,0 +1,8 @@
+---
+title: GitHub API pagination bug
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Fixed a bug where pagination stopped working after the GitHub
+  API stopped providing a reference to the last page.


### PR DESCRIPTION
Fixed a bug where pagination stopped working after the GitHub API stopped providing a reference to the last page.