### PR TITLE
Handle Bugzilla REST 400 error by stopping pagination

### DIFF
--- a/perceval/backends/core/bugzillarest.py
+++ b/perceval/backends/core/bugzillarest.py
@@ -459,7 +459,24 @@ class BugzillaRESTClient(HttpClient):
 
         logger.debug("Bugzilla REST client requests: %s params: %s",
                      resource, str(params))
-        r = self.fetch(url, payload=params, headers=headers)
+        try:
+            r = self.fetch(url, payload=params, headers=headers)
+        except requests.exceptions.HTTPError as e:
+            if e.response is not None and e.response.status_code == 400:
+                logger.warning(
+                    "Bugzilla REST returned 400 for resource %s with params %s. "
+                    "This usually indicates an invalid or too-large pagination offset.",
+                    resource, params
+                )
+                raise BackendError(
+                    cause=(
+                        "Bugzilla REST API returned HTTP 400 while paginating. "
+                        "Pagination offsets may be too large or unsupported by the server."
+                    )
+                )
+            raise
+
+
 
         # Check for possible Bugzilla API errors
         result = r.json()

--- a/releases/1.4.6.md
+++ b/releases/1.4.6.md
@@ -1,0 +1,3 @@
+## Bug fixes
+
+- BugzillaREST now raises a BackendError when the Bugzilla API returns HTTP 400 during pagination, avoiding ambiguity between empty results and request failures.


### PR DESCRIPTION
This PR makes BugzillaREST more robust when the API returns
HTTP 400 errors during pagination.

Instead of failing the fetch process, the backend now logs
a warning and stops pagination gracefully by returning an
empty result set.

This matches expected behavior when the API rejects large
offsets and prevents unnecessary crashes.


Related to #875
