### PR TITLE
Add more trailer types for Git

### DIFF
--- a/perceval/backends/core/git.py
+++ b/perceval/backends/core/git.py
@@ -587,7 +587,17 @@ class GitParser:
      FILE) = range(5)
 
     # Git trailers
-    TRAILERS = ['Signed-off-by']
+    TRAILERS = [
+        "Acked-by",
+        "Co-authored-by",
+        "Helped-by",
+        "Mentored-by",
+        "Reported-by",
+        "Reviewed-by",
+        "Signed-off-by",
+        "Suggested-by",
+        "Tested-by",
+    ]
 
     def __init__(self, stream):
         self.stream = stream
@@ -751,7 +761,7 @@ class GitParser:
         if not m:
             return
 
-        trailer = m.group('name')
+        trailer = m.group('name').capitalize()
         value = m.group('value')
 
         if trailer not in self.TRAILERS:

--- a/releases/unreleased/new-trailers-for-git-commits.yml
+++ b/releases/unreleased/new-trailers-for-git-commits.yml
@@ -1,0 +1,8 @@
+---
+title: New trailers for Git commits
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  The list of recognized trailers in Git has been expanded using the
+  ones listed by the [Git documentation](https://git-scm.com/docs/SubmittingPatches#sign-off).

--- a/tests/data/git/git_log_trailers.txt
+++ b/tests/data/git/git_log_trailers.txt
@@ -9,6 +9,7 @@ CommitDate: Tue Aug 14 14:33:27 2012 -0300
     Signed-off-by: John Smith <jsmith@example.com>
     MyTrailer: this is my trailer
     Signed-off-by: John Doe <jdoe@example.com>
+    Reported-by: Jane Doe <jane@example.com>
 
 :000000 100644 0000000... e69de29... A	bbb/ccc/yet_anotherthing
 0	0	bbb/ccc/yet_anotherthing

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1472,11 +1472,15 @@ class TestGitParser(TestCaseGit):
                 'John Smith <jsmith@example.com>',
                 'John Doe <jdoe@example.com>'
             ],
+            'Reported-by': [
+                'Jane Doe <jane@example.com>'
+            ],
             'message': "Commit with a list of trailers\n"
                        "\n"
                        "Signed-off-by: John Smith <jsmith@example.com>\n"
                        "MyTrailer: this is my trailer\n"
-                       "Signed-off-by: John Doe <jdoe@example.com>",
+                       "Signed-off-by: John Doe <jdoe@example.com>\n"
+                       "Reported-by: Jane Doe <jane@example.com>",
             'files': [
                 {
                     'file': 'bbb/ccc/yet_anotherthing',


### PR DESCRIPTION
Expand the list of recognized trailers in Git using the ones listed by the Git documentation.