### PR TITLE
[github] Return basic user data when the API does not find the user

### DIFF
--- a/releases/unreleased/missing-user-at-github-api.yml
+++ b/releases/unreleased/missing-user-at-github-api.yml
@@ -1,0 +1,9 @@
+---
+title: GitHub user data fallback
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  When the API returns a 404 for a user, Perceval returns the
+  basic user data available in the related issue, pull request,
+  comment, or review.


### PR DESCRIPTION
This PR ensures that when the API returns a 404 for a user, Perceval returns the basic user data available in the related issue, pull request, comment, or review.