### PR TITLE
Add ETag conditional requests to the GitHub backend

### DIFF
--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -635,6 +635,8 @@ class GitHubClient(HttpClient, RateLimitHandler):
     # API headers
     HAUTHORIZATION = 'Authorization'
     HACCEPT = 'Accept'
+    HIF_NONE_MATCH = 'If-None-Match'
+    HETAG = 'ETag'
 
     # Resource parameters
     PSTATE = 'state'
@@ -669,6 +671,12 @@ class GitHubClient(HttpClient, RateLimitHandler):
         self.max_items = max_items
         self.github_app_id = github_app_id
         self.github_app_pk_filepath = github_app_pk_filepath
+
+        # Conditional-request (ETag) cache: {request key: (etag, response)}.
+        # Only used for live GET requests without an archive, so recorded and
+        # replayed responses keep their full body.
+        self._etag_cache = {}
+        self._etag_enabled = (not from_archive) and (archive is None)
 
         if base_url:
             base_url = urijoin(base_url, 'api', 'v3')
@@ -910,6 +918,16 @@ class GitHubClient(HttpClient, RateLimitHandler):
                 logger.debug("GitHub APP with {} ID: access token expired, creating new one".format(self.github_app_id))
                 self._choose_best_api_token()
 
+        # Replay a stored ETag as a conditional request so unchanged
+        # resources are revalidated with a cheap "304 Not Modified".
+        cache_key = None
+        if self._etag_enabled and method == HttpClient.GET:
+            cache_key = self._conditional_request_key(url, payload)
+            cached = self._etag_cache.get(cache_key)
+            if cached:
+                headers = dict(headers) if headers else {}
+                headers[self.HIF_NONE_MATCH] = cached[0]
+
         response = super().fetch(url, payload, headers, method, stream, auth)
 
         if not self.from_archive:
@@ -918,7 +936,25 @@ class GitHubClient(HttpClient, RateLimitHandler):
             else:
                 self.update_rate_limit(response)
 
+        # A 304 carries no body: return the cached response instead. Otherwise
+        # store the ETag (if any) to condition the next identical request.
+        if cache_key is not None:
+            if response.status_code == 304:
+                response = self._etag_cache[cache_key][1]
+            elif response.status_code == 200 and self.HETAG in response.headers:
+                self._etag_cache[cache_key] = (response.headers[self.HETAG], response)
+
         return response
+
+    def _conditional_request_key(self, url, payload):
+        """Build a stable cache key for a GET request from its URL and params."""
+
+        if not payload:
+            return url
+
+        params = '&'.join('%s=%s' % (key, payload[key]) for key in sorted(payload))
+        separator = '&' if '?' in url else '?'
+        return url + separator + params
 
     def fetch_items(self, path, payload):
         """Return the items from github API using links pagination"""

--- a/releases/unreleased/github-conditional-requests.yml
+++ b/releases/unreleased/github-conditional-requests.yml
@@ -1,0 +1,12 @@
+title: Conditional requests (ETag) for the GitHub backend
+category: performance
+author: null
+issue: 915
+notes: >
+  The GitHub client now stores the ETag returned for each resource and
+  replays it as an If-None-Match header on the next request. Unchanged
+  pull requests, issues and their sub-resources are revalidated with a
+  cheap "304 Not Modified" that reuses the cached body, instead of
+  re-downloading the full response on every collection run. Because a
+  304 does not count against the token's primary rate limit, repeated
+  runs use less rate-limit budget and bandwidth.

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -3388,6 +3388,54 @@ class TestGitHubClient(unittest.TestCase):
         self.assertEqual(httpretty.last_request().headers["Authorization"], "token aaa")
 
     @httpretty.activate
+    def test_conditional_request_not_modified(self):
+        """Test whether a stored ETag revalidates unchanged data with a 304"""
+
+        issues = read_file('data/github/github_request')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUES_URL,
+                               responses=[
+                                   httpretty.Response(body=issues, status=200,
+                                                      forcing_headers={
+                                                          'ETag': '"aefc8f27"',
+                                                          'X-RateLimit-Remaining': '19',
+                                                          'X-RateLimit-Reset': '15'
+                                                      }),
+                                   httpretty.Response(body="", status=304,
+                                                      forcing_headers={
+                                                          'ETag': '"aefc8f27"',
+                                                          'X-RateLimit-Remaining': '18',
+                                                          'X-RateLimit-Reset': '15'
+                                                      })
+                               ])
+
+        client = GitHubClient("zhquan_example", "repo", ["aaa"], None)
+
+        # First run caches the ETag and does not send a conditional header
+        first = [raw for raw in client.issues()]
+        self.assertEqual(first[0], issues)
+        self.assertNotIn('If-None-Match', httpretty.latest_requests()[-1].headers)
+
+        # Second run replays the ETag; the 304 is served from cache with the body
+        second = [raw for raw in client.issues()]
+        self.assertEqual(second[0], issues)
+        self.assertEqual(httpretty.last_request().headers['If-None-Match'], '"aefc8f27"')
+
+        # The rate limit is still updated from the 304 response headers
+        self.assertEqual(client.rate_limit, 18)
+
+    @httpretty.activate
     def test_issues_github_app(self):
         """Test issues API call using GitHub APP"""
 


### PR DESCRIPTION
## Summary

The GitHub backend currently issues every REST request unconditionally. The
`ETag` returned by the GitHub API is never stored or replayed, so each
collection run re-downloads pull requests, issues and their sub-resources in
full even when nothing has changed upstream.

This adds HTTP conditional-request (`ETag` / `If-None-Match`) support to
`GitHubClient`:

- The client caches the `ETag` of each GET response, keyed by URL and query
  parameters.
- On the next identical GET it sends the cached value as `If-None-Match`.
- When the API answers `304 Not Modified`, the cached response body is served,
  avoiding a full re-download.

Rate-limit accounting continues to read the headers of the live response
(including the `304`), so throttling behaviour is unchanged. Per the GitHub
REST API docs, a `304 Not Modified` response does not count against the
token's primary rate limit, so repeated runs consume less rate-limit budget
and bandwidth while producing identical data.

The conditional cache is automatically disabled when an archive is in use (both
while recording and while replaying), so archived/replayed responses keep their
full bodies.

## Testing

- Added `test_conditional_request_not_modified`, which verifies that the first
  request carries no `If-None-Match` header, the second sends the cached
  `ETag`, and a `304` response is served from cache with the original body
  while the rate limit is updated from the live response.
- `python -m unittest tests.test_github` passes locally.

Closes #915
