### PR TITLE
[github] GitHub App installation token for public repos

### DIFF
--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -1040,9 +1040,13 @@ class GitHubClient(HttpClient, RateLimitHandler):
         return private_key
 
     def _get_installation_id(self, headers):
-        """Get installation ID given the GitHub login
+        """Return the GitHub App installation ID for the configured owner.
 
-        :param headers: request headers with JWT token
+        For private repositories, the installation must match the owner.
+        For public repositories, any available installation ID is sufficient.
+
+        If no installation matches the owner, the first available installation
+        is returned (if any).
 
         :returns: Installation ID
         """
@@ -1054,6 +1058,10 @@ class GitHubClient(HttpClient, RateLimitHandler):
             if i['account']['login'] == self.owner:
                 installation_id = i['id']
                 break
+
+        if not installation_id and data:
+            installation_id = data[0]['id']
+
         return installation_id
 
     def _create_access_token(self, headers, installation_id):

--- a/releases/unreleased/github-app-fallback-for-public-repositories.yml
+++ b/releases/unreleased/github-app-fallback-for-public-repositories.yml
@@ -1,0 +1,9 @@
+---
+title: GitHub App token for public repositories
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: 898
+notes: >
+  When no matching GitHub App installation is available for a repository,
+  Perceval now falls back to using another installation token to retrieve
+  public data.

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -3724,6 +3724,82 @@ class TestGitHubClient(unittest.TestCase):
         self.assertEqual(httpretty.last_request().headers["Authorization"], "token aaa")
 
     @httpretty.activate
+    def test_get_installation_id(self):
+        """Test installation ID lookup for the matching owner"""
+
+        rate_limit = read_file("data/github/rate_limit")
+
+        httpretty.register_uri(
+            httpretty.GET,
+            GITHUB_RATE_LIMIT,
+            body=rate_limit,
+            status=200,
+            forcing_headers={"X-RateLimit-Remaining": "20", "X-RateLimit-Reset": "15"},
+        )
+
+        client = GitHubClient(
+            "zhquan_example",
+            "repo",
+            [],
+            github_app_id="1",
+            github_app_pk_filepath="data/github/private.pem",
+            from_archive=True,
+        )
+
+        installations = [
+            {"account": {"login": "other_owner"}, "id": "7"},
+            {"account": {"login": "zhquan_example"}, "id": "8"},
+        ]
+        response = unittest.mock.Mock()
+        response.json.return_value = installations
+        client.session.get = unittest.mock.Mock(return_value=response)
+
+        installation_id = client._get_installation_id({"Authorization": "Bearer token"})
+
+        self.assertEqual(installation_id, "8")
+        client.session.get.assert_called_once_with(
+            GITHUB_APP_INSTALLATION_URL, headers={"Authorization": "Bearer token"}
+        )
+
+    @httpretty.activate
+    def test_get_installation_id_fallback(self):
+        """Test installation ID lookup fallback for public repositories"""
+
+        rate_limit = read_file("data/github/rate_limit")
+
+        httpretty.register_uri(
+            httpretty.GET,
+            GITHUB_RATE_LIMIT,
+            body=rate_limit,
+            status=200,
+            forcing_headers={"X-RateLimit-Remaining": "20", "X-RateLimit-Reset": "15"},
+        )
+
+        client = GitHubClient(
+            "public_owner",
+            "repo",
+            [],
+            github_app_id="1",
+            github_app_pk_filepath="data/github/private.pem",
+            from_archive=True,
+        )
+
+        installations = [
+            {"account": {"login": "other_owner"}, "id": "7"},
+            {"account": {"login": "another_owner"}, "id": "8"},
+        ]
+        response = unittest.mock.Mock()
+        response.json.return_value = installations
+        client.session.get = unittest.mock.Mock(return_value=response)
+
+        installation_id = client._get_installation_id({"Authorization": "Bearer token"})
+
+        self.assertEqual(installation_id, "7")
+        client.session.get.assert_called_once_with(
+            GITHUB_APP_INSTALLATION_URL, headers={"Authorization": "Bearer token"}
+        )
+
+    @httpretty.activate
     def test_get_from_date_issues(self):
         """Test issues from date API call"""
 


### PR DESCRIPTION
Use a non-matching GitHub App installation token when no installation exists for the target repo owner, enabling access to public data with higher rate limits.

Fixes https://github.com/chaoss/grimoirelab-perceval/issues/898