### PR TITLE
[MediaWiki] Add revision history pagination support

### DIFF
--- a/perceval/backends/core/mediawiki.py
+++ b/perceval/backends/core/mediawiki.py
@@ -524,8 +524,6 @@ class MediaWikiClient(HttpClient):
         return self.call(params)
 
     def get_revisions(self, pageid, last_date=None):
-        # TODO: Iterate if more than self.max reviews (500)
-
         if last_date:
             last_date_str = last_date.isoformat()
 
@@ -540,7 +538,52 @@ class MediaWikiClient(HttpClient):
         if last_date:
             params[self.PRV_START] = last_date_str
 
-        return self.call(params)
+        responses = []
+        visited_continues = set()
+
+        while True:
+            raw_res = self.call(params)
+            res = json.loads(raw_res)
+
+            if 'continue' in res and all(params.get(k) == v for k, v in res['continue'].items()):
+                break
+
+            responses.append(raw_res)
+
+            if 'continue' not in res:
+                break
+
+            cont_tuple = tuple(sorted(res['continue'].items()))
+            if cont_tuple in visited_continues:
+                logger.warning("Detected duplicate/looping continue parameter in MediaWiki API response: %s", res['continue'])
+                break
+            visited_continues.add(cont_tuple)
+
+            for k, v in res['continue'].items():
+                params[k] = v
+
+        if len(responses) == 1:
+            return responses[0]
+
+        all_revisions = []
+        full_response = json.loads(responses[0])
+
+        for raw in responses:
+            parsed = json.loads(raw)
+            pageid_str = str(pageid)
+            if 'query' in parsed and 'pages' in parsed['query'] and pageid_str in parsed['query']['pages']:
+                page_data = parsed['query']['pages'][pageid_str]
+                if 'revisions' in page_data:
+                    all_revisions.extend(page_data['revisions'])
+
+        if full_response and 'query' in full_response and 'pages' in full_response['query'] and str(pageid) in full_response['query']['pages']:
+            page_data = full_response['query']['pages'][str(pageid)]
+            if 'revisions' in page_data or all_revisions:
+                page_data['revisions'] = all_revisions
+            if 'continue' in full_response:
+                del full_response['continue']
+
+        return json.dumps(full_response)
 
     def get_pages_from_allrevisions(self, namespaces, from_date=None, arvcontinue=None):
 

--- a/releases/unreleased/mediawiki-pagination.yaml
+++ b/releases/unreleased/mediawiki-pagination.yaml
@@ -1,0 +1,8 @@
+title: 'Add pagination for revisions in MediaWiki backend'
+category: changed
+author: Aamir377300 <belalaamirkhan@gmail.com>
+notes: >
+    Implement pagination support in get_revisions for the MediaWiki backend
+    using the continue parameter. This ensures the full revision history
+    is retrieved for high-activity pages while keeping existing last_date
+    filtering intact.

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -26,9 +26,11 @@
 #     Harshal Mittal <harshalmittal4@gmail.com>
 #
 
+import copy
 import datetime
 import dateutil
 import httpretty
+import json
 import os
 import unittest
 import urllib
@@ -93,6 +95,17 @@ class HTTPServer():
         mediawiki_page_476589 = read_file('data/mediawiki/mediawiki_page_476589_revisions.json')
         mediawiki_page_476590 = read_file('data/mediawiki/mediawiki_page_476590_revisions.json')
 
+        page_476583_data = json.loads(mediawiki_page_476583)
+        page_476583_part1 = copy.deepcopy(page_476583_data)
+        page_476583_part2 = copy.deepcopy(page_476583_data)
+
+        all_revs = page_476583_data["query"]["pages"]["476583"]["revisions"]
+        page_476583_part1["query"]["pages"]["476583"]["revisions"] = all_revs[:250]
+
+        page_476583_part2["query"]["pages"]["476583"]["revisions"] = all_revs[250:]
+        if 'continue' in page_476583_part2:
+            del page_476583_part2['continue']
+
         def request_callback(method, uri, headers):
             params = urllib.parse.parse_qs(urllib.parse.urlparse(uri).query)
             if 'meta' in params and 'siteinfo' in params['meta']:
@@ -108,7 +121,10 @@ class HTTPServer():
                     body = mediawiki_pages_allrevisions
             elif 'pageids' in params:
                 if params['pageids'][0] == '476583':
-                    body = mediawiki_page_476583
+                    if 'rvcontinue' in params or 'continue' in params:
+                        body = json.dumps(page_476583_part2)
+                    else:
+                        body = json.dumps(page_476583_part1)
                 elif params['pageids'][0] == '592384':
                     body = mediawiki_page_592384
                 elif params['pageids'][0] == '476589':
@@ -560,11 +576,16 @@ class TestMediaWikiClient(unittest.TestCase):
         body = read_file('data/mediawiki/mediawiki_page_476583_revisions.json')
         client = MediaWikiClient(MEDIAWIKI_SERVER_URL)
         response = client.get_revisions(476583)
-        req = HTTPServer.requests_http[-1]
-        self.assertEqual(response, body)
-        self.assertEqual(req.method, 'GET')
-        self.assertRegex(req.path, '/api.php')
-        # Check request params
+        
+        # Verify the aggregated output contains all 500 revisions
+        resp_json = json.loads(response)
+        self.assertEqual(len(resp_json['query']['pages']['476583']['revisions']), 500)
+        self.assertNotIn('continue', resp_json)
+
+        # Check first request (without continue parameter)
+        first_req = HTTPServer.requests_http[-2]
+        self.assertEqual(first_req.method, 'GET')
+        self.assertRegex(first_req.path, '/api.php')
         expected = {
             'action': ['query'],
             'prop': ['revisions'],
@@ -573,7 +594,13 @@ class TestMediaWikiClient(unittest.TestCase):
             'rvlimit': ['max'],
             'rvdir': ['newer']
         }
-        self.assertDictEqual(req.querystring, expected)
+        self.assertDictEqual(first_req.querystring, expected)
+
+        # Check second request (with continue parameter)
+        second_req = HTTPServer.requests_http[-1]
+        self.assertEqual(second_req.method, 'GET')
+        self.assertRegex(second_req.path, '/api.php')
+        self.assertEqual(second_req.querystring['rvcontinue'], ['20160226140047|2062172'])
 
     @httpretty.activate
     def test_get_revisions_last_date(self):
@@ -584,11 +611,16 @@ class TestMediaWikiClient(unittest.TestCase):
         str_date = '2016-01-01 00:00'
         dt = str_to_datetime(str_date)
         response = client.get_revisions(476583, last_date=dt)
-        req = HTTPServer.requests_http[-1]
-        self.assertEqual(response, body)
-        self.assertEqual(req.method, 'GET')
-        self.assertRegex(req.path, '/api.php')
-        # Check request params
+        
+        # Verify the aggregated output contains all 500 revisions
+        resp_json = json.loads(response)
+        self.assertEqual(len(resp_json['query']['pages']['476583']['revisions']), 500)
+        self.assertNotIn('continue', resp_json)
+
+        # Check first request (without continue parameter, with rvstart)
+        first_req = HTTPServer.requests_http[-2]
+        self.assertEqual(first_req.method, 'GET')
+        self.assertRegex(first_req.path, '/api.php')
         expected = {
             'action': ['query'],
             'prop': ['revisions'],
@@ -598,7 +630,7 @@ class TestMediaWikiClient(unittest.TestCase):
             'rvdir': ['newer'],
             'rvstart': ['2016-01-01T00:00:00 00:00']
         }
-        self.assertDictEqual(req.querystring, expected)
+        self.assertDictEqual(first_req.querystring, expected)
 
     @httpretty.activate
     def test_get_pages_from_allrevisions(self):


### PR DESCRIPTION
This issue fix issue #905 
## Description

This PR adds pagination support to the MediaWiki backend revision fetching flow.

Previously, `get_revisions` only returned the first batch of revisions when a page exceeded the MediaWiki API limit (typically 500 results). This meant pages with very large edit histories could end up with incomplete revision data.

This PR addresses the existing TODO in the code:

```python id="x7t4kn"
# TODO: Iterate if more than self.max reviews (500)
```

## Changes Included

### Pagination Support

* added loop-based pagination handling using MediaWiki’s `continue` mechanism
* continued fetching revisions until all available batches are retrieved
* preserved existing filtering behavior such as `last_date` / `rvstart`

### Response Handling

* kept the original raw response behavior when only a single page of results exists
* merged paginated revision batches into a consolidated final response
* removed intermediate `continue` blocks from the aggregated output

### Safety Improvements

* added safeguards to avoid infinite pagination loops in mocked/static response environments where continuation tokens do not advance correctly

### Tests

Updated `tests/test_mediawiki.py` to cover paginated revision fetching by:

* splitting mock revisions into multiple API pages
* verifying multiple requests are dispatched correctly
* validating that revisions are merged into the expected final response

please review this pr and provide your feedback
