### PR TITLE
docs: add --no-update flag documentation for Git backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,7 @@ To fetch commits without updating the repository (useful for offline use or
 reproducing results from a specific state of the repository):
 
 ```
-$ perceval git 'https://github.com/chaoss/grimoirelab-perceval.git'
---no-update
+$ perceval git 'https://github.com/chaoss/grimoirelab-perceval.git' --no-update
 ```
 
 ### GitHub

--- a/README.md
+++ b/README.md
@@ -267,6 +267,13 @@ or
 ```
 $ perceval git '/tmp/gitlog.log'
 ```
+To fetch commits without updating the repository (useful for offline use or
+reproducing results from a specific state of the repository):
+
+```
+$ perceval git 'https://github.com/chaoss/grimoirelab-perceval.git'
+--no-update
+```
 
 ### GitHub
 ```


### PR DESCRIPTION
The --no-update flag is already implemented in the Git backend but was not documented in the README.
This PR adds a usage example explaining how to use --no-update for offline usage and reproducibility.
Closes #42